### PR TITLE
feat: add TypeScript, Python, and React presets

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -2,8 +2,10 @@ import { parse as parseToml } from "smol-toml";
 import { parse as parseYaml } from "yaml";
 import { buildCiWorkflow } from "./ci.js";
 import { expandMarkdown, mergeFile } from "./merge.js";
-// Preset modules — only base is available now; others will be added in later phases
 import { basePreset } from "./presets/base.js";
+import { pythonPreset } from "./presets/python.js";
+import { reactPreset } from "./presets/react.js";
+import { typescriptPreset } from "./presets/typescript.js";
 import { expandSetupScript } from "./setup.js";
 import type {
   FileWriter,
@@ -15,6 +17,9 @@ import type {
 
 const ALL_PRESETS: Record<string, Preset> = {
   base: basePreset,
+  typescript: typescriptPreset,
+  python: pythonPreset,
+  react: reactPreset,
 };
 
 /** Canonical application order for presets. */
@@ -118,6 +123,29 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
     const base = allFiles.get(filePath) ?? defaultBase;
     const merged = mergeFile(filePath, base, patches);
     allFiles.set(filePath, replaceVariables(merged, vars));
+  }
+
+  // 2.5. Build lint:all script dynamically from merged package.json
+  const pkgContent = allFiles.get("package.json");
+  if (pkgContent) {
+    const pkg = JSON.parse(pkgContent) as Record<string, Record<string, string>>;
+    const scripts = pkg.scripts ?? {};
+    const lintParts: string[] = [];
+    // Biome lint (if present)
+    if (scripts.lint) lintParts.push("pnpm run lint");
+    // TypeScript typecheck (if present)
+    if (scripts.typecheck) lintParts.push("pnpm run typecheck");
+    // All lint:* scripts in sorted order (except lint:all and lint:fix)
+    for (const key of Object.keys(scripts).sort()) {
+      if (key.startsWith("lint:") && key !== "lint:all" && key !== "lint:fix") {
+        lintParts.push(`pnpm run ${key}`);
+      }
+    }
+    if (lintParts.length > 0) {
+      scripts["lint:all"] = lintParts.join(" && ");
+      pkg.scripts = scripts;
+      allFiles.set("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
+    }
   }
 
   // 3. Expand Markdown templates

--- a/src/presets/python.ts
+++ b/src/presets/python.ts
@@ -1,0 +1,137 @@
+import type { Preset } from "../types.js";
+import { readTemplateFiles } from "../utils.js";
+
+export const pythonPreset: Preset = {
+  name: "python",
+  files: readTemplateFiles("python"),
+  merge: {
+    "package.json": {
+      scripts: {
+        "lint:python": "ruff check . && ruff format --check .",
+        "lint:mypy": "uv run mypy tests/",
+      },
+    },
+    ".mise.toml": {
+      tools: {
+        python: "3.12",
+        uv: "0.7",
+        "pipx:ruff": "0.11",
+        "pipx:mypy": "1",
+      },
+    },
+    "lefthook.yaml": {
+      "pre-commit": {
+        commands: {
+          "ruff-format": {
+            glob: "*.py",
+            run: "ruff format {staged_files}",
+            stage_fixed: true,
+          },
+          "ruff-check": {
+            glob: "*.py",
+            run: "ruff check --fix {staged_files}",
+            stage_fixed: true,
+          },
+        },
+      },
+      "pre-push": {
+        commands: {
+          mypy: { run: "uv run mypy tests/" },
+        },
+      },
+    },
+  },
+  markdown: {
+    "CLAUDE.md": [
+      {
+        placeholder: "<!-- SECTION:TECH_STACK -->",
+        content: "- **Language**: Python 3.12+ (uv)",
+      },
+      {
+        placeholder: "<!-- SECTION:TECH_STACK_LINTING -->",
+        content: "  - Ruff (Python lint + format)\n  - mypy (Python type check)",
+      },
+      {
+        placeholder: "<!-- SECTION:PROJECT_STRUCTURE -->",
+        content: "tests/        -> Python tests (pytest)",
+      },
+      {
+        placeholder: "<!-- SECTION:SETUP_COMMANDS -->",
+        content: "uv sync                   # Install Python dependencies",
+      },
+      {
+        placeholder: "<!-- SECTION:LINT_COMMANDS -->",
+        content:
+          "pnpm run lint:python       # Ruff check\npnpm run lint:mypy         # mypy type check",
+      },
+      {
+        placeholder: "<!-- SECTION:TEST_COMMANDS -->",
+        content: "# Test\nuv run pytest              # Run Python tests",
+      },
+      {
+        placeholder: "<!-- SECTION:CODING_CONVENTIONS -->",
+        content:
+          "- Python: 3.12+, type hints required, Ruff for lint + format\n- Max line width: 100 (Ruff)",
+      },
+      {
+        placeholder: "<!-- SECTION:PRE_PUSH_HOOKS -->",
+        content: "mypy",
+      },
+      {
+        placeholder: "<!-- SECTION:GIT_WORKFLOW -->",
+        content: "- Lefthook `pre-push` runs mypy type check (`uv run mypy tests/`)",
+      },
+    ],
+    "README.md": [
+      {
+        placeholder: "<!-- SECTION:DIR_STRUCTURE -->",
+        content: "├── tests/               # Python テスト（pytest）",
+      },
+      {
+        placeholder: "<!-- SECTION:ROOT_FILES -->",
+        content:
+          "├── pyproject.toml       # Python プロジェクト設定（Ruff, mypy）\n├── uv.lock              # uv ロックファイル",
+      },
+      {
+        placeholder: "<!-- SECTION:SETUP_STEPS -->",
+        content: "3. `uv sync`（Python 依存パッケージ）",
+      },
+      {
+        placeholder: "<!-- SECTION:SETUP_COMMANDS -->",
+        content: "| `uv sync` | Python 依存パッケージインストール |",
+      },
+      {
+        placeholder: "<!-- SECTION:LINT_COMMANDS -->",
+        content:
+          "| `pnpm run lint:python` | Ruff チェック |\n| `pnpm run lint:mypy` | mypy 型チェック |",
+      },
+      {
+        placeholder: "<!-- SECTION:TEST_COMMANDS -->",
+        content:
+          "### テスト\n\n| コマンド | 説明 |\n|---------|------|\n| `uv run pytest` | Python テスト実行 |",
+      },
+    ],
+  },
+  ciSteps: {
+    setupSteps: [
+      {
+        name: "uv cache",
+        uses: "actions/cache@5a3ec84eff668545956fd18022155c47e93e2684",
+        with: {
+          path: "~/.cache/uv",
+          // biome-ignore lint/suspicious/noTemplateCurlyInString: GitHub Actions expression
+          key: "uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}",
+          // biome-ignore lint/suspicious/noTemplateCurlyInString: GitHub Actions expression
+          "restore-keys": "uv-${{ runner.os }}-",
+        },
+      },
+      { name: "Install Python dependencies", run: "uv sync" },
+    ],
+    lintSteps: [
+      { name: "Lint (Ruff)", run: "ruff check . && ruff format --check ." },
+      { name: "Typecheck (mypy)", run: "uv run mypy tests/" },
+    ],
+    testSteps: [{ name: "Test (pytest)", run: "uv run pytest" }],
+  },
+  setupExtra: "uv sync",
+};

--- a/src/presets/react.ts
+++ b/src/presets/react.ts
@@ -1,0 +1,52 @@
+import type { Preset } from "../types.js";
+import { readTemplateFiles } from "../utils.js";
+
+export const reactPreset: Preset = {
+  name: "react",
+  requires: ["typescript"],
+  files: readTemplateFiles("react"),
+  merge: {
+    "package.json": {
+      scripts: {
+        dev: "vite",
+        build: "vite build",
+        preview: "vite preview",
+      },
+      dependencies: {
+        react: "^19.0.0",
+        "react-dom": "^19.0.0",
+      },
+      devDependencies: {
+        vite: "^6.0.0",
+        "@vitejs/plugin-react": "^4.0.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+      },
+    },
+  },
+  markdown: {
+    "CLAUDE.md": [
+      {
+        placeholder: "<!-- SECTION:TECH_STACK -->",
+        content: "- **Frontend**: React 19 + Vite",
+      },
+      {
+        placeholder: "<!-- SECTION:PROJECT_STRUCTURE -->",
+        content: "src/          -> React application source",
+      },
+    ],
+    "README.md": [
+      {
+        placeholder: "<!-- SECTION:DIR_STRUCTURE -->",
+        content: "├── src/                 # React アプリケーション",
+      },
+      {
+        placeholder: "<!-- SECTION:ROOT_FILES -->",
+        content:
+          "├── vite.config.ts       # Vite 設定\n├── index.html           # HTML エントリポイント",
+      },
+    ],
+  },
+  // No ciSteps needed — TypeScript's "Build" step runs `pnpm run build`,
+  // which executes `vite build` since React overrides the build script.
+};

--- a/src/presets/typescript.ts
+++ b/src/presets/typescript.ts
@@ -1,0 +1,128 @@
+import type { Preset } from "../types.js";
+import { readTemplateFiles } from "../utils.js";
+
+export const typescriptPreset: Preset = {
+  name: "typescript",
+  files: readTemplateFiles("typescript"),
+  merge: {
+    "package.json": {
+      scripts: {
+        build: "tsdown",
+        typecheck: "tsc --noEmit",
+        test: "vitest run",
+        "test:watch": "vitest",
+        dev: "tsdown --watch",
+        lint: "biome check",
+        "lint:fix": "biome check --write",
+      },
+      devDependencies: {
+        typescript: "^5.0.0",
+        "@types/node": "^22.0.0",
+        vitest: "^3.0.0",
+        tsdown: "^0.12.0",
+      },
+    },
+    ".mise.toml": {
+      tools: {
+        "npm:@biomejs/biome": "2",
+      },
+    },
+    "lefthook.yaml": {
+      "pre-commit": {
+        commands: {
+          biome: {
+            glob: "*.{ts,tsx,js,jsx,json,jsonc}",
+            run: "biome check --write {staged_files}",
+            stage_fixed: true,
+          },
+        },
+      },
+      "pre-push": {
+        commands: {
+          typecheck: { run: "tsc --noEmit" },
+        },
+      },
+    },
+  },
+  markdown: {
+    "CLAUDE.md": [
+      {
+        placeholder: "<!-- SECTION:TECH_STACK -->",
+        content: '- **Language**: TypeScript (ESM, strict mode, `"type": "module"`)',
+      },
+      {
+        placeholder: "<!-- SECTION:TECH_STACK_LINTING -->",
+        content: "  - Biome (TypeScript/JavaScript/JSON)",
+      },
+      {
+        placeholder: "<!-- SECTION:PROJECT_STRUCTURE -->",
+        content: "src/          -> TypeScript source code\ntests/        -> Test files (vitest)",
+      },
+      {
+        placeholder: "<!-- SECTION:SETUP_COMMANDS -->",
+        content: "pnpm install              # Install dependencies",
+      },
+      {
+        placeholder: "<!-- SECTION:LINT_COMMANDS -->",
+        content:
+          "pnpm run lint              # Biome check\npnpm run lint:fix          # Biome check with auto-fix\npnpm run typecheck         # TypeScript type check",
+      },
+      {
+        placeholder: "<!-- SECTION:TEST_COMMANDS -->",
+        content:
+          "# Test\npnpm test                  # Run tests (vitest)\npnpm run test:watch        # Watch mode tests",
+      },
+      {
+        placeholder: "<!-- SECTION:CODING_CONVENTIONS -->",
+        content:
+          '- TypeScript: ESM (`"type": "module"`), strict mode, NodeNext module resolution\n- Use `import type` for type-only imports (verbatimModuleSyntax enabled)\n- Max line width: 100 (Biome)',
+      },
+      {
+        placeholder: "<!-- SECTION:PRE_PUSH_HOOKS -->",
+        content: "typecheck (tsc)",
+      },
+      {
+        placeholder: "<!-- SECTION:GIT_WORKFLOW -->",
+        content: "- Lefthook `pre-push` runs TypeScript typecheck (`tsc --noEmit`)",
+      },
+    ],
+    "README.md": [
+      {
+        placeholder: "<!-- SECTION:DIR_STRUCTURE -->",
+        content:
+          "├── src/                 # TypeScript ソースコード\n├── tests/               # テスト（vitest）",
+      },
+      {
+        placeholder: "<!-- SECTION:ROOT_FILES -->",
+        content:
+          "├── biome.json           # Biome 設定\n├── tsconfig.json        # TypeScript 設定",
+      },
+      {
+        placeholder: "<!-- SECTION:SETUP_STEPS -->",
+        content: "3. `pnpm install`（Node.js 依存パッケージ）",
+      },
+      {
+        placeholder: "<!-- SECTION:SETUP_COMMANDS -->",
+        content: "| `pnpm install` | Node.js 依存パッケージインストール |",
+      },
+      {
+        placeholder: "<!-- SECTION:LINT_COMMANDS -->",
+        content:
+          "| `pnpm run lint` | Biome チェック |\n| `pnpm run lint:fix` | Biome チェック（自動修正） |\n| `pnpm run typecheck` | TypeScript 型チェック |",
+      },
+      {
+        placeholder: "<!-- SECTION:TEST_COMMANDS -->",
+        content:
+          "### テスト\n\n| コマンド | 説明 |\n|---------|------|\n| `pnpm test` | テスト実行（vitest） |\n| `pnpm run test:watch` | ウォッチモードテスト |",
+      },
+    ],
+  },
+  ciSteps: {
+    lintSteps: [{ name: "Lint (Biome)", run: "biome check ." }],
+    testSteps: [{ name: "Test", run: "pnpm test" }],
+    buildSteps: [
+      { name: "Typecheck", run: "tsc --noEmit" },
+      { name: "Build", run: "pnpm run build" },
+    ],
+  },
+};

--- a/templates/python/pyproject.toml
+++ b/templates/python/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "{{projectName}}"
+version = "0.0.0"
+requires-python = ">=3.12"
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = ["ALL"]
+ignore = [
+  "D",      # pydocstyle
+  "ANN",    # flake8-annotations (gradual adoption)
+  "ERA001", # commented-out code
+  "T201",   # print
+]
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**/*.py" = ["S101", "PLR2004"]
+
+[tool.mypy]
+python_version = "3.12"
+strict = true
+warn_return_any = true
+warn_unused_configs = true

--- a/templates/python/tests/test_placeholder.py
+++ b/templates/python/tests/test_placeholder.py
@@ -1,0 +1,2 @@
+def test_placeholder() -> None:
+    assert True

--- a/templates/python/uv.lock
+++ b/templates/python/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 1
+requires-python = ">=3.12"

--- a/templates/react/index.html
+++ b/templates/react/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>{{projectName}}</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/templates/react/src/App.css
+++ b/templates/react/src/App.css
@@ -1,0 +1,20 @@
+:root {
+  font-family:
+    Inter,
+    system-ui,
+    Avenir,
+    Helvetica,
+    Arial,
+    sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #213547;
+  background-color: #ffffff;
+}
+
+main {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 2rem;
+  text-align: center;
+}

--- a/templates/react/src/App.tsx
+++ b/templates/react/src/App.tsx
@@ -1,0 +1,8 @@
+export function App() {
+  return (
+    <main>
+      <h1>{{projectName}}</h1>
+      <p>Edit src/App.tsx and save to reload.</p>
+    </main>
+  );
+}

--- a/templates/react/src/index.ts
+++ b/templates/react/src/index.ts
@@ -1,0 +1,1 @@
+export { App } from "./App.js";

--- a/templates/react/src/main.tsx
+++ b/templates/react/src/main.tsx
@@ -1,0 +1,12 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import { App } from "./App.js";
+
+const root = document.getElementById("root");
+if (!root) throw new Error("Root element not found");
+
+createRoot(root).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/templates/react/src/vite-env.d.ts
+++ b/templates/react/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/templates/react/tests/index.test.ts
+++ b/templates/react/tests/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { App } from "../src/index.js";
+
+describe("App", () => {
+  it("is defined", () => {
+    expect(App).toBeDefined();
+  });
+});

--- a/templates/react/vite.config.ts
+++ b/templates/react/vite.config.ts
@@ -1,0 +1,6 @@
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react()],
+});

--- a/templates/typescript/biome.json
+++ b/templates/typescript/biome.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true,
+    "defaultBranch": "main"
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "trailingCommas": "all"
+    }
+  },
+  "files": {
+    "ignore": ["dist/", "*.d.ts"]
+  }
+}

--- a/templates/typescript/src/index.ts
+++ b/templates/typescript/src/index.ts
@@ -1,0 +1,3 @@
+export function hello(name: string): string {
+  return `Hello, ${name}!`;
+}

--- a/templates/typescript/tests/index.test.ts
+++ b/templates/typescript/tests/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { hello } from "../src/index.js";
+
+describe("hello", () => {
+  it("returns greeting", () => {
+    expect(hello("World")).toBe("Hello, World!");
+  });
+});

--- a/templates/typescript/tsconfig.json
+++ b/templates/typescript/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -139,4 +139,299 @@ describe("generate (base only)", () => {
     expect(claude).not.toContain("<!-- SECTION:PRE_PUSH_HOOKS -->");
     expect(claude).not.toContain("<!-- SECTION:GIT_WORKFLOW -->");
   });
+
+  it("base only has no TypeScript/Python specific files", () => {
+    expect(result.hasFile("biome.json")).toBe(false);
+    expect(result.hasFile("tsconfig.json")).toBe(false);
+    expect(result.hasFile("pyproject.toml")).toBe(false);
+    expect(result.hasFile("uv.lock")).toBe(false);
+  });
+});
+
+// --- Pattern 1: Minimal TypeScript ---
+describe("generate (typescript)", () => {
+  const answers = makeAnswers({ languages: ["typescript"] });
+  const result = generate(answers);
+
+  it("includes TypeScript owned files", () => {
+    expect(result.hasFile("biome.json")).toBe(true);
+    expect(result.hasFile("tsconfig.json")).toBe(true);
+    expect(result.hasFile("src/index.ts")).toBe(true);
+    expect(result.hasFile("tests/index.test.ts")).toBe(true);
+  });
+
+  it("merges TypeScript devDependencies into package.json", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const devDeps = pkg.devDependencies as Record<string, string>;
+    expect(devDeps.typescript).toBeDefined();
+    expect(devDeps["@types/node"]).toBeDefined();
+    expect(devDeps.vitest).toBeDefined();
+    expect(devDeps.tsdown).toBeDefined();
+  });
+
+  it("merges TypeScript scripts into package.json", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const scripts = pkg.scripts as Record<string, string>;
+    expect(scripts.build).toBe("tsdown");
+    expect(scripts.typecheck).toBe("tsc --noEmit");
+    expect(scripts.test).toBe("vitest run");
+    expect(scripts.lint).toBe("biome check");
+    // lint:all dynamically generated with all lint scripts
+    expect(scripts["lint:all"]).toContain("pnpm run lint");
+    expect(scripts["lint:all"]).toContain("pnpm run typecheck");
+    expect(scripts["lint:all"]).toContain("pnpm run lint:yaml");
+    expect(scripts["lint:all"]).toContain("pnpm run lint:secrets");
+    // base scripts still present
+    expect(scripts.prepare).toBe("lefthook install");
+    expect(scripts["lint:yaml"]).toContain("yamllint");
+  });
+
+  it("merges Biome into .mise.toml", () => {
+    const toml = result.readToml(".mise.toml") as Record<string, Record<string, string>>;
+    expect(toml.tools["npm:@biomejs/biome"]).toBe("2");
+    // base tools still present
+    expect(toml.tools.node).toBe("24");
+  });
+
+  it("merges biome and typecheck hooks into lefthook.yaml", () => {
+    const hook = result.readYaml("lefthook.yaml") as Record<string, unknown>;
+    const preCommit = hook["pre-commit"] as Record<string, unknown>;
+    const preCommitCmds = preCommit.commands as Record<string, unknown>;
+    expect(preCommitCmds.biome).toBeDefined();
+    // base hooks still present
+    expect(preCommitCmds.shellcheck).toBeDefined();
+
+    const prePush = hook["pre-push"] as Record<string, unknown>;
+    const prePushCmds = prePush.commands as Record<string, unknown>;
+    expect(prePushCmds.typecheck).toBeDefined();
+  });
+
+  it("adds TypeScript CI steps", () => {
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name);
+    expect(stepNames).toContain("Lint (Biome)");
+    expect(stepNames).toContain("Test");
+    expect(stepNames).toContain("Typecheck");
+    expect(stepNames).toContain("Build");
+    // base steps still present
+    expect(stepNames).toContain("Lint (Markdown)");
+  });
+
+  it("expands CLAUDE.md with TypeScript sections", () => {
+    const claude = result.readText("CLAUDE.md");
+    expect(claude).toContain("TypeScript");
+    expect(claude).toContain("Biome");
+    expect(claude).toContain("typecheck (tsc)");
+    expect(claude).not.toContain("<!-- SECTION:");
+  });
+
+  it("does not include Python files", () => {
+    expect(result.hasFile("pyproject.toml")).toBe(false);
+    expect(result.hasFile("uv.lock")).toBe(false);
+  });
+});
+
+// --- Pattern 2: Minimal Python ---
+describe("generate (python)", () => {
+  const answers = makeAnswers({ languages: ["python"] });
+  const result = generate(answers);
+
+  it("includes Python owned files", () => {
+    expect(result.hasFile("pyproject.toml")).toBe(true);
+    expect(result.hasFile("uv.lock")).toBe(true);
+    expect(result.hasFile("tests/__init__.py")).toBe(true);
+    expect(result.hasFile("tests/test_placeholder.py")).toBe(true);
+  });
+
+  it("merges Python tools into .mise.toml", () => {
+    const toml = result.readToml(".mise.toml") as Record<string, Record<string, string>>;
+    expect(toml.tools.python).toBe("3.12");
+    expect(toml.tools.uv).toBe("0.7");
+    expect(toml.tools["pipx:ruff"]).toBe("0.11");
+    expect(toml.tools["pipx:mypy"]).toBe("1");
+  });
+
+  it("merges Python scripts into package.json", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const scripts = pkg.scripts as Record<string, string>;
+    expect(scripts["lint:python"]).toContain("ruff");
+    expect(scripts["lint:mypy"]).toContain("mypy");
+  });
+
+  it("merges ruff and mypy hooks into lefthook.yaml", () => {
+    const hook = result.readYaml("lefthook.yaml") as Record<string, unknown>;
+    const preCommit = hook["pre-commit"] as Record<string, unknown>;
+    const preCommitCmds = preCommit.commands as Record<string, unknown>;
+    expect(preCommitCmds["ruff-format"]).toBeDefined();
+    expect(preCommitCmds["ruff-check"]).toBeDefined();
+
+    const prePush = hook["pre-push"] as Record<string, unknown>;
+    const prePushCmds = prePush.commands as Record<string, unknown>;
+    expect(prePushCmds.mypy).toBeDefined();
+  });
+
+  it("adds Python CI steps", () => {
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name);
+    expect(stepNames).toContain("Lint (Ruff)");
+    expect(stepNames).toContain("Typecheck (mypy)");
+    expect(stepNames).toContain("Test (pytest)");
+    expect(stepNames).toContain("Install Python dependencies");
+  });
+
+  it("adds uv sync to setup.sh", () => {
+    const setup = result.readText("scripts/setup.sh");
+    expect(setup).toContain("uv sync");
+  });
+
+  it("expands CLAUDE.md with Python sections", () => {
+    const claude = result.readText("CLAUDE.md");
+    expect(claude).toContain("Python");
+    expect(claude).toContain("Ruff");
+    expect(claude).toContain("mypy");
+    expect(claude).not.toContain("<!-- SECTION:");
+  });
+
+  it("does not include TypeScript files", () => {
+    expect(result.hasFile("biome.json")).toBe(false);
+    expect(result.hasFile("tsconfig.json")).toBe(false);
+  });
+});
+
+// --- Pattern 3: TypeScript + Python ---
+describe("generate (typescript + python)", () => {
+  const answers = makeAnswers({ languages: ["typescript", "python"] });
+  const result = generate(answers);
+
+  it("includes both TypeScript and Python files", () => {
+    expect(result.hasFile("biome.json")).toBe(true);
+    expect(result.hasFile("tsconfig.json")).toBe(true);
+    expect(result.hasFile("pyproject.toml")).toBe(true);
+    expect(result.hasFile("uv.lock")).toBe(true);
+  });
+
+  it("merges both language tools into .mise.toml", () => {
+    const toml = result.readToml(".mise.toml") as Record<string, Record<string, string>>;
+    expect(toml.tools["npm:@biomejs/biome"]).toBe("2");
+    expect(toml.tools.python).toBe("3.12");
+    expect(toml.tools.uv).toBe("0.7");
+  });
+
+  it("merges both language hooks into lefthook.yaml", () => {
+    const hook = result.readYaml("lefthook.yaml") as Record<string, unknown>;
+    const preCommit = hook["pre-commit"] as Record<string, unknown>;
+    const cmds = preCommit.commands as Record<string, unknown>;
+    expect(cmds.biome).toBeDefined();
+    expect(cmds["ruff-format"]).toBeDefined();
+  });
+
+  it("has CI steps from both presets", () => {
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name);
+    expect(stepNames).toContain("Lint (Biome)");
+    expect(stepNames).toContain("Lint (Ruff)");
+    expect(stepNames).toContain("Test");
+    expect(stepNames).toContain("Test (pytest)");
+  });
+
+  it("expands CLAUDE.md with both language sections", () => {
+    const claude = result.readText("CLAUDE.md");
+    expect(claude).toContain("TypeScript");
+    expect(claude).toContain("Python");
+    expect(claude).not.toContain("<!-- SECTION:");
+  });
+
+  it("lint:all includes both TypeScript and Python lint scripts", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const scripts = pkg.scripts as Record<string, string>;
+    expect(scripts["lint:all"]).toContain("pnpm run lint");
+    expect(scripts["lint:all"]).toContain("pnpm run typecheck");
+    expect(scripts["lint:all"]).toContain("pnpm run lint:python");
+    expect(scripts["lint:all"]).toContain("pnpm run lint:mypy");
+    expect(scripts["lint:all"]).toContain("pnpm run lint:secrets");
+  });
+});
+
+// --- Pattern 4: TypeScript + React ---
+describe("generate (react)", () => {
+  const answers = makeAnswers({ frontend: "react" });
+  const result = generate(answers);
+
+  it("forces TypeScript preset inclusion", () => {
+    // React requires TypeScript — TypeScript files should be present
+    expect(result.hasFile("biome.json")).toBe(true);
+    expect(result.hasFile("tsconfig.json")).toBe(true);
+  });
+
+  it("includes React owned files", () => {
+    expect(result.hasFile("vite.config.ts")).toBe(true);
+    expect(result.hasFile("index.html")).toBe(true);
+    expect(result.hasFile("src/main.tsx")).toBe(true);
+    expect(result.hasFile("src/App.tsx")).toBe(true);
+    expect(result.hasFile("src/App.css")).toBe(true);
+    expect(result.hasFile("src/vite-env.d.ts")).toBe(true);
+  });
+
+  it("merges React dependencies into package.json", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const deps = pkg.dependencies as Record<string, string>;
+    expect(deps.react).toBeDefined();
+    expect(deps["react-dom"]).toBeDefined();
+    const devDeps = pkg.devDependencies as Record<string, string>;
+    expect(devDeps.vite).toBeDefined();
+    expect(devDeps["@vitejs/plugin-react"]).toBeDefined();
+    expect(devDeps["@types/react"]).toBeDefined();
+    expect(devDeps["@types/react-dom"]).toBeDefined();
+    // TypeScript devDeps also present
+    expect(devDeps.typescript).toBeDefined();
+  });
+
+  it("React overrides TypeScript build script with vite", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const scripts = pkg.scripts as Record<string, string>;
+    // React preset's build/dev override TypeScript's (applied later in order)
+    expect(scripts.build).toBe("vite build");
+    expect(scripts.dev).toBe("vite");
+    expect(scripts.preview).toBe("vite preview");
+  });
+
+  it("has TypeScript CI steps (React uses TS build step via script override)", () => {
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name);
+    expect(stepNames).toContain("Lint (Biome)");
+    expect(stepNames).toContain("Typecheck");
+    expect(stepNames).toContain("Build");
+    // No duplicate "Build (Vite)" — React overrides the build script instead
+    expect(stepNames).not.toContain("Build (Vite)");
+  });
+
+  it("overrides TypeScript sample files with React-appropriate versions", () => {
+    const indexTs = result.readText("src/index.ts");
+    expect(indexTs).toContain("App");
+    expect(indexTs).not.toContain("hello");
+
+    const testFile = result.readText("tests/index.test.ts");
+    expect(testFile).toContain("App");
+  });
+
+  it("expands CLAUDE.md with React sections", () => {
+    const claude = result.readText("CLAUDE.md");
+    expect(claude).toContain("React");
+    expect(claude).toContain("Vite");
+    expect(claude).not.toContain("<!-- SECTION:");
+  });
+
+  it("replaces {{projectName}} in React templates", () => {
+    const html = result.readText("index.html");
+    expect(html).toContain("test-app");
+    expect(html).not.toContain("{{projectName}}");
+  });
 });


### PR DESCRIPTION
## Summary

Issue #3 の実装。TypeScript / Python / React の3プリセットを追加。

- **TypeScript**: Biome (lint/format), tsconfig, vitest, tsdown, pre-push typecheck
- **Python**: Ruff (lint/format), mypy, uv, pytest, pre-push mypy
- **React**: Vite + React 19, requires TypeScript, overrides build/dev scripts
- **Dynamic `lint:all`**: マージ後の package.json から全 lint スクリプトを自動収集して動的に構築
- **CI/lefthook/Markdown**: 各プリセットが CI ステップ、Git フック、CLAUDE.md/README.md セクションを提供
- **テスト**: Pattern 1-4 (Minimal TS, Minimal Python, TS+Python, React) — 65 tests pass

## Test plan

- [x] `pnpm test` — 65 tests pass (merge 20 + generator 45)
- [x] `pnpm run lint` — Biome check pass
- [x] `pnpm run typecheck` — TypeScript check pass
- [x] `pnpm run build` — Build success

Closes #3