### PR TITLE
fix: filter empty strings and fix inline separator in expandMarkdown

### DIFF
--- a/src/merge.ts
+++ b/src/merge.ts
@@ -56,9 +56,9 @@ export function expandMarkdown(template: string, sections: MarkdownSection[]): s
     grouped.set(placeholder, list);
   }
   for (const [placeholder, contents] of grouped) {
-    // Deduplicate identical lines across preset contributions
+    // Deduplicate identical lines and filter empty strings
     const allLines = contents.flatMap((c) => c.split("\n"));
-    const unique = [...new Set(allLines)];
+    const unique = [...new Set(allLines)].filter((l) => l !== "");
 
     // Detect inline placeholder (preceded by non-whitespace on same line) → join with ", "
     const idx = result.indexOf(placeholder);

--- a/src/presets/base.ts
+++ b/src/presets/base.ts
@@ -96,16 +96,7 @@ export const basePreset: Preset = {
     },
   },
   markdown: {
-    "CLAUDE.md": [
-      {
-        placeholder: "<!-- SECTION:PRE_PUSH_HOOKS -->",
-        content: "",
-      },
-      {
-        placeholder: "<!-- SECTION:GIT_WORKFLOW -->",
-        content: "",
-      },
-    ],
+    "CLAUDE.md": [],
     "README.md": [],
   },
   ciSteps: {

--- a/src/presets/cdk.ts
+++ b/src/presets/cdk.ts
@@ -43,7 +43,7 @@ export const cdkPreset: Preset = {
       },
       {
         placeholder: "<!-- SECTION:TECH_STACK_MCP -->",
-        content: "AWS IaC",
+        content: ", AWS IaC",
       },
       {
         placeholder: "<!-- SECTION:PROJECT_STRUCTURE -->",

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -138,6 +138,15 @@ describe("expandMarkdown", () => {
     expect(result).toBe("pre-push: typecheck, mypy)");
   });
 
+  it("filters out empty strings from contributions", () => {
+    const template = "pre-push: <!-- SECTION:HOOKS -->)";
+    const result = expandMarkdown(template, [
+      { placeholder: "<!-- SECTION:HOOKS -->", content: "" },
+      { placeholder: "<!-- SECTION:HOOKS -->", content: "typecheck" },
+    ]);
+    expect(result).toBe("pre-push: typecheck)");
+  });
+
   it("leaves unmatched placeholders unchanged", () => {
     const template = "<!-- SECTION:UNKNOWN -->";
     const result = expandMarkdown(template, [


### PR DESCRIPTION
## Summary

- `expandMarkdown` で空文字列をフィルタリングし、`pre-push: , typecheck` のような先頭カンマ問題を解消
- base プリセットの不要な空文字列注入（`PRE_PUSH_HOOKS`, `GIT_WORKFLOW`）を削除
- CDK プリセットの MCP servers 注入に `, ` セパレータを含め、`Fetch (web), AWS IaC` と正しく結合

Closes #20

## Test plan

- [x] `pnpm test` 全 115 テストパス（新規 1 テスト含む）
- [x] `pnpm run typecheck` パス
- [x] `gitleaks detect` パス
- [ ] `pnpm run build && pnpm link --global` で再生成して動作確認