### PR TITLE
fix: resolve generated project issues found in manual verification

### DIFF
--- a/src/presets/cdk.ts
+++ b/src/presets/cdk.ts
@@ -59,7 +59,7 @@ export const cdkPreset: Preset = {
       },
       {
         placeholder: "<!-- SECTION:TEST_COMMANDS -->",
-        content: "# Infra Test\npnpm run test:infra         # CDK infrastructure tests",
+        content: "pnpm run test:infra         # CDK infrastructure tests",
       },
       {
         placeholder: "<!-- SECTION:CODING_CONVENTIONS -->",
@@ -91,7 +91,7 @@ export const cdkPreset: Preset = {
       {
         placeholder: "<!-- SECTION:TEST_COMMANDS -->",
         content:
-          "### インフラテスト\n\n| コマンド | 説明 |\n|---------|------|\n| `pnpm run test:infra` | CDK インフラテスト |\n| `pnpm run cdk:synth` | CDK テンプレート合成 |\n| `pnpm run cdk:diff` | CDK 差分確認 |",
+          "| `pnpm run test:infra` | CDK インフラテスト |\n| `pnpm run cdk:synth` | CDK テンプレート合成 |\n| `pnpm run cdk:diff` | CDK 差分確認 |",
       },
     ],
   },

--- a/src/presets/python.ts
+++ b/src/presets/python.ts
@@ -66,7 +66,7 @@ export const pythonPreset: Preset = {
       },
       {
         placeholder: "<!-- SECTION:TEST_COMMANDS -->",
-        content: "# Test\nuv run pytest              # Run Python tests",
+        content: "uv run pytest              # Run Python tests",
       },
       {
         placeholder: "<!-- SECTION:CODING_CONVENTIONS -->",
@@ -107,8 +107,7 @@ export const pythonPreset: Preset = {
       },
       {
         placeholder: "<!-- SECTION:TEST_COMMANDS -->",
-        content:
-          "### テスト\n\n| コマンド | 説明 |\n|---------|------|\n| `uv run pytest` | Python テスト実行 |",
+        content: "| `uv run pytest` | Python テスト実行 |",
       },
     ],
   },

--- a/src/presets/typescript.ts
+++ b/src/presets/typescript.ts
@@ -18,7 +18,7 @@ export const typescriptPreset: Preset = {
       devDependencies: {
         typescript: "^5.0.0",
         "@types/node": "^22.0.0",
-        vitest: "^3.0.0",
+        vitest: "^4.0.0",
         tsdown: "^0.12.0",
       },
     },
