### PR TITLE
docs: add development guide with manual verification steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,22 +2,9 @@
 
 Thank you for your interest in contributing to `create-agentic-dev`!
 
-## Development Setup
+## Getting Started
 
-```bash
-git clone https://github.com/ozzy-3/create-agentic-dev.git
-cd create-agentic-dev
-mise install
-pnpm install
-```
-
-## Development Workflow
-
-```bash
-pnpm run dev          # Watch mode build
-pnpm test             # Run tests
-pnpm run lint:all     # All linters + typecheck
-```
+For development setup, commands, and testing guide, see [docs/development.md](docs/development.md).
 
 ## Branch & Commit Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ src/              # CLI source code
 src/presets/      # Preset logic (merge contributions, dependencies)
 templates/        # Preset file assets (copied as-is to output)
 tests/            # Test files
-docs/             # Design document
+docs/             # Design docs, guides
 ```
 
 See [docs/design.md](docs/design.md) for the full architecture and design decisions.

--- a/README.md
+++ b/README.md
@@ -50,12 +50,7 @@ Every generated project includes:
 
 ## Development
 
-```bash
-pnpm install
-pnpm run dev          # Watch mode build
-pnpm test             # Run tests
-pnpm run lint:all     # All linters + typecheck
-```
+See [docs/development.md](docs/development.md) for setup instructions, commands, and testing guide.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ See [docs/design.md](docs/design.md) for the full design document.
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.
 
 To add a new preset, see [docs/preset-authoring.md](docs/preset-authoring.md).
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,102 @@
+# Development Guide
+
+## Prerequisites
+
+- Node.js >= 20 (recommended: 24)
+- [pnpm](https://pnpm.io/) 10
+- [mise](https://mise.jdx.dev/) (version management)
+
+## Development Setup
+
+```bash
+git clone https://github.com/ozzy-3/create-agentic-dev.git
+cd create-agentic-dev
+mise install
+pnpm install
+```
+
+## Development Workflow
+
+```bash
+pnpm run dev          # Watch mode build
+pnpm run build        # Production build
+pnpm test             # Run tests
+pnpm run test:watch   # Watch mode tests
+```
+
+### Lint & Format
+
+| Command | Description |
+|---------|-------------|
+| `pnpm run lint` | Biome check |
+| `pnpm run lint:fix` | Biome check with auto-fix |
+| `pnpm run lint:all` | All linters + typecheck + gitleaks |
+| `pnpm run typecheck` | TypeScript type check |
+| `pnpm run lint:md` | Markdown lint |
+| `pnpm run lint:yaml` | YAML lint |
+| `pnpm run lint:shell` | Shell lint |
+| `pnpm run lint:toml` | TOML format check |
+| `pnpm run lint:secrets` | Secret detection (Gitleaks) |
+
+All code must pass `pnpm run lint:all` before committing.
+
+## Testing
+
+### Automated Tests
+
+Tests are located in `tests/` and run with [vitest](https://vitest.dev/):
+
+| Level | Target | Purpose |
+|-------|--------|---------|
+| Unit | `merge.ts` | Merge logic correctness for JSON, YAML, TOML, Markdown |
+| Integration | `generator.ts` | Verify generated output for each preset combination |
+| Snapshot | Generated file sets | Detect unintended changes in output |
+
+Tests use an in-memory file writer (`createMemoryWriter`) so no disk I/O or cleanup is needed.
+
+See [Testing Strategy](design.md#testing-strategy) in the design document for the full test matrix.
+
+### Manual Verification
+
+After making changes to the CLI or templates, verify the generated output by installing
+the CLI locally with `pnpm link`:
+
+1. Build the project:
+
+   ```bash
+   pnpm run build
+   ```
+
+2. Link the CLI globally:
+
+   ```bash
+   pnpm link --global
+   ```
+
+3. Generate a test project in a temporary directory:
+
+   ```bash
+   cd /tmp
+   create-agentic-dev my-test-app
+   ```
+
+4. Verify the generated project:
+   - Check that expected files exist
+   - Review merged file contents (package.json, lefthook.yaml, CLAUDE.md, etc.)
+   - Run `bash scripts/setup.sh` in the generated project if needed
+
+5. Clean up when done:
+
+   ```bash
+   pnpm unlink --global create-agentic-dev
+   rm -rf /tmp/my-test-app
+   ```
+
+> **Tip**: Test multiple preset combinations to ensure merge logic works correctly.
+> See the [integration test matrix](design.md#testing-strategy) for representative patterns.
+
+## Further Reading
+
+- [Design Document](design.md) — Architecture, preset composition, and testing strategy
+- [Preset Authoring Guide](preset-authoring.md) — How to add a new preset
+- [Contributing](../CONTRIBUTING.md) — Branch conventions, PR process, and project structure

--- a/docs/development.md
+++ b/docs/development.md
@@ -58,8 +58,7 @@ See [Testing Strategy](design.md#testing-strategy) in the design document for th
 
 ### Manual Verification
 
-After making changes to the CLI or templates, verify the generated output by installing
-the CLI locally with `pnpm link`:
+After making changes to the CLI or templates, verify the generated output by installing the CLI locally with `pnpm link`:
 
 1. Build the project:
 


### PR DESCRIPTION
## Summary

- `docs/development.md` を新規作成し、開発セットアップ・ワークフロー・リントコマンド一覧・テスト・手動動作確認（`pnpm link --global`）手順を集約
- `CONTRIBUTING.md` から Development Setup / Workflow セクションを `docs/development.md` へ移管しリンクに置換
- `README.md` の Development セクションを `docs/development.md` へのリンクに簡略化

## Test plan

- [x] `pnpm run lint:md` パス
- [x] `gitleaks detect` パス
- [x] `pnpm test` 全 112 テストパス
- [ ] ドキュメント間のリンクが正しく機能すること