### PR TITLE
docs: add branch strategy and tool addition guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,7 @@ src/              -> CLI source code
 src/presets/      -> Preset logic (merge contributions, dependencies)
 templates/        -> Preset file assets (copied as-is to output)
 tests/            -> Test files
-docs/             -> Design document
+docs/             -> Design docs, guides
 scripts/          -> Shell scripts
 ```
 
@@ -86,6 +86,7 @@ Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`
 
 GitHub Flow: `main` + feature branches. **squash merge only**.
 Branch naming: `<type>/<short-description>` (e.g., `feat/add-wizard`, `fix/merge-bug`).
+See [`docs/branch-strategy.md`](docs/branch-strategy.md) for full details.
 
 ## Skills
 

--- a/docs/adding-tools.md
+++ b/docs/adding-tools.md
@@ -1,0 +1,70 @@
+# リンター・フォーマッター追加ガイド
+
+新しいリンター/フォーマッターをこのリポジトリに追加する際に更新が必要な箇所のチェックリストです。
+
+> **Note**: 生成プロジェクトにリンター/フォーマッターを追加する場合は、プリセットとして実装します。
+> [docs/preset-authoring.md](preset-authoring.md) を参照してください。
+
+## チェックリスト
+
+### 1. ツールのインストール
+
+- [ ] `.mise.toml` にツールとバージョンプレフィックスを追加
+- [ ] `mise install` で動作確認
+- [ ] バージョンが最新安定版であることを確認（プレリリース版を避ける）
+
+### 2. 設定ファイル
+
+- [ ] ツール固有の設定ファイルを作成（例: `.hadolint.yaml`）
+- [ ] プロジェクトの規約に合わせた設定（インデント 2、行幅 100、LF 等）
+- [ ] exclude/ignore パターンの設定（`node_modules`, `templates`, `dist` 等）
+
+### 3. package.json
+
+- [ ] `scripts` に `lint:<name>` を追加
+- [ ] `lint:all` に含めるか判断し、必要なら `lint:all` の `&&` チェーンに追加
+- [ ] `lint:all` に含めない場合、コメントでその旨を明記
+
+### 4. lefthook.yaml（pre-commit）
+
+- [ ] フォーマッター → `stage_fixed: true` 付きで追加
+- [ ] リンター → `glob` パターンを設定して追加
+- [ ] フォーマッターとリンターの実行順序が正しいことを確認（フォーマッター先）
+- [ ] CI やローカルコマンドとオプションが一致していることを確認
+
+### 5. CI ワークフロー（`.github/workflows/ci.yaml`）
+
+- [ ] lint ステップを追加
+- [ ] package.json の `lint:<name>` コマンドと**同じオプション**を使用
+- [ ] 前提条件があるツールは適切な位置に配置
+
+### 6. ドキュメント
+
+- [ ] `CLAUDE.md` — Tech Stack (Linting/Formatting)
+- [ ] `CLAUDE.md` — Key Commands (lint コマンド一覧)
+- [ ] `CLAUDE.md` — Coding Conventions (規約追加)
+- [ ] `.claude/skills/lint-rules/SKILL.md` — 拡張子別コマンド表
+- [ ] `docs/branch-strategy.md` — Lefthook フック構成
+
+### 7. 整合性確認
+
+- [ ] `pnpm run lint:all` が通ること
+- [ ] `pnpm test` が通ること
+- [ ] 各場所でのコマンドオプションが一致していること:
+  - package.json scripts
+  - `.github/workflows/ci.yaml`
+  - lefthook.yaml
+  - `.claude/skills/lint-rules/SKILL.md`
+
+## 対象ファイルのクイックリファレンス
+
+| 更新箇所 | ファイル |
+|----------|---------|
+| ツール定義 | `.mise.toml` |
+| ツール設定 | プロジェクトルートの設定ファイル |
+| npm scripts | `package.json` |
+| Git hooks | `lefthook.yaml` |
+| CI | `.github/workflows/ci.yaml` |
+| プロジェクトガイダンス | `CLAUDE.md` |
+| Lint ルール | `.claude/skills/lint-rules/SKILL.md` |
+| ブランチ戦略 | `docs/branch-strategy.md` |