@@ -70,7 +70,7 @@ export const typescriptPreset: Preset = {
       {
         placeholder: "<!-- SECTION:TEST_COMMANDS -->",
         content:
-          "# Test\npnpm test                  # Run tests (vitest)\npnpm run test:watch        # Watch mode tests",
+          "pnpm test                  # Run tests (vitest)\npnpm run test:watch        # Watch mode tests",
       },
       {
         placeholder: "<!-- SECTION:CODING_CONVENTIONS -->",
@@ -113,7 +113,7 @@ export const typescriptPreset: Preset = {
       {
         placeholder: "<!-- SECTION:TEST_COMMANDS -->",
         content:
-          "### テスト\n\n| コマンド | 説明 |\n|---------|------|\n| `pnpm test` | テスト実行（vitest） |\n| `pnpm run test:watch` | ウォッチモードテスト |",
+          "| `pnpm test` | テスト実行（vitest） |\n| `pnpm run test:watch` | ウォッチモードテスト |",
       },
     ],
   },
@@ -121,7 +121,7 @@ export const typescriptPreset: Preset = {
     lintSteps: [{ name: "Lint (Biome)", run: "biome check ." }],
     testSteps: [{ name: "Test", run: "pnpm test" }],
     buildSteps: [
-      { name: "Typecheck", run: "tsc --noEmit" },
+      { name: "Typecheck (TypeScript)", run: "tsc --noEmit" },
       { name: "Build", run: "pnpm run build" },
     ],
   },

--- a/templates/base/.claude/rules/git-workflow.md
+++ b/templates/base/.claude/rules/git-workflow.md
@@ -29,7 +29,7 @@ Conventional Commits 形式を使用する:
 3段構成で品質を担保:
 
 1. **commit-msg**: commitlint でメッセージ形式を検証
-2. **pre-commit**: 各リンター・フォーマッター + セキュリティが並列実行（Biome, Ruff, sqlfluff, mdformat, markdownlint, yamlfmt, yamllint, shellcheck, shfmt, taplo, dockerfmt, hadolint, actionlint, gitleaks）
+2. **pre-commit**: 各リンター・フォーマッター + セキュリティが並列実行（Biome, Ruff, markdownlint, yamlfmt, yamllint, shellcheck, shfmt, taplo, dockerfmt, hadolint, actionlint, gitleaks）
 3. **pre-push**: TypeScript typecheck + mypy
 
 ## 禁止事項

--- a/templates/base/.devcontainer/devcontainer.json
+++ b/templates/base/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "name": "agentic-dev-template",
+  "name": "{{projectName}}",
   "build": {
     "dockerfile": "Dockerfile",
     "context": "..",

--- a/templates/base/.gitignore
+++ b/templates/base/.gitignore
@@ -13,7 +13,6 @@ build/
 
 # CDK
 cdk.out/
-infra/cdk.out/
 cdk.context.json
 
 # IDE

--- a/templates/base/.mcp.json.example
+++ b/templates/base/.mcp.json.example
@@ -6,7 +6,7 @@
     },
     "aws-iac": {
       "command": "uvx",
-      "args": ["awslabs.aws-iac-mcp-server@latest"],
+      "args": ["awslabs.aws-iac-mcp@latest"],
       "env": {
         "AWS_PROFILE": "${AWS_PROFILE:-default}",
         "AWS_REGION": "${AWS_REGION:-ap-northeast-1}"

--- a/templates/base/.yamllint.yaml
+++ b/templates/base/.yamllint.yaml
@@ -2,7 +2,7 @@ extends: default
 
 rules:
   line-length:
-    max: 120
+    max: 100
     level: warning
   document-start: disable
   truthy:

--- a/templates/base/CLAUDE.md
+++ b/templates/base/CLAUDE.md
@@ -72,6 +72,7 @@ pnpm run lint:compose      # Docker Compose lint (dclint)
 pnpm run lint:actions      # GitHub Actions lint (actionlint)
 pnpm run lint:secrets      # Secret detection (Gitleaks)
 <!-- SECTION:LINT_COMMANDS -->
+# Test
 <!-- SECTION:TEST_COMMANDS -->
 ```
 

--- a/templates/base/README.md
+++ b/templates/base/README.md
@@ -62,6 +62,10 @@ bash scripts/setup.sh
 | `pnpm run lint:secrets` | シークレット検出（Gitleaks） |
 <!-- SECTION:LINT_COMMANDS -->
 
+### テスト
+
+| コマンド | 説明 |
+|---------|------|
 <!-- SECTION:TEST_COMMANDS -->
 
 ## Conventional Commits

--- a/templates/base/docs/adding-tools.md
+++ b/templates/base/docs/adding-tools.md
@@ -58,4 +58,14 @@
 
 ## 対象ファイルのクイックリファレンス
 
-| 更新箇所 | ファイル | |---------|---------| | ツール定義 | `.mise.toml` | | ツール設定 | プロジェクトルートの設定ファイル | | npm scripts | `package.json` | | Git hooks | `lefthook.yaml` | | CI | `.github/workflows/ci.yaml` | | プロジェクトガイダンス | `CLAUDE.md` | | Lint ルール | `.claude/skills/lint-rules/SKILL.md` | | README | `README.md` | | ブランチ戦略 | `docs/branch-strategy.md` |
+| 更新箇所 | ファイル |
+|---------|---------|
+| ツール定義 | `.mise.toml` |
+| ツール設定 | プロジェクトルートの設定ファイル |
+| npm scripts | `package.json` |
+| Git hooks | `lefthook.yaml` |
+| CI | `.github/workflows/ci.yaml` |
+| プロジェクトガイダンス | `CLAUDE.md` |
+| Lint ルール | `.claude/skills/lint-rules/SKILL.md` |
+| README | `README.md` |
+| ブランチ戦略 | `docs/branch-strategy.md` |

--- a/templates/base/docs/branch-strategy.md
+++ b/templates/base/docs/branch-strategy.md
@@ -75,7 +75,7 @@
 | フック | 実行内容 |
 |--------|----------|
 | `commit-msg` | commitlint（コミットメッセージ検証） |
-| `pre-commit` | Biome, Ruff, shellcheck, shfmt, taplo, mdformat, markdownlint, yamlfmt, yamllint, sqlfluff, dockerfmt, hadolint, actionlint, gitleaks（自動修正 + セキュリティ） |
+| `pre-commit` | Biome, Ruff, shellcheck, shfmt, taplo, markdownlint, yamlfmt, yamllint, dockerfmt, hadolint, actionlint, gitleaks（自動修正 + セキュリティ） |
 | `pre-push` | TypeScript typecheck, mypy |
 
 設定ファイル: [`lefthook.yaml`](../lefthook.yaml)

--- a/templates/base/trivy.yaml
+++ b/templates/base/trivy.yaml
@@ -1,7 +1,0 @@
-scan:
-  skip-dirs:
-    - node_modules
-    - .pnpm-store
-    - .venv
-    - infra/node_modules
-    - infra/cdk.out

--- a/tests/__snapshots__/generator.test.ts.snap
+++ b/tests/__snapshots__/generator.test.ts.snap
@@ -48,7 +48,6 @@ exports[`file list snapshots > base only 1`] = `
   "scripts/apply-rulesets.sh",
   "scripts/configure-repo.sh",
   "scripts/setup.sh",
-  "trivy.yaml",
 ]
 `;
 
@@ -111,7 +110,6 @@ exports[`file list snapshots > cdk 1`] = `
   "scripts/setup.sh",
   "src/index.ts",
   "tests/index.test.ts",
-  "trivy.yaml",
   "tsconfig.json",
 ]
 `;
@@ -170,7 +168,6 @@ exports[`file list snapshots > cloudformation (ts) 1`] = `
   "scripts/setup.sh",
   "src/index.ts",
   "tests/index.test.ts",
-  "trivy.yaml",
   "tsconfig.json",
 ]
 `;
@@ -242,7 +239,6 @@ exports[`file list snapshots > full config 1`] = `
   "tests/__init__.py",
   "tests/index.test.ts",
   "tests/test_placeholder.py",
