### PR TITLE
feat: add CDK, CloudFormation, and Terraform presets

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -3,8 +3,11 @@ import { parse as parseYaml } from "yaml";
 import { buildCiWorkflow } from "./ci.js";
 import { expandMarkdown, mergeFile } from "./merge.js";
 import { basePreset } from "./presets/base.js";
+import { cdkPreset } from "./presets/cdk.js";
+import { cloudformationPreset } from "./presets/cloudformation.js";
 import { pythonPreset } from "./presets/python.js";
 import { reactPreset } from "./presets/react.js";
+import { terraformPreset } from "./presets/terraform.js";
 import { typescriptPreset } from "./presets/typescript.js";
 import { expandSetupScript } from "./setup.js";
 import type {
@@ -20,6 +23,9 @@ const ALL_PRESETS: Record<string, Preset> = {
   typescript: typescriptPreset,
   python: pythonPreset,
   react: reactPreset,
+  cdk: cdkPreset,
+  cloudformation: cloudformationPreset,
+  terraform: terraformPreset,
 };
 
 /** Canonical application order for presets. */

--- a/src/presets/cdk.ts
+++ b/src/presets/cdk.ts
@@ -1,0 +1,107 @@
+import type { Preset } from "../types.js";
+import { readTemplateFiles } from "../utils.js";
+
+export const cdkPreset: Preset = {
+  name: "cdk",
+  requires: ["typescript"],
+  files: readTemplateFiles("cdk"),
+  merge: {
+    "package.json": {
+      scripts: {
+        "cdk:synth": "cd infra && npx cdk synth",
+        "cdk:deploy": "cd infra && npx cdk deploy",
+        "cdk:diff": "cd infra && npx cdk diff",
+        "test:infra": "cd infra && pnpm test",
+        "lint:cfn": "cfn-lint",
+      },
+    },
+    ".mise.toml": {
+      tools: {
+        awscli: "2",
+        "npm:aws-cdk": "2",
+        "pipx:cfn-lint": "1",
+      },
+    },
+    ".mcp.json": {
+      mcpServers: {
+        "aws-iac": {
+          command: "uvx",
+          args: ["awslabs.aws-iac-mcp@latest"],
+        },
+      },
+    },
+  },
+  markdown: {
+    "CLAUDE.md": [
+      {
+        placeholder: "<!-- SECTION:TECH_STACK -->",
+        content: "- **IaC**: AWS CDK v2 (TypeScript)",
+      },
+      {
+        placeholder: "<!-- SECTION:TECH_STACK_LINTING -->",
+        content: "  - cfn-lint (CloudFormation)",
+      },
+      {
+        placeholder: "<!-- SECTION:TECH_STACK_MCP -->",
+        content: "- **MCP servers**: AWS IaC — configured in `.mcp.json`",
+      },
+      {
+        placeholder: "<!-- SECTION:PROJECT_STRUCTURE -->",
+        content: "infra/        -> CDK infrastructure (bin/, lib/, test/)",
+      },
+      {
+        placeholder: "<!-- SECTION:SETUP_COMMANDS -->",
+        content: "cd infra && pnpm install  # Install CDK dependencies",
+      },
+      {
+        placeholder: "<!-- SECTION:LINT_COMMANDS -->",
+        content: "pnpm run lint:cfn          # CloudFormation lint (cfn-lint)",
+      },
+      {
+        placeholder: "<!-- SECTION:TEST_COMMANDS -->",
+        content: "# Infra Test\npnpm run test:infra         # CDK infrastructure tests",
+      },
+      {
+        placeholder: "<!-- SECTION:CODING_CONVENTIONS -->",
+        content: "- CDK: cdk-nag for security best practices",
+      },
+    ],
+    "README.md": [
+      {
+        placeholder: "<!-- SECTION:DIR_STRUCTURE -->",
+        content:
+          "├── infra/               # CDK インフラストラクチャ\n│   ├── bin/             # CDK アプリエントリポイント\n│   ├── lib/             # スタック定義\n│   └── test/            # インフラテスト",
+      },
+      {
+        placeholder: "<!-- SECTION:ROOT_FILES -->",
+        content: "├── .cfnlintrc.yaml      # cfn-lint 設定",
+      },
+      {
+        placeholder: "<!-- SECTION:SETUP_STEPS -->",
+        content: "4. `cd infra && pnpm install`（CDK 依存パッケージ）",
+      },
+      {
+        placeholder: "<!-- SECTION:SETUP_COMMANDS -->",
+        content: "| `cd infra && pnpm install` | CDK 依存パッケージインストール |",
+      },
+      {
+        placeholder: "<!-- SECTION:LINT_COMMANDS -->",
+        content: "| `pnpm run lint:cfn` | CloudFormation リント |",
+      },
+      {
+        placeholder: "<!-- SECTION:TEST_COMMANDS -->",
+        content:
+          "### インフラテスト\n\n| コマンド | 説明 |\n|---------|------|\n| `pnpm run test:infra` | CDK インフラテスト |\n| `pnpm run cdk:synth` | CDK テンプレート合成 |\n| `pnpm run cdk:diff` | CDK 差分確認 |",
+      },
+    ],
+  },
+  ciSteps: {
+    setupSteps: [
+      { name: "Install infra dependencies", run: "cd infra && pnpm install --frozen-lockfile" },
+      { name: "CDK synth", run: "cd infra && npx cdk synth" },
+    ],
+    lintSteps: [{ name: "Lint (cfn-lint)", run: "cfn-lint" }],
+    testSteps: [{ name: "Test (CDK)", run: "cd infra && pnpm test" }],
+  },
+  setupExtra: "cd infra && pnpm install",
+};

--- a/src/presets/cloudformation.ts
+++ b/src/presets/cloudformation.ts
@@ -1,0 +1,73 @@
+import type { Preset } from "../types.js";
+import { readTemplateFiles } from "../utils.js";
+
+export const cloudformationPreset: Preset = {
+  name: "cloudformation",
+  files: readTemplateFiles("cloudformation"),
+  merge: {
+    "package.json": {
+      scripts: {
+        "lint:cfn": "cfn-lint",
+      },
+    },
+    ".mise.toml": {
+      tools: {
+        awscli: "2",
+        "pipx:cfn-lint": "1",
+      },
+    },
+    ".mcp.json": {
+      mcpServers: {
+        "aws-iac": {
+          command: "uvx",
+          args: ["awslabs.aws-iac-mcp@latest"],
+        },
+      },
+    },
+  },
+  markdown: {
+    "CLAUDE.md": [
+      {
+        placeholder: "<!-- SECTION:TECH_STACK -->",
+        content: "- **IaC**: AWS CloudFormation",
+      },
+      {
+        placeholder: "<!-- SECTION:TECH_STACK_LINTING -->",
+        content: "  - cfn-lint (CloudFormation)",
+      },
+      {
+        placeholder: "<!-- SECTION:TECH_STACK_MCP -->",
+        content: "- **MCP servers**: AWS IaC — configured in `.mcp.json`",
+      },
+      {
+        placeholder: "<!-- SECTION:PROJECT_STRUCTURE -->",
+        content: "infra/        -> CloudFormation templates",
+      },
+      {
+        placeholder: "<!-- SECTION:LINT_COMMANDS -->",
+        content: "pnpm run lint:cfn          # CloudFormation lint (cfn-lint)",
+      },
+      {
+        placeholder: "<!-- SECTION:CODING_CONVENTIONS -->",
+        content: "- CloudFormation: must pass cfn-lint",
+      },
+    ],
+    "README.md": [
+      {
+        placeholder: "<!-- SECTION:DIR_STRUCTURE -->",
+        content: "├── infra/               # CloudFormation テンプレート",
+      },
+      {
+        placeholder: "<!-- SECTION:ROOT_FILES -->",
+        content: "├── .cfnlintrc.yaml      # cfn-lint 設定",
+      },
+      {
+        placeholder: "<!-- SECTION:LINT_COMMANDS -->",
+        content: "| `pnpm run lint:cfn` | CloudFormation リント |",
+      },
+    ],
+  },
+  ciSteps: {
+    lintSteps: [{ name: "Lint (cfn-lint)", run: "cfn-lint" }],
+  },
+};

--- a/src/presets/terraform.ts
+++ b/src/presets/terraform.ts
@@ -1,0 +1,74 @@
+import type { Preset } from "../types.js";
+import { readTemplateFiles } from "../utils.js";
+
+export const terraformPreset: Preset = {
+  name: "terraform",
+  files: readTemplateFiles("terraform"),
+  merge: {
+    "package.json": {
+      scripts: {
+        "lint:tf": "terraform fmt -check -recursive && tflint",
+      },
+    },
+    ".mise.toml": {
+      tools: {
+        awscli: "2",
+        terraform: "1",
+        tflint: "0.55",
+      },
+    },
+    ".mcp.json": {
+      mcpServers: {
+        "aws-iac": {
+          command: "uvx",
+          args: ["awslabs.aws-iac-mcp@latest"],
+        },
+      },
+    },
+  },
+  markdown: {
+    "CLAUDE.md": [
+      {
+        placeholder: "<!-- SECTION:TECH_STACK -->",
+        content: "- **IaC**: Terraform",
+      },
+      {
+        placeholder: "<!-- SECTION:TECH_STACK_LINTING -->",
+        content: "  - tflint (Terraform)",
+      },
+      {
+        placeholder: "<!-- SECTION:TECH_STACK_MCP -->",
+        content: "- **MCP servers**: AWS IaC — configured in `.mcp.json`",
+      },
+      {
+        placeholder: "<!-- SECTION:PROJECT_STRUCTURE -->",
+        content: "*.tf          -> Terraform configuration files",
+      },
+      {
+        placeholder: "<!-- SECTION:LINT_COMMANDS -->",
+        content: "pnpm run lint:tf           # Terraform fmt + tflint",
+      },
+      {
+        placeholder: "<!-- SECTION:CODING_CONVENTIONS -->",
+        content: "- Terraform: must pass `terraform fmt` and tflint",
+      },
+    ],
+    "README.md": [
+      {
+        placeholder: "<!-- SECTION:DIR_STRUCTURE -->",
+        content: "├── *.tf                 # Terraform 設定ファイル",
+      },
+      {
+        placeholder: "<!-- SECTION:ROOT_FILES -->",
+        content: "├── .tflint.hcl          # tflint 設定",
+      },
+      {
+        placeholder: "<!-- SECTION:LINT_COMMANDS -->",
+        content: "| `pnpm run lint:tf` | Terraform フォーマット + tflint |",
+      },
+    ],
+  },
+  ciSteps: {
+    lintSteps: [{ name: "Lint (Terraform)", run: "terraform fmt -check -recursive && tflint" }],
+  },
+};

--- a/templates/cdk/.cfnlintrc.yaml
+++ b/templates/cdk/.cfnlintrc.yaml
@@ -1,0 +1,3 @@
+templates:
+  - cdk.out/**/*.template.json
+ignore_templates: []

--- a/templates/cdk/.github/workflows/cd.yaml
+++ b/templates/cdk/.github/workflows/cd.yaml
@@ -1,0 +1,39 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Setup mise
+        uses: jdx/mise-action@5083fe46f0db0d17c4a46080674d3981cf8e538e
+        with:
+          install: "true"
+          cache: "true"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Install infra dependencies
+        run: cd infra && pnpm install --frozen-lockfile
+
+      - name: CDK deploy
+        run: cd infra && npx cdk deploy --all --require-approval never

--- a/templates/cdk/infra/bin/app.ts
+++ b/templates/cdk/infra/bin/app.ts
@@ -1,0 +1,13 @@
+#!/usr/bin/env node
+import "source-map-support/register";
+import * as cdk from "aws-cdk-lib";
+import { AppStack } from "../lib/app-stack.js";
+
+const app = new cdk.App();
+
+new AppStack(app, "AppStack", {
+  env: {
+    account: process.env.CDK_DEFAULT_ACCOUNT,
+    region: process.env.CDK_DEFAULT_REGION,
+  },
+});

--- a/templates/cdk/infra/cdk.json
+++ b/templates/cdk/infra/cdk.json
@@ -1,0 +1,22 @@
+{
+  "app": "npx tsx bin/app.ts",
+  "watch": {
+    "include": ["**"],
+    "exclude": [
+      "README.md",
+      "cdk*.json",
+      "**/*.d.ts",
+      "**/*.js",
+      "tsconfig.json",
+      "package*.json",
+      "node_modules",
+      "test"
+    ]
+  },
+  "context": {
+    "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
+    "@aws-cdk/core:checkSecretUsage": true,
+    "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
+    "@aws-cdk/core:target-partitions": ["aws", "aws-cn"]
+  }
+}

--- a/templates/cdk/infra/lib/app-stack.ts
+++ b/templates/cdk/infra/lib/app-stack.ts
@@ -1,0 +1,10 @@
+import * as cdk from "aws-cdk-lib";
+import type { Construct } from "constructs";
+
+export class AppStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    // Define your infrastructure here
+  }
+}