--- a/docs/branch-strategy.md
+++ b/docs/branch-strategy.md
@@ -1,0 +1,81 @@
+# ブランチ戦略
+
+このドキュメントはブランチ戦略の SSOT（Single Source of Truth）です。
+
+## 採用戦略: GitHub Flow
+
+シンプルな `main` + feature branches モデルを採用。
+
+- `main` は常にデプロイ可能な状態を維持
+- 全変更は feature branch から PR を経由して `main` にマージ
+- マージ方法は **squash merge のみ**（1 PR = 1 コミット）
+
+## ブランチ命名規則
+
+```text
+<type>/<short-description>
+```
+
+### type 一覧
+
+| type | 用途 | 例 |
+|------|------|----|
+| `feat` | 新機能 | `feat/add-vue-preset` |
+| `fix` | バグ修正 | `fix/merge-array-dedup` |
+| `docs` | ドキュメント | `docs/update-readme` |
+| `style` | フォーマット（動作変更なし） | `style/fix-indent` |
+| `refactor` | リファクタリング | `refactor/extract-utils` |
+| `perf` | パフォーマンス改善 | `perf/optimize-merge` |
+| `test` | テスト | `test/add-preset-tests` |
+| `build` | ビルド・依存関係 | `build/upgrade-tsdown` |
+| `ci` | CI 設定 | `ci/add-lint-job` |
+| `chore` | その他 | `chore/update-gitignore` |
+
+### 命名ルール
+
+- 英小文字 + ハイフン区切り（`kebab-case`）
+- 簡潔で内容が伝わる名前にする
+- Issue 番号を含める場合: `feat/123-add-vue-preset`
+
+## ワークフロー
+
+```text
+1. main から feature branch を作成
+2. 変更を実装・コミット（Conventional Commits）
+3. GitHub に push
+4. PR を作成
+5. CI チェック通過を確認
+6. squash merge で main にマージ
+7. feature branch を削除
+```
+
+## main ブランチ保護ルール
+
+- main への直接 push 禁止
+- force push 禁止
+- PR 経由のマージのみ許可
+- CI チェック通過必須
+
+## Issue 作成ポリシー
+
+- Issue 作成は **任意**
+- `feat`（新機能）と `fix`（バグ修正）は Issue 作成を **推奨**
+- `docs`, `chore`, `style` 等の軽微な変更は Issue 不要
+
+## コミット規約
+
+[Conventional Commits 1.0.0](https://www.conventionalcommits.org/) に準拠。commitlint で強制。
+
+```text
+<type>[optional scope]: <description>
+```
+
+## Lefthook フック構成
+
+| フック | 実行内容 |
+|--------|----------|
+| `commit-msg` | commitlint（コミットメッセージ検証） |
+| `pre-commit` | Biome, shellcheck, shfmt, taplo, markdownlint, yamlfmt, yamllint, actionlint, gitleaks（自動修正 + セキュリティ） |
+| `pre-push` | TypeScript typecheck |
+
+設定ファイル: [`lefthook.yaml`](../lefthook.yaml)


### PR DESCRIPTION
## Summary

- **docs/branch-strategy.md**: ブランチ戦略の SSOT（GitHub Flow、命名規則、ワークフロー、保護ルール、コミット規約、Lefthook フック構成）
- **docs/adding-tools.md**: リンター・フォーマッター追加チェックリスト（mise → 設定 → package.json → lefthook → CI → ドキュメント → 整合性確認）
- **CLAUDE.md**: branch-strategy.md への参照追加、docs/ 説明を更新

生成プロジェクトには `templates/base/docs/` に同等のドキュメントがあるが、本リポジトリ自体には存在しなかった不整合を解消。

## Type of Change

- [x] Documentation

## Testing

- `pnpm run lint:all` — 全パス
- `pnpm test` — 112 テスト全パス
- ドキュメントのみの変更のためコード影響なし

## Checklist

- [x] Code follows project conventions
- [x] Linters pass (`pnpm run lint:all`)
- [x] Self-reviewed
- [x] Documentation updated (if applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)