### PR TITLE
feat: support output path in CLI argument

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -14,10 +14,11 @@ async function main(): Promise<void> {
   const answers = await runWizard(defaultName);
 
   const outDir = path.resolve(parentDir, answers.projectName);
+  const relPath = path.relative(process.cwd(), outDir) || ".";
 
   if (fs.existsSync(outDir) && fs.readdirSync(outDir).length > 0) {
     const overwrite = await p.confirm({
-      message: `Directory "${answers.projectName}" already exists and is not empty. Overwrite?`,
+      message: `Directory "${relPath}" already exists and is not empty. Overwrite?`,
     });
     if (p.isCancel(overwrite) || !overwrite) {
       p.cancel("Operation cancelled.");
@@ -33,7 +34,6 @@ async function main(): Promise<void> {
 
   s.stop(`Generated ${result.fileList().length} files`);
 
-  const relPath = path.relative(process.cwd(), outDir) || ".";
   p.note([`cd ${relPath}`, "bash scripts/setup.sh"].join("\n"), "Next steps");
 
   p.outro(pc.green("Done! Happy coding."));

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,10 +8,12 @@ import { generate } from "./generator.js";
 import { createDiskWriter } from "./utils.js";
 
 async function main(): Promise<void> {
-  const defaultName = process.argv[2];
+  const arg = process.argv[2];
+  const defaultName = arg ? path.basename(arg) : undefined;
+  const parentDir = arg ? path.resolve(process.cwd(), path.dirname(arg)) : process.cwd();
   const answers = await runWizard(defaultName);
 
-  const outDir = path.resolve(process.cwd(), answers.projectName);
+  const outDir = path.resolve(parentDir, answers.projectName);
 
   if (fs.existsSync(outDir) && fs.readdirSync(outDir).length > 0) {
     const overwrite = await p.confirm({
@@ -31,7 +33,8 @@ async function main(): Promise<void> {
 
   s.stop(`Generated ${result.fileList().length} files`);
 
-  p.note([`cd ${answers.projectName}`, "bash scripts/setup.sh"].join("\n"), "Next steps");
+  const relPath = path.relative(process.cwd(), outDir) || ".";
+  p.note([`cd ${relPath}`, "bash scripts/setup.sh"].join("\n"), "Next steps");
 
   p.outro(pc.green("Done! Happy coding."));
 }


### PR DESCRIPTION
## Summary

- CLI 引数をパスとして解釈するよう変更。ディレクトリ部分を出力先、ベース名をプロジェクト名のデフォルトにする
- `create-agentic-dev tmp/my-app` → `tmp/my-app/` に生成（従来は `./my-app/` に生成されていた）
- Next steps の `cd` パスも実際の出力先を反映するよう修正

## Test plan

- [x] 全 120 テスト通過
- [x] Biome lint / TypeScript typecheck 通過
- [ ] 手動確認: `create-agentic-dev tmp/test` で `tmp/test/` に生成されること
- [ ] 手動確認: `create-agentic-dev my-app` で `./my-app/` に生成されること（従来動作）
- [ ] 手動確認: 引数なしで従来通り動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)