-  "trivy.yaml",
   "tsconfig.json",
   "uv.lock",
   "vite.config.ts",
@@ -303,7 +299,6 @@ exports[`file list snapshots > python + cloudformation 1`] = `
   "scripts/setup.sh",
   "tests/__init__.py",
   "tests/test_placeholder.py",
-  "trivy.yaml",
   "uv.lock",
 ]
 `;
@@ -361,7 +356,6 @@ exports[`file list snapshots > python + terraform 1`] = `
   "scripts/setup.sh",
   "tests/__init__.py",
   "tests/test_placeholder.py",
-  "trivy.yaml",
   "uv.lock",
 ]
 `;
@@ -417,7 +411,6 @@ exports[`file list snapshots > python 1`] = `
   "scripts/setup.sh",
   "tests/__init__.py",
   "tests/test_placeholder.py",
-  "trivy.yaml",
   "uv.lock",
 ]
 `;
@@ -478,7 +471,6 @@ exports[`file list snapshots > react 1`] = `
   "src/main.tsx",
   "src/vite-env.d.ts",
   "tests/index.test.ts",
-  "trivy.yaml",
   "tsconfig.json",
   "vite.config.ts",
 ]
@@ -537,7 +529,6 @@ exports[`file list snapshots > terraform (ts) 1`] = `
   "scripts/setup.sh",
   "src/index.ts",
   "tests/index.test.ts",