--- a/templates/cdk/infra/package.json
+++ b/templates/cdk/infra/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "{{projectName}}-infra",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "test": "vitest run",
+    "cdk": "cdk",
+    "synth": "cdk synth",
+    "deploy": "cdk deploy",
+    "diff": "cdk diff"
+  },
+  "dependencies": {
+    "aws-cdk-lib": "^2.0.0",
+    "cdk-nag": "^2.0.0",
+    "constructs": "^10.0.0",
+    "source-map-support": "^0.5.0"
+  },
+  "devDependencies": {
+    "aws-cdk": "^2.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^3.0.0",
+    "tsx": "^4.0.0"
+  }
+}

--- a/templates/cdk/infra/test/app.test.ts
+++ b/templates/cdk/infra/test/app.test.ts
@@ -1,0 +1,13 @@
+import * as cdk from "aws-cdk-lib";
+import { Template } from "aws-cdk-lib/assertions";
+import { describe, expect, it } from "vitest";
+import { AppStack } from "../lib/app-stack.js";
+
+describe("AppStack", () => {
+  it("creates a stack", () => {
+    const app = new cdk.App();
+    const stack = new AppStack(app, "TestStack");
+    const template = Template.fromStack(stack);
+    expect(template).toBeDefined();
+  });
+});

