### PR TITLE
docs: fix design.md inaccuracies and add CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,55 @@
+# Contributing
+
+Thank you for your interest in contributing to `create-agentic-dev`!
+
+## Development Setup
+
+```bash
+git clone https://github.com/ozzy-3/create-agentic-dev.git
+cd create-agentic-dev
+mise install
+pnpm install
+```
+
+## Development Workflow
+
+```bash
+pnpm run dev          # Watch mode build
+pnpm test             # Run tests
+pnpm run lint:all     # All linters + typecheck
+```
+
+## Branch & Commit Conventions
+
+- **Branching**: GitHub Flow — create feature branches from `main`
+- **Branch naming**: `<type>/<short-description>` (e.g., `feat/add-vue`, `fix/merge-bug`)
+- **Commits**: [Conventional Commits](https://www.conventionalcommits.org/) (enforced by commitlint)
+- **Merge**: Squash merge only
+
+## Pull Requests
+
+1. Create a feature branch from `main`
+2. Make your changes
+3. Ensure `pnpm run lint:all` and `pnpm test` pass
+4. Open a PR using the provided template
+5. PRs are squash-merged after review
+
+## Project Structure
+
+```text
+src/              # CLI source code
+src/presets/      # Preset logic (merge contributions, dependencies)
+templates/        # Preset file assets (copied as-is to output)
+tests/            # Test files
+docs/             # Design document
+```
+
+See [docs/design.md](docs/design.md) for the full architecture and design decisions.
+
+## Adding a New Preset
+
+1. Create `templates/<preset>/` with owned files
+2. Create `src/presets/<preset>.ts` implementing the `Preset` interface
+3. Register it in `src/generator.ts` (`ALL_PRESETS` and `PRESET_ORDER`)
+4. Add integration tests in `tests/generator.test.ts`
+5. Update `docs/design.md` with the new preset details

--- a/docs/design.md
+++ b/docs/design.md
@@ -40,7 +40,7 @@ Application order: `base → typescript → python → react → cdk / cloudform
 
 | Category | Elements | Files |
 |----------|----------|-------|
-| Git | .gitignore, .gitattributes, EditorConfig, lefthook, commitlint, Gitleaks | `.gitignore`, `.gitattributes`, `.editorconfig`, `lefthook.yaml`, `.commitlintrc.yaml` |
+| Git | .gitignore, .gitattributes, EditorConfig, lefthook, commitlint, Gitleaks | `.gitignore`, `.gitattributes`, `.editorconfig`, `.commitlintrc.yaml` |
 | Package management | mise, pnpm | `.mise.toml`, `package.json`, `pnpm-lock.yaml`, `.npmrc` |
 | Shell | shellcheck, shfmt | via lefthook / CI |
 | Markdown | markdownlint, mdformat | `.markdownlint-cli2.yaml`, `.mdformat.toml` |
@@ -123,7 +123,7 @@ Application order: `base → typescript → python → react → cdk / cloudform
 
 | Shared file | Modified by |
 |-------------|-------------|
-| `package.json` | base, typescript, react, cdk |
+| `package.json` | base, typescript, python, react, cdk |
 | `.mise.toml` | base, typescript, python, cdk, cloudformation, terraform |
 | `lefthook.yaml` | base, typescript, python |
 | `.github/workflows/ci.yaml` | base, typescript, python, cdk, cloudformation, terraform |
@@ -309,9 +309,12 @@ npm create agentic-dev [my-app]
   │                          → { name, languages, frontend, iac }
   ├─ src/generator.ts      # 1. Resolve dependencies → preset list
   │                          2. Collect owned files from templates/
-  │                          3. Deep merge shared files
-  │                          4. Expand Markdown templates
-  │                          5. Write all files to output directory
+  │                          3. Deep merge shared files (JSON/YAML/TOML)
+  │                          4. Build lint:all script dynamically
+  │                          5. Expand Markdown templates
+  │                          6. Build CI workflow (src/ci.ts)
+  │                          7. Expand setup.sh template (src/setup.ts)
+  │                          8. Write all files to output directory
   └─ Done message (next steps)
 ```
 


### PR DESCRIPTION
## Summary

- **design.md Execution Flow 更新**: 実装と乖離していた実行フローを 8 ステップに修正（`lint:all` 動的生成、CI workflow ビルド、setup.sh テンプレート展開が未記載だった）
- **design.md Shared files テーブル修正**: `package.json` の Modified by に `python` を追加
- **design.md base テーブル修正**: `lefthook.yaml` を Files 列から削除（shared file であり owned file ではない）
- **CONTRIBUTING.md 新規作成**: 開発セットアップ、ワークフロー、プリセット追加手順を記載

## Type of Change

- [x] Documentation

## Testing

- `pnpm run lint:all` — 全パス
- `pnpm test` — 112 テスト全パス
- ドキュメントのみの変更のためコード影響なし

## Checklist

- [x] Code follows project conventions
- [x] Linters pass (`pnpm run lint:all`)
- [x] Self-reviewed
- [x] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)