-  "trivy.yaml",
   "tsconfig.json",
 ]
 `;
@@ -596,7 +587,6 @@ exports[`file list snapshots > typescript + python 1`] = `
   "tests/__init__.py",
   "tests/index.test.ts",
   "tests/test_placeholder.py",
-  "trivy.yaml",
   "tsconfig.json",
   "uv.lock",
 ]
@@ -653,7 +643,6 @@ exports[`file list snapshots > typescript 1`] = `
   "scripts/setup.sh",
   "src/index.ts",
   "tests/index.test.ts",
-  "trivy.yaml",
   "tsconfig.json",
 ]
 `;

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -66,7 +66,6 @@ describe("generate (base only)", () => {
     expect(result.hasFile("docs/adding-tools.md")).toBe(true);
     expect(result.hasFile("docs/branch-strategy.md")).toBe(true);
     expect(result.hasFile(".hadolint.yaml")).toBe(true);
-    expect(result.hasFile("trivy.yaml")).toBe(true);
     expect(result.hasFile("renovate.json")).toBe(true);
     expect(result.hasFile(".mcp.json.example")).toBe(true);
   });
@@ -214,7 +213,7 @@ describe("generate (typescript)", () => {
     const stepNames = steps.map((s) => s.name);
     expect(stepNames).toContain("Lint (Biome)");
     expect(stepNames).toContain("Test");
-    expect(stepNames).toContain("Typecheck");
+    expect(stepNames).toContain("Typecheck (TypeScript)");
     expect(stepNames).toContain("Build");
     // base steps still present
     expect(stepNames).toContain("Lint (Markdown)");
@@ -408,7 +407,7 @@ describe("generate (react)", () => {
     const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
     const stepNames = steps.map((s) => s.name);
     expect(stepNames).toContain("Lint (Biome)");
-    expect(stepNames).toContain("Typecheck");
+    expect(stepNames).toContain("Typecheck (TypeScript)");
     expect(stepNames).toContain("Build");
     // No duplicate "Build (Vite)" — React overrides the build script instead
     expect(stepNames).not.toContain("Build (Vite)");


### PR DESCRIPTION
## Summary

手動動作確認で発見された生成プロジェクトの問題を一括修正。

### 修正内容

- **devcontainer.json**: ハードコード名を `{{projectName}}` テンプレート変数に置換
- **README.md / CLAUDE.md テストセクション重複**: テストヘッダーをテンプレートに移動し、プリセットは行のみ注入するように変更
- **CI ステップ名**: `Typecheck` → `Typecheck (TypeScript)` に明確化
- **ドキュメント**: Lefthook ツール一覧から未実装の `sqlfluff`, `mdformat` を削除
- **.mcp.json.example**: パッケージ名を `.mcp.json` と統一 (`awslabs.aws-iac-mcp`)
- **.gitignore**: 冗長な `infra/cdk.out/` を削除（`cdk.out/` で十分）
- **trivy.yaml**: CI で未使用のため削除
- **docs/adding-tools.md**: 壊れたマークダウン表を修正
- **.yamllint.yaml**: line-length を 120 → 100 に変更（プロジェクト規約と統一）
- **vitest バージョン**: `^3.0.0` → `^4.0.0` に更新

Closes #16

## Test plan

- [x] `pnpm run typecheck` パス
- [x] `gitleaks detect` パス
- [x] `pnpm test` 全 112 テストパス（スナップショット 11 件更新）
- [ ] `pnpm run build && pnpm link --global` で再生成して動作確認