--- a/templates/cdk/infra/tsconfig.json
+++ b/templates/cdk/infra/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "verbatimModuleSyntax": true
+  },
+  "include": ["bin", "lib", "test"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/templates/cloudformation/.cfnlintrc.yaml
+++ b/templates/cloudformation/.cfnlintrc.yaml
@@ -1,0 +1,3 @@
+templates:
+  - infra/**/*.yaml
+ignore_templates: []

--- a/templates/cloudformation/.github/workflows/cd.yaml
+++ b/templates/cloudformation/.github/workflows/cd.yaml
@@ -1,0 +1,41 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Setup mise
+        uses: jdx/mise-action@5083fe46f0db0d17c4a46080674d3981cf8e538e
+        with:
+          install: "true"
+          cache: "true"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Deploy CloudFormation stack
+        run: |
+          aws cloudformation deploy \
+            --template-file infra/template.yaml \
+            --stack-name ${{ github.event.repository.name }} \
+            --capabilities CAPABILITY_IAM CAPABILITY_NAMED_IAM \
+            --no-fail-on-empty-changeset

--- a/templates/cloudformation/infra/template.yaml
+++ b/templates/cloudformation/infra/template.yaml
@@ -1,0 +1,6 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: {{projectName}} infrastructure
+
+Resources:
+  Placeholder:
+    Type: AWS::CloudFormation::WaitConditionHandle

--- a/templates/terraform/.github/workflows/cd.yaml
+++ b/templates/terraform/.github/workflows/cd.yaml
@@ -1,0 +1,39 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: cd-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      - name: Setup mise
+        uses: jdx/mise-action@5083fe46f0db0d17c4a46080674d3981cf8e538e
+        with:
+          install: "true"
+          cache: "true"
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722
+        with:
+          role-to-assume: ${{ vars.AWS_ROLE_ARN }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Terraform init
+        run: terraform init
+
+      - name: Terraform apply
+        run: terraform apply -auto-approve

--- a/templates/terraform/.tflint.hcl
+++ b/templates/terraform/.tflint.hcl
@@ -1,0 +1,5 @@
+plugin "aws" {
+  enabled = true
+  version = "0.38.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -435,3 +435,301 @@ describe("generate (react)", () => {
     expect(html).not.toContain("{{projectName}}");
   });
 });
+
+// --- Pattern 5: TypeScript + CDK ---
+describe("generate (cdk)", () => {
+  const answers = makeAnswers({ iac: "cdk" });
+  const result = generate(answers);
+
+  it("forces TypeScript preset inclusion", () => {
+    expect(result.hasFile("biome.json")).toBe(true);
+    expect(result.hasFile("tsconfig.json")).toBe(true);
+  });
+
+  it("includes CDK owned files", () => {
+    expect(result.hasFile("infra/bin/app.ts")).toBe(true);
+    expect(result.hasFile("infra/lib/app-stack.ts")).toBe(true);
+    expect(result.hasFile("infra/test/app.test.ts")).toBe(true);
+    expect(result.hasFile("infra/cdk.json")).toBe(true);
+    expect(result.hasFile("infra/tsconfig.json")).toBe(true);
+    expect(result.hasFile("infra/package.json")).toBe(true);
+    expect(result.hasFile(".cfnlintrc.yaml")).toBe(true);
+    expect(result.hasFile(".github/workflows/cd.yaml")).toBe(true);
+  });
+
+  it("merges CDK tools into .mise.toml", () => {
+    const toml = result.readToml(".mise.toml") as Record<string, Record<string, string>>;
+    expect(toml.tools.awscli).toBe("2");
+    expect(toml.tools["npm:aws-cdk"]).toBe("2");
+    expect(toml.tools["pipx:cfn-lint"]).toBe("1");
+  });
+
+  it("merges CDK scripts into package.json", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const scripts = pkg.scripts as Record<string, string>;
+    expect(scripts["cdk:synth"]).toContain("cdk synth");
+    expect(scripts["cdk:deploy"]).toContain("cdk deploy");
+    expect(scripts["test:infra"]).toContain("pnpm test");
+    expect(scripts["lint:cfn"]).toBe("cfn-lint");
+  });
+
+  it("merges aws-iac MCP server into .mcp.json", () => {
+    const mcp = result.readJson(".mcp.json") as Record<string, Record<string, unknown>>;
+    expect(mcp.mcpServers["aws-iac"]).toBeDefined();
+    // base servers still present
+    expect(mcp.mcpServers.context7).toBeDefined();
+  });
+
+  it("adds CDK CI steps with correct order (synth before cfn-lint)", () => {
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name);
+    expect(stepNames).toContain("Install infra dependencies");
+    expect(stepNames).toContain("CDK synth");
+    expect(stepNames).toContain("Lint (cfn-lint)");
+    expect(stepNames).toContain("Test (CDK)");
+    // CDK synth must run before cfn-lint (synth generates templates that cfn-lint checks)
+    const synthIdx = stepNames.indexOf("CDK synth");
+    const cfnLintIdx = stepNames.indexOf("Lint (cfn-lint)");
+    expect(synthIdx).toBeLessThan(cfnLintIdx);
+    // TypeScript steps still present
+    expect(stepNames).toContain("Lint (Biome)");
+  });
+
+  it("adds infra install to setup.sh", () => {
+    const setup = result.readText("scripts/setup.sh");
+    expect(setup).toContain("cd infra && pnpm install");
+  });
+
+  it("replaces {{projectName}} in CDK templates", () => {
+    const infraPkg = result.readText("infra/package.json");
+    expect(infraPkg).toContain("test-app-infra");
+    expect(infraPkg).not.toContain("{{projectName}}");
+  });
+
+  it("expands CLAUDE.md with CDK sections", () => {
+    const claude = result.readText("CLAUDE.md");
+    expect(claude).toContain("CDK");
+    expect(claude).toContain("cfn-lint");
+    expect(claude).not.toContain("<!-- SECTION:");
+  });
+});
+
+// --- Pattern 6: TypeScript + CloudFormation ---
+describe("generate (cloudformation)", () => {
+  const answers = makeAnswers({ languages: ["typescript"], iac: "cloudformation" });
+  const result = generate(answers);
+
+  it("includes CloudFormation owned files", () => {
+    expect(result.hasFile("infra/template.yaml")).toBe(true);
+    expect(result.hasFile(".cfnlintrc.yaml")).toBe(true);
+    expect(result.hasFile(".github/workflows/cd.yaml")).toBe(true);
+  });
+
+  it("merges cfn-lint into .mise.toml", () => {
+    const toml = result.readToml(".mise.toml") as Record<string, Record<string, string>>;
+    expect(toml.tools.awscli).toBe("2");
+    expect(toml.tools["pipx:cfn-lint"]).toBe("1");
+  });
+
+  it("merges aws-iac MCP server into .mcp.json", () => {
+    const mcp = result.readJson(".mcp.json") as Record<string, Record<string, unknown>>;
+    expect(mcp.mcpServers["aws-iac"]).toBeDefined();
+  });
+
+  it("adds cfn-lint CI step", () => {
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name);
+    expect(stepNames).toContain("Lint (cfn-lint)");
+  });
+
+  it("does not include CDK or Terraform files", () => {
+    expect(result.hasFile("infra/cdk.json")).toBe(false);
+    expect(result.hasFile(".tflint.hcl")).toBe(false);
+  });
+
+  it("expands CLAUDE.md with CloudFormation sections", () => {
+    const claude = result.readText("CLAUDE.md");
+    expect(claude).toContain("CloudFormation");
+    expect(claude).not.toContain("<!-- SECTION:");
+  });
+});
+
+// --- Pattern 7: TypeScript + Terraform ---
+describe("generate (terraform)", () => {
+  const answers = makeAnswers({ languages: ["typescript"], iac: "terraform" });
+  const result = generate(answers);
+
+  it("includes Terraform owned files", () => {
+    expect(result.hasFile(".tflint.hcl")).toBe(true);
+    expect(result.hasFile(".github/workflows/cd.yaml")).toBe(true);
+  });
+
+  it("merges Terraform tools into .mise.toml", () => {
+    const toml = result.readToml(".mise.toml") as Record<string, Record<string, string>>;
+    expect(toml.tools.terraform).toBe("1");
+    expect(toml.tools.tflint).toBe("0.55");
+    expect(toml.tools.awscli).toBe("2");
+  });
+
+  it("merges aws-iac MCP server into .mcp.json", () => {
+    const mcp = result.readJson(".mcp.json") as Record<string, Record<string, unknown>>;
+    expect(mcp.mcpServers["aws-iac"]).toBeDefined();
+  });
+
+  it("adds tflint CI step", () => {
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name);
+    expect(stepNames).toContain("Lint (Terraform)");
+  });
+
+  it("does not include CDK or CloudFormation files", () => {
+    expect(result.hasFile("infra/cdk.json")).toBe(false);
+    expect(result.hasFile("infra/template.yaml")).toBe(false);
+  });
+
+  it("expands CLAUDE.md with Terraform sections", () => {
+    const claude = result.readText("CLAUDE.md");
+    expect(claude).toContain("Terraform");
+    expect(claude).toContain("tflint");
+    expect(claude).not.toContain("<!-- SECTION:");
+  });
+
+  it("includes lint:tf in lint:all", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const scripts = pkg.scripts as Record<string, string>;
+    expect(scripts["lint:all"]).toContain("pnpm run lint:tf");
+  });
+});
+
+// --- Pattern 8: Full config (TS + Python + React + CDK) ---
+describe("generate (full config)", () => {
+  const answers = makeAnswers({
+    languages: ["typescript", "python"],
+    frontend: "react",
+    iac: "cdk",
+  });
+  const result = generate(answers);
+
+  it("includes all preset files", () => {
+    // TypeScript
+    expect(result.hasFile("biome.json")).toBe(true);
+    // Python
+    expect(result.hasFile("pyproject.toml")).toBe(true);
+    // React
+    expect(result.hasFile("vite.config.ts")).toBe(true);
+    expect(result.hasFile("index.html")).toBe(true);
+    // CDK
+    expect(result.hasFile("infra/bin/app.ts")).toBe(true);
+    expect(result.hasFile(".cfnlintrc.yaml")).toBe(true);
+    expect(result.hasFile(".github/workflows/cd.yaml")).toBe(true);
+  });
+
+  it("merges all tools into .mise.toml", () => {
+    const toml = result.readToml(".mise.toml") as Record<string, Record<string, string>>;
+    expect(toml.tools["npm:@biomejs/biome"]).toBe("2");
+    expect(toml.tools.python).toBe("3.12");
+    expect(toml.tools["npm:aws-cdk"]).toBe("2");
+  });
+
+  it("merges all MCP servers", () => {
+    const mcp = result.readJson(".mcp.json") as Record<string, Record<string, unknown>>;
+    expect(mcp.mcpServers.context7).toBeDefined();
+    expect(mcp.mcpServers.fetch).toBeDefined();
+    expect(mcp.mcpServers["aws-iac"]).toBeDefined();
+  });
+
+  it("lint:all includes all lint scripts", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const scripts = pkg.scripts as Record<string, string>;
+    expect(scripts["lint:all"]).toContain("pnpm run lint");
+    expect(scripts["lint:all"]).toContain("pnpm run typecheck");
+    expect(scripts["lint:all"]).toContain("pnpm run lint:python");
+    expect(scripts["lint:all"]).toContain("pnpm run lint:cfn");
+    expect(scripts["lint:all"]).toContain("pnpm run lint:secrets");
+  });
+
+  it("CLAUDE.md contains all preset sections", () => {
+    const claude = result.readText("CLAUDE.md");
+    expect(claude).toContain("TypeScript");
+    expect(claude).toContain("Python");
+    expect(claude).toContain("React");
+    expect(claude).toContain("CDK");
+    expect(claude).not.toContain("<!-- SECTION:");
+  });
+});
+
+// --- Pattern 9: Python + Terraform ---
+describe("generate (python + terraform)", () => {
+  const answers = makeAnswers({ languages: ["python"], iac: "terraform" });
+  const result = generate(answers);
+
+  it("includes Python and Terraform files", () => {
+    expect(result.hasFile("pyproject.toml")).toBe(true);
+    expect(result.hasFile(".tflint.hcl")).toBe(true);
+  });
+
+  it("does not include TypeScript files", () => {
+    expect(result.hasFile("biome.json")).toBe(false);
+    expect(result.hasFile("tsconfig.json")).toBe(false);
+  });
+
+  it("merges both preset tools into .mise.toml", () => {
+    const toml = result.readToml(".mise.toml") as Record<string, Record<string, string>>;
+    expect(toml.tools.python).toBe("3.12");
+    expect(toml.tools.terraform).toBe("1");
+    expect(toml.tools.tflint).toBe("0.55");
+  });
+
+  it("has CI steps from both presets", () => {
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name);
+    expect(stepNames).toContain("Lint (Ruff)");
+    expect(stepNames).toContain("Lint (Terraform)");
+  });
+});
+
+// --- Pattern 10: Python + CloudFormation ---
+describe("generate (python + cloudformation)", () => {
+  const answers = makeAnswers({ languages: ["python"], iac: "cloudformation" });
+  const result = generate(answers);
+
+  it("includes Python and CloudFormation files", () => {
+    expect(result.hasFile("pyproject.toml")).toBe(true);
+    expect(result.hasFile("infra/template.yaml")).toBe(true);
+    expect(result.hasFile(".cfnlintrc.yaml")).toBe(true);
+  });
+
+  it("does not include TypeScript or Terraform files", () => {
+    expect(result.hasFile("biome.json")).toBe(false);
+    expect(result.hasFile(".tflint.hcl")).toBe(false);
+  });
+
+  it("merges both preset tools into .mise.toml", () => {
+    const toml = result.readToml(".mise.toml") as Record<string, Record<string, string>>;
+    expect(toml.tools.python).toBe("3.12");
+    expect(toml.tools["pipx:cfn-lint"]).toBe("1");
+  });
+
+  it("has CI steps from both presets", () => {
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name);
+    expect(stepNames).toContain("Lint (Ruff)");
+    expect(stepNames).toContain("Lint (cfn-lint)");
+  });
+
+  it("replaces {{projectName}} in CloudFormation template", () => {
+    const template = result.readText("infra/template.yaml");
+    expect(template).toContain("test-app");
+    expect(template).not.toContain("{{projectName}}");
+  });
+});


### PR DESCRIPTION
## Summary

Issue #4 の実装。CDK / CloudFormation / Terraform の3つの IaC プリセットを追加。

- **CDK**: `requires: ['typescript']`, infra/ scaffold (bin/app.ts, lib/app-stack.ts, test/, cdk.json, tsconfig.json, package.json), cfn-lint, cdk-nag, CD workflow
- **CloudFormation**: infra/template.yaml, cfn-lint, CD workflow
- **Terraform**: tflint, terraform fmt, CD workflow
- 全 IaC プリセットが aws-iac MCP サーバーと awscli を自動追加
- CDK synth を CI の setupSteps に配置し、cfn-lint の前に実行される正しい順序を保証
- CLAUDE.md / README.md にセクション注入

## Test plan

- [x] `pnpm test` — 101 tests pass (merge 20 + generator 81)
- [x] `pnpm run lint` — Biome check pass
- [x] `pnpm run typecheck` — TypeScript check pass
- [x] `pnpm run build` — Build success
- [x] CDK synth の CI ステップ順序テスト（synth < cfn-lint）

Closes #4