### PR TITLE
fix: deduplicate markdown section injections across presets

### DIFF
--- a/src/merge.ts
+++ b/src/merge.ts
@@ -56,7 +56,20 @@ export function expandMarkdown(template: string, sections: MarkdownSection[]): s
     grouped.set(placeholder, list);
   }
   for (const [placeholder, contents] of grouped) {
-    result = result.replaceAll(placeholder, contents.join("\n"));
+    // Deduplicate identical lines across preset contributions
+    const allLines = contents.flatMap((c) => c.split("\n"));
+    const unique = [...new Map(allLines.map((l) => [l, l])).values()];
+
+    // Detect inline placeholder (preceded by non-whitespace on same line) → join with ", "
+    const idx = result.indexOf(placeholder);
+    let separator = "\n";
+    if (idx > 0) {
+      const lineStart = result.lastIndexOf("\n", idx - 1) + 1;
+      const prefix = result.slice(lineStart, idx);
+      if (prefix.trim().length > 0) separator = ", ";
+    }
+
+    result = result.replaceAll(placeholder, unique.join(separator));
   }
   return result;
 }

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -58,7 +58,7 @@ export function expandMarkdown(template: string, sections: MarkdownSection[]): s
   for (const [placeholder, contents] of grouped) {
     // Deduplicate identical lines across preset contributions
     const allLines = contents.flatMap((c) => c.split("\n"));
-    const unique = [...new Map(allLines.map((l) => [l, l])).values()];
+    const unique = [...new Set(allLines)];
 
     // Detect inline placeholder (preceded by non-whitespace on same line) → join with ", "
     const idx = result.indexOf(placeholder);

--- a/src/presets/cdk.ts
+++ b/src/presets/cdk.ts
@@ -43,7 +43,7 @@ export const cdkPreset: Preset = {
       },
       {
         placeholder: "<!-- SECTION:TECH_STACK_MCP -->",
-        content: "- **MCP servers**: AWS IaC — configured in `.mcp.json`",
+        content: "AWS IaC",
       },
       {
         placeholder: "<!-- SECTION:PROJECT_STRUCTURE -->",
@@ -78,7 +78,7 @@ export const cdkPreset: Preset = {
       },
       {
         placeholder: "<!-- SECTION:SETUP_STEPS -->",
-        content: "4. `cd infra && pnpm install`（CDK 依存パッケージ）",
+        content: "1. `cd infra && pnpm install`（CDK 依存パッケージ）",
       },
       {
         placeholder: "<!-- SECTION:SETUP_COMMANDS -->",

--- a/src/presets/python.ts
+++ b/src/presets/python.ts
@@ -53,7 +53,7 @@ export const pythonPreset: Preset = {
       },
       {
         placeholder: "<!-- SECTION:PROJECT_STRUCTURE -->",
-        content: "tests/        -> Python tests (pytest)",
+        content: "tests/        -> Tests",
       },
       {
         placeholder: "<!-- SECTION:SETUP_COMMANDS -->",
@@ -85,7 +85,7 @@ export const pythonPreset: Preset = {
     "README.md": [
       {
         placeholder: "<!-- SECTION:DIR_STRUCTURE -->",
-        content: "├── tests/               # Python テスト（pytest）",
+        content: "├── tests/               # テスト",
       },
       {
         placeholder: "<!-- SECTION:ROOT_FILES -->",
@@ -94,7 +94,7 @@ export const pythonPreset: Preset = {
       },
       {
         placeholder: "<!-- SECTION:SETUP_STEPS -->",
-        content: "3. `uv sync`（Python 依存パッケージ）",
+        content: "1. `uv sync`（Python 依存パッケージ）",
       },
       {
         placeholder: "<!-- SECTION:SETUP_COMMANDS -->",

--- a/src/presets/react.ts
+++ b/src/presets/react.ts
@@ -32,13 +32,13 @@ export const reactPreset: Preset = {
       },
       {
         placeholder: "<!-- SECTION:PROJECT_STRUCTURE -->",
-        content: "src/          -> React application source",
+        content: "src/          -> Source code",
       },
     ],
     "README.md": [
       {
         placeholder: "<!-- SECTION:DIR_STRUCTURE -->",
-        content: "├── src/                 # React アプリケーション",
+        content: "├── src/                 # ソースコード",
       },
       {
         placeholder: "<!-- SECTION:ROOT_FILES -->",

--- a/src/presets/typescript.ts
+++ b/src/presets/typescript.ts
@@ -56,7 +56,7 @@ export const typescriptPreset: Preset = {
       },
       {
         placeholder: "<!-- SECTION:PROJECT_STRUCTURE -->",
-        content: "src/          -> TypeScript source code\ntests/        -> Test files (vitest)",
+        content: "src/          -> Source code\ntests/        -> Tests",
       },
       {
         placeholder: "<!-- SECTION:SETUP_COMMANDS -->",
@@ -89,8 +89,7 @@ export const typescriptPreset: Preset = {
     "README.md": [
       {
         placeholder: "<!-- SECTION:DIR_STRUCTURE -->",
-        content:
-          "├── src/                 # TypeScript ソースコード\n├── tests/               # テスト（vitest）",
+        content: "├── src/                 # ソースコード\n├── tests/               # テスト",
       },
       {
         placeholder: "<!-- SECTION:ROOT_FILES -->",
@@ -99,7 +98,7 @@ export const typescriptPreset: Preset = {
       },
       {
         placeholder: "<!-- SECTION:SETUP_STEPS -->",
-        content: "3. `pnpm install`（Node.js 依存パッケージ）",
+        content: "1. `pnpm install`（Node.js 依存パッケージ）",
       },
       {
         placeholder: "<!-- SECTION:SETUP_COMMANDS -->",

--- a/templates/base/CLAUDE.md
+++ b/templates/base/CLAUDE.md
@@ -25,8 +25,7 @@
 <!-- SECTION:TECH_STACK_LINTING -->
 - **Security scanning**: Gitleaks (secrets)
 <!-- SECTION:TECH_STACK_SECURITY -->
-- **MCP servers**: Context7 (docs), Fetch (web) — configured in `.mcp.json`
-<!-- SECTION:TECH_STACK_MCP -->
+- **MCP servers**: Context7 (docs), Fetch (web)<!-- SECTION:TECH_STACK_MCP --> — configured in `.mcp.json`
 - **Git hooks**: lefthook (commit-msg: commitlint, pre-commit: linters + gitleaks, pre-push: <!-- SECTION:PRE_PUSH_HOOKS -->)
 
 ## Project Structure

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -120,6 +120,24 @@ describe("expandMarkdown", () => {
     expect(result).toBe("- TypeScript\n- Python");
   });
 
+  it("deduplicates identical lines from multiple presets", () => {
+    const template = "<!-- SECTION:DIRS -->";
+    const result = expandMarkdown(template, [
+      { placeholder: "<!-- SECTION:DIRS -->", content: "src/\ntests/" },
+      { placeholder: "<!-- SECTION:DIRS -->", content: "tests/" },
+    ]);
+    expect(result).toBe("src/\ntests/");
+  });
+
+  it("joins with comma-space for inline placeholders", () => {
+    const template = "pre-push: <!-- SECTION:HOOKS -->)";
+    const result = expandMarkdown(template, [
+      { placeholder: "<!-- SECTION:HOOKS -->", content: "typecheck" },
+      { placeholder: "<!-- SECTION:HOOKS -->", content: "mypy" },
+    ]);
+    expect(result).toBe("pre-push: typecheck, mypy)");
+  });
+
   it("leaves unmatched placeholders unchanged", () => {
     const template = "<!-- SECTION:UNKNOWN -->";
     const result = expandMarkdown(template, [


### PR DESCRIPTION
## Summary

複数プリセット選択時のマークダウンセクション注入における重複問題を修正。

### 修正内容

- **`expandMarkdown` 改善**: 同一プレースホルダーへの注入時に重複行を除去。インラインプレースホルダー（行中）は `, ` で結合
- **ディレクトリ構成の重複解消**: `src/` と `tests/` の説明を汎用テキストに統一し、重複除去で1行に
- **CLAUDE.md pre-push フック表記**: インライン検出により `typecheck (tsc), mypy` と正しく結合
- **CLAUDE.md MCP servers 重複**: プレースホルダーをインライン化し `, AWS IaC` を追記する形に変更
- **README.md ステップ番号**: Markdown 自動番号付けに対応

Closes #18

## Test plan

- [x] `pnpm run typecheck` パス
- [x] `gitleaks detect` パス
- [x] `pnpm test` 全 114 テストパス（新規 2 テスト含む）
- [ ] `pnpm run build && pnpm link --global` で再生成して動作確認