### PR TITLE
fix: resolve generated project issues found in manual verification (round 2)

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -130,11 +130,22 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
     allFiles.set(filePath, replaceVariables(merged, vars));
   }
 
-  // 2.5. Build lint:all script dynamically from merged package.json
+  // 2.5. Post-merge cleanup & lint:all generation for package.json
   const pkgContent = allFiles.get("package.json");
   if (pkgContent) {
     const pkg = JSON.parse(pkgContent) as Record<string, Record<string, string>>;
     const scripts = pkg.scripts ?? {};
+
+    // Remove devDependencies not referenced by any script (e.g. tsdown when React overrides build)
+    const devDeps = (pkg.devDependencies ?? {}) as Record<string, string>;
+    const scriptValues = Object.values(scripts).join(" ");
+    for (const dep of ["tsdown"]) {
+      if (dep in devDeps && !scriptValues.includes(dep)) {
+        delete devDeps[dep];
+      }
+    }
+
+    // Build lint:all dynamically
     const lintParts: string[] = [];
     // Biome lint (if present)
     if (scripts.lint) lintParts.push("pnpm run lint");

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -137,9 +137,10 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
     const scripts = pkg.scripts ?? {};
 
     // Remove devDependencies not referenced by any script (e.g. tsdown when React overrides build)
+    const conditionalDeps = presets.flatMap((p) => p.conditionalDevDeps ?? []);
     const devDeps = (pkg.devDependencies ?? {}) as Record<string, string>;
     const scriptValues = Object.values(scripts).join(" ");
-    for (const dep of ["tsdown"]) {
+    for (const dep of conditionalDeps) {
       if (dep in devDeps && !scriptValues.includes(dep)) {
         delete devDeps[dep];
       }

--- a/src/presets/react.ts
+++ b/src/presets/react.ts
@@ -8,6 +8,8 @@ export const reactPreset: Preset = {
   merge: {
     "tsconfig.json": {
       compilerOptions: {
+        module: "ESNext",
+        moduleResolution: "bundler",
         jsx: "react-jsx",
       },
     },

--- a/src/presets/typescript.ts
+++ b/src/presets/typescript.ts
@@ -152,4 +152,5 @@ export const typescriptPreset: Preset = {
     testSteps: [{ name: "Test", run: "pnpm test" }],
     buildSteps: [{ name: "Build", run: "pnpm run build" }],
   },
+  conditionalDevDeps: ["tsdown"],
 };

--- a/src/presets/typescript.ts
+++ b/src/presets/typescript.ts
@@ -75,7 +75,7 @@ export const typescriptPreset: Preset = {
       {
         placeholder: "<!-- SECTION:CODING_CONVENTIONS -->",
         content:
-          '- TypeScript: ESM (`"type": "module"`), strict mode, NodeNext module resolution\n- Use `import type` for type-only imports (verbatimModuleSyntax enabled)\n- Max line width: 100 (Biome)',
+          '- TypeScript: ESM (`"type": "module"`), strict mode\n- Use `import type` for type-only imports (verbatimModuleSyntax enabled)\n- Max line width: 100 (Biome)',
       },
       {
         placeholder: "<!-- SECTION:PRE_PUSH_HOOKS -->",

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,8 @@ export interface Preset {
   ciSteps?: CiContribution;
   /** Extra commands for setup.sh */
   setupExtra?: string;
+  /** devDependencies that should be removed if not referenced by any script */
+  conditionalDevDeps?: string[];
 }
 
 // --- File I/O abstraction ---

--- a/templates/base/README.md
+++ b/templates/base/README.md
@@ -18,7 +18,7 @@ bash scripts/setup.sh
 `scripts/setup.sh` は以下を実行します:
 
 1. mise 未インストール時の自動インストール
-2. `mise trust` + `mise install`（全開発ツール）
+1. `mise trust` + `mise install`（全開発ツール）
 <!-- SECTION:SETUP_STEPS -->
 
 ## ディレクトリ構成

--- a/templates/cdk/infra/bin/app.ts
+++ b/templates/cdk/infra/bin/app.ts
@@ -1,5 +1,4 @@
 #!/usr/bin/env node
-import "source-map-support/register";
 import * as cdk from "aws-cdk-lib";
 import { AppStack } from "../lib/app-stack.js";
 

--- a/templates/cdk/infra/package.json
+++ b/templates/cdk/infra/package.json
@@ -14,13 +14,12 @@
   "dependencies": {
     "aws-cdk-lib": "^2.170.0",
     "cdk-nag": "^2.0.0",
-    "constructs": "^10.0.0",
-    "source-map-support": "^0.5.0"
+    "constructs": "^10.0.0"
   },
   "devDependencies": {
     "aws-cdk": "^2.170.0",
     "typescript": "^5.0.0",
-    "vitest": "^3.0.0",
+    "vitest": "^4.0.0",
     "tsx": "^4.0.0"
   }
 }

--- a/templates/python/pyproject.toml
+++ b/templates/python/pyproject.toml
@@ -3,6 +3,9 @@ name = "{{projectName}}"
 version = "0.0.0"
 requires-python = ">=3.12"
 
+[dependency-groups]
+dev = ["pytest"]
+
 [tool.ruff]
 line-length = 100
 

--- a/templates/react/src/App.tsx
+++ b/templates/react/src/App.tsx
@@ -1,3 +1,5 @@
+import "./App.css";
+
 export function App() {
   return (
     <main>

--- a/templates/typescript/tsconfig.json
+++ b/templates/typescript/tsconfig.json
@@ -7,15 +7,10 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
-    "outDir": "dist",
-    "rootDir": "src",
     "verbatimModuleSyntax": true,
     "isolatedModules": true,
     "resolveJsonModule": true
   },
-  "include": ["src"],
+  "include": ["src", "tests"],
   "exclude": ["node_modules", "dist"]
 }

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -187,6 +187,23 @@ describe("generate (typescript)", () => {
     expect(devDeps.tsdown).toBeDefined();
   });
 
+  it("tsconfig includes both src and tests", () => {
+    const tsconfig = result.readJson("tsconfig.json") as Record<string, unknown>;
+    const include = tsconfig.include as string[];
+    expect(include).toContain("src");
+    expect(include).toContain("tests");
+  });
+
+  it("tsconfig does not have build output options", () => {
+    const tsconfig = result.readJson("tsconfig.json") as Record<string, unknown>;
+    const compilerOptions = tsconfig.compilerOptions as Record<string, unknown>;
+    expect(compilerOptions.declaration).toBeUndefined();
+    expect(compilerOptions.declarationMap).toBeUndefined();
+    expect(compilerOptions.sourceMap).toBeUndefined();
+    expect(compilerOptions.outDir).toBeUndefined();
+    expect(compilerOptions.rootDir).toBeUndefined();
+  });
+
   it("merges TypeScript scripts into package.json", () => {
     const pkg = result.readJson("package.json") as Record<string, unknown>;
     const scripts = pkg.scripts as Record<string, string>;
@@ -323,6 +340,12 @@ describe("generate (python)", () => {
     expect(setup).toContain("uv sync");
   });
 
+  it("pyproject.toml includes pytest in dependency-groups", () => {
+    const pyproject = result.readText("pyproject.toml");
+    expect(pyproject).toContain("[dependency-groups]");
+    expect(pyproject).toContain("pytest");
+  });
+
   it("expands CLAUDE.md with Python sections", () => {
     const claude = result.readText("CLAUDE.md");
     expect(claude).toContain("Python");
@@ -445,6 +468,25 @@ describe("generate (react)", () => {
     expect(scripts.preview).toBe("vite preview");
   });
 
+  it("removes tsdown from devDependencies when not used in scripts", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const devDeps = pkg.devDependencies as Record<string, string>;
+    expect(devDeps.tsdown).toBeUndefined();
+  });
+
+  it("overrides tsconfig module resolution to bundler for Vite", () => {
+    const tsconfig = result.readJson("tsconfig.json") as Record<string, unknown>;
+    const compilerOptions = tsconfig.compilerOptions as Record<string, unknown>;
+    expect(compilerOptions.module).toBe("ESNext");
+    expect(compilerOptions.moduleResolution).toBe("bundler");
+    expect(compilerOptions.jsx).toBe("react-jsx");
+  });
+
+  it("App.tsx imports App.css", () => {
+    const appTsx = result.readText("src/App.tsx");
+    expect(appTsx).toContain("./App.css");
+  });
+
   it("has TypeScript CI steps (React uses TS build step via script override)", () => {
     const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
     const jobs = ci.jobs as Record<string, Record<string, unknown>>;
@@ -550,6 +592,23 @@ describe("generate (cdk)", () => {
     const infraPkg = result.readText("infra/package.json");
     expect(infraPkg).toContain("test-app-infra");
     expect(infraPkg).not.toContain("{{projectName}}");
+  });
+
+  it("infra/package.json does not include source-map-support", () => {
+    const infraPkg = result.readJson("infra/package.json") as Record<string, unknown>;
+    const deps = infraPkg.dependencies as Record<string, string>;
+    expect(deps["source-map-support"]).toBeUndefined();
+  });
+
+  it("infra/package.json vitest matches root version", () => {
+    const infraPkg = result.readJson("infra/package.json") as Record<string, unknown>;
+    const devDeps = infraPkg.devDependencies as Record<string, string>;
+    expect(devDeps.vitest).toBe("^4.0.0");
+  });
+
+  it("infra/bin/app.ts does not import source-map-support", () => {
+    const appTs = result.readText("infra/bin/app.ts");
+    expect(appTs).not.toContain("source-map-support");
   });
 
   it("expands CLAUDE.md with CDK sections", () => {


### PR DESCRIPTION
## Summary

`create-agentic-dev` で生成されたプロジェクトの手動検証で見つかった不整合・改善点を修正。

- tsconfig.json からビルド出力オプション（declaration, sourceMap, outDir, rootDir）を削除
- tsconfig の include に tests を追加（型チェック対象漏れ修正）
- React プリセットで module/moduleResolution を ESNext/bundler に上書き
- React 使用時に未使用の tsdown を devDependencies から自動除去
- React App.tsx テンプレートに CSS インポート追加
- README 番号リストの崩れ修正
- CDK テンプレートから source-map-support を削除（Node.js 24 ネイティブサポート）
- infra の vitest バージョンを ^4.0.0 に統一
- Python の dependency-groups に pytest を追加
- CLAUDE.md コーディング規約から NodeNext 固定記述を削除

## Test plan

- [x] 既存テスト 129 件全通過
- [x] 新規テスト 9 件追加（tsconfig overrides, tsdown removal, CSS import, source-map-support, pytest, vitest version）
- [x] lint 全通過
- [x] typecheck 通過

Closes #36