### PR TITLE
refactor: fix review findings (CI pnpm install, dedup buildResult, docs sync)

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -154,6 +154,9 @@ interface Preset {
     'lefthook.yaml'?: DeepPartial<LefthookConfig>;
     // ...
   };
+  markdown?: Record<string, MarkdownSection[]>;  // Markdown section injection
+  ciSteps?: CiContribution;      // CI workflow contributions
+  setupExtra?: string;           // Extra commands for setup.sh
 }
 ```
 
@@ -198,6 +201,9 @@ create-agentic-dev/
 │   ├── cli.ts                # Wizard (@clack/prompts)
 │   ├── generator.ts          # Composition engine (resolve → merge → output)
 │   ├── merge.ts              # Per-filetype merge logic
+│   ├── ci.ts                 # CI workflow builder
+│   ├── setup.ts              # setup.sh template expansion
+│   ├── utils.ts              # File I/O utilities (readTemplateFiles, writers)
 │   ├── types.ts              # Type definitions (Preset interface, etc.)
 │   └── presets/
 │       ├── base.ts

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,5 +1,3 @@
-import { parse as parseToml } from "smol-toml";
-import { parse as parseYaml } from "yaml";
 import { buildCiWorkflow } from "./ci.js";
 import { expandMarkdown, mergeFile } from "./merge.js";
 import { basePreset } from "./presets/base.js";
@@ -17,6 +15,7 @@ import type {
   Preset,
   WizardAnswers,
 } from "./types.js";
+import { buildResult } from "./utils.js";
 
 const ALL_PRESETS: Record<string, Preset> = {
   base: basePreset,
@@ -200,32 +199,4 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
   }
 
   return buildResult(allFiles);
-}
-
-function buildResult(files: Map<string, string>): GenerateResult {
-  return {
-    files,
-    fileList: () => [...files.keys()].sort(),
-    hasFile: (p: string) => files.has(p),
-    readText: (p: string) => {
-      const content = files.get(p);
-      if (content === undefined) throw new Error(`File not found: ${p}`);
-      return content;
-    },
-    readJson: (p: string) => {
-      const c = files.get(p);
-      if (c === undefined) throw new Error(`File not found: ${p}`);
-      return JSON.parse(c) as unknown;
-    },
-    readYaml: (p: string) => {
-      const c = files.get(p);
-      if (c === undefined) throw new Error(`File not found: ${p}`);
-      return parseYaml(c) as unknown;
-    },
-    readToml: (p: string) => {
-      const c = files.get(p);
-      if (c === undefined) throw new Error(`File not found: ${p}`);
-      return parseToml(c) as unknown;
-    },
-  };
 }

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -41,7 +41,8 @@ export function mergeYaml(base: string, ...patches: unknown[]): string {
 export function mergeToml(base: string, ...patches: unknown[]): string {
   const baseObj = base.trim() ? (parseToml(base) as Record<string, unknown>) : {};
   const merged = mergeDeep(baseObj, ...patches);
-  return stringifyToml(merged as Record<string, unknown>);
+  const result = stringifyToml(merged as Record<string, unknown>);
+  return result.endsWith("\n") ? result : `${result}\n`;
 }
 
 /** Replace placeholders in a Markdown template with injected sections. */

--- a/src/presets/base.ts
+++ b/src/presets/base.ts
@@ -121,6 +121,7 @@ export const basePreset: Preset = {
           "restore-keys": "pnpm-${{ runner.os }}-",
         },
       },
+      { name: "Install dependencies", run: "pnpm install --frozen-lockfile" },
     ],
     lintSteps: [
       { name: "Lint (Markdown)", run: "markdownlint-cli2 '**/*.md' '#**/node_modules'" },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,6 +46,35 @@ export function createDiskWriter(outDir: string): FileWriter {
   };
 }
 
+/** Build a GenerateResult from a file map. */
+export function buildResult(files: Map<string, string>): GenerateResult {
+  return {
+    files,
+    fileList: () => [...files.keys()].sort(),
+    hasFile: (p: string) => files.has(p),
+    readText: (p: string) => {
+      const content = files.get(p);
+      if (content === undefined) throw new Error(`File not found: ${p}`);
+      return content;
+    },
+    readJson: (p: string) => {
+      const c = files.get(p);
+      if (c === undefined) throw new Error(`File not found: ${p}`);
+      return JSON.parse(c) as unknown;
+    },
+    readYaml: (p: string) => {
+      const c = files.get(p);
+      if (c === undefined) throw new Error(`File not found: ${p}`);
+      return parseYaml(c) as unknown;
+    },
+    readToml: (p: string) => {
+      const c = files.get(p);
+      if (c === undefined) throw new Error(`File not found: ${p}`);
+      return parseToml(c) as unknown;
+    },
+  };
+}
+
 /** Create a memory-based FileWriter for testing. Returns writer and a function to build GenerateResult. */
 export function createMemoryWriter(): { writer: FileWriter; getResult: () => GenerateResult } {
   const files = new Map<string, string>();
@@ -55,33 +84,5 @@ export function createMemoryWriter(): { writer: FileWriter; getResult: () => Gen
     },
   };
 
-  function getResult(): GenerateResult {
-    return {
-      files,
-      fileList: () => [...files.keys()].sort(),
-      hasFile: (p: string) => files.has(p),
-      readText: (p: string) => {
-        const content = files.get(p);
-        if (content === undefined) throw new Error(`File not found: ${p}`);
-        return content;
-      },
-      readJson: (p: string) => {
-        const c = files.get(p);
-        if (c === undefined) throw new Error(`File not found: ${p}`);
-        return JSON.parse(c) as unknown;
-      },
-      readYaml: (p: string) => {
-        const c = files.get(p);
-        if (c === undefined) throw new Error(`File not found: ${p}`);
-        return parseYaml(c) as unknown;
-      },
-      readToml: (p: string) => {
-        const c = files.get(p);
-        if (c === undefined) throw new Error(`File not found: ${p}`);
-        return parseToml(c) as unknown;
-      },
-    };
-  }
-
-  return { writer, getResult };
+  return { writer, getResult: () => buildResult(files) };
 }

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -111,6 +111,7 @@ describe("generate (base only)", () => {
     const jobs = ci.jobs as Record<string, Record<string, unknown>>;
     const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
     const stepNames = steps.map((s) => s.name);
+    expect(stepNames).toContain("Install dependencies");
     expect(stepNames).toContain("Lint (Markdown)");
     expect(stepNames).toContain("Security (Gitleaks)");
   });


### PR DESCRIPTION
## Summary

リポジトリ全体レビューで発見した指摘事項を修正。

- **Warning-2 fix**: 生成される CI workflow に `pnpm install --frozen-lockfile` ステップが欠落していた問題を修正。base プリセットの `ciSteps.setupSteps` に追加
- **Info-1 fix**: `docs/design.md` のディレクトリレイアウトに `ci.ts`, `setup.ts`, `utils.ts` を追記。Preset interface に `markdown`, `ciSteps`, `setupExtra` フィールドを追記
- **Info-2 fix**: `mergeToml` の出力に末尾改行を保証
- **Info-3 fix**: `generator.ts` と `utils.ts` で重複していた `buildResult` を `utils.ts` に共通化

## Test plan

- [x] 112 テスト全パス
- [x] Biome lint クリーン
- [x] TypeScript typecheck クリーン
- [x] CI workflow テストに `Install dependencies` ステップの存在確認を追加