### PR TITLE
feat: add i18n support with English and Japanese locales

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:watch": "vitest"
   },
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "packageManager": "pnpm@10.32.1",
   "license": "MIT",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,56 +1,65 @@
 import * as p from "@clack/prompts";
 import pc from "picocolors";
+import { t } from "./i18n/index.js";
 import type { WizardAnswers } from "./types.js";
 
 function handleCancel(value: unknown): void {
   if (p.isCancel(value)) {
-    p.cancel("Operation cancelled.");
+    p.cancel(t("cancel"));
     process.exit(0);
   }
 }
 
 export async function runWizard(defaultName?: string): Promise<WizardAnswers> {
-  p.intro(pc.bold("create-agentic-dev"));
+  p.intro(pc.bold(t("intro")));
 
   const projectName = await p.text({
-    message: "Project name",
-    placeholder: "my-app",
+    message: t("wizard.projectName.message"),
+    placeholder: t("wizard.projectName.placeholder"),
     initialValue: defaultName ?? "",
     validate(value) {
-      if (!value.trim()) return "Project name is required.";
+      if (!value.trim()) return t("wizard.projectName.required");
       if (!/^[a-z0-9][a-z0-9._-]*$/i.test(value.trim())) {
-        return "Invalid project name. Use alphanumeric characters, hyphens, dots, or underscores.";
+        return t("wizard.projectName.invalid");
       }
     },
   });
   handleCancel(projectName);
 
   const languages = await p.multiselect({
-    message: "Languages",
+    message: `${t("wizard.languages.message")} ${pc.dim(t("wizard.languages.hint"))}`,
     options: [
-      { value: "typescript" as const, label: "TypeScript" },
-      { value: "python" as const, label: "Python" },
+      { value: "typescript" as const, label: t("wizard.languages.typescript.label") },
+      { value: "python" as const, label: t("wizard.languages.python.label") },
     ],
     required: false,
   });
   handleCancel(languages);
 
   const frontend = await p.select({
-    message: "Frontend framework",
+    message: `${t("wizard.frontend.message")} ${pc.dim(t("wizard.frontend.hint"))}`,
     options: [
-      { value: "none" as const, label: "None" },
-      { value: "react" as const, label: "React (Vite)", hint: "forces TypeScript" },
+      { value: "none" as const, label: t("wizard.frontend.none.label") },
+      {
+        value: "react" as const,
+        label: t("wizard.frontend.react.label"),
+        hint: t("wizard.frontend.react.hint"),
+      },
     ],
   });
   handleCancel(frontend);
 
   const iac = await p.select({
-    message: "Infrastructure as Code",
+    message: `${t("wizard.iac.message")} ${pc.dim(t("wizard.iac.hint"))}`,
     options: [
-      { value: "none" as const, label: "None" },
-      { value: "cdk" as const, label: "AWS CDK", hint: "forces TypeScript" },
-      { value: "cloudformation" as const, label: "CloudFormation" },
-      { value: "terraform" as const, label: "Terraform" },
+      { value: "none" as const, label: t("wizard.iac.none.label") },
+      {
+        value: "cdk" as const,
+        label: t("wizard.iac.cdk.label"),
+        hint: t("wizard.iac.cdk.hint"),
+      },
+      { value: "cloudformation" as const, label: t("wizard.iac.cloudformation.label") },
+      { value: "terraform" as const, label: t("wizard.iac.terraform.label") },
     ],
   });
   handleCancel(iac);

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,0 +1,43 @@
+{
+  "intro": "create-agentic-dev",
+  "cancel": "Operation cancelled.",
+  "wizard": {
+    "projectName": {
+      "message": "Project name",
+      "placeholder": "my-app",
+      "required": "Project name is required.",
+      "invalid": "Invalid project name. Use alphanumeric characters, hyphens, dots, or underscores."
+    },
+    "languages": {
+      "message": "Languages",
+      "hint": "Select languages for your project",
+      "typescript": { "label": "TypeScript" },
+      "python": { "label": "Python" }
+    },
+    "frontend": {
+      "message": "Frontend framework",
+      "hint": "Choose a frontend framework or skip",
+      "none": { "label": "None" },
+      "react": { "label": "React (Vite)", "hint": "forces TypeScript" }
+    },
+    "iac": {
+      "message": "Infrastructure as Code",
+      "hint": "Choose a cloud IaC tool or skip",
+      "none": { "label": "None" },
+      "cdk": { "label": "AWS CDK", "hint": "forces TypeScript" },
+      "cloudformation": { "label": "CloudFormation" },
+      "terraform": { "label": "Terraform" }
+    }
+  },
+  "overwrite": {
+    "message": "Directory \"{{path}}\" already exists and is not empty. Overwrite?"
+  },
+  "spinner": {
+    "start": "Generating project...",
+    "stop": "Generated {{count}} files"
+  },
+  "nextSteps": {
+    "title": "Next steps"
+  },
+  "outro": "Done! Happy coding."
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -40,6 +40,11 @@ export function getLocale(): Locale {
   return currentLocale;
 }
 
+/** Reset locale to default (en). Useful for testing. */
+export function resetLocale(): void {
+  currentLocale = "en";
+}
+
 /**
  * Detect locale from a CLI flag or environment variables.
  * Priority: langFlag > LC_ALL > LANG > "en"

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,70 @@
+import en from "./en.json" with { type: "json" };
+import ja from "./ja.json" with { type: "json" };
+
+// --- Types ---
+
+type Messages = typeof en;
+
+/** Supported locale codes. */
+export type Locale = "en" | "ja";
+
+/**
+ * Recursively extract dot-separated paths that resolve to a string leaf.
+ * e.g. "wizard.projectName.message" | "cancel" | ...
+ */
+type PathKeys<T, Prefix extends string = ""> = T extends string
+  ? Prefix
+  : T extends Record<string, unknown>
+    ? {
+        [K in keyof T & string]: PathKeys<T[K], Prefix extends "" ? K : `${Prefix}.${K}`>;
+      }[keyof T & string]
+    : never;
+
+/** All valid translation keys derived from the English locale file. */
+export type MessageKey = PathKeys<Messages>;
+
+// --- Locale map & state ---
+
+const locales: Record<Locale, Messages> = { en, ja };
+let currentLocale: Locale = "en";
+
+// --- Public API ---
+
+/** Set the active locale. */
+export function setLocale(locale: Locale): void {
+  currentLocale = locale;
+}
+
+/** Get the active locale. */
+export function getLocale(): Locale {
+  return currentLocale;
+}
+
+/**
+ * Detect locale from a CLI flag or environment variables.
+ * Priority: langFlag > LC_ALL > LANG > "en"
+ */
+export function detectLocale(langFlag?: string): Locale {
+  if (langFlag && langFlag in locales) return langFlag as Locale;
+  const envLang = process.env.LC_ALL || process.env.LANG || "";
+  if (envLang.startsWith("ja")) return "ja";
+  return "en";
+}
+
+/**
+ * Look up a translated string by dot-separated key.
+ * Supports `{{var}}` interpolation via the `vars` parameter.
+ */
+export function t(key: MessageKey, vars?: Record<string, string | number>): string {
+  const parts = key.split(".");
+  let value: unknown = locales[currentLocale];
+  for (const part of parts) {
+    if (value == null || typeof value !== "object") return key;
+    value = (value as Record<string, unknown>)[part];
+  }
+  if (typeof value !== "string") return key;
+  if (!vars) return value;
+  return value.replace(/\{\{(\w+)\}\}/g, (_, k: string) =>
+    vars[k] != null ? String(vars[k]) : `{{${k}}}`,
+  );
+}

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -1,0 +1,43 @@
+{
+  "intro": "create-agentic-dev",
+  "cancel": "操作がキャンセルされました。",
+  "wizard": {
+    "projectName": {
+      "message": "プロジェクト名",
+      "placeholder": "my-app",
+      "required": "プロジェクト名は必須です。",
+      "invalid": "プロジェクト名が無効です。英数字、ハイフン、ドット、アンダースコアのみ使用できます。"
+    },
+    "languages": {
+      "message": "言語",
+      "hint": "プロジェクトで使用する言語を選択",
+      "typescript": { "label": "TypeScript" },
+      "python": { "label": "Python" }
+    },
+    "frontend": {
+      "message": "フロントエンドフレームワーク",
+      "hint": "フレームワークを選択（不要なら None）",
+      "none": { "label": "なし" },
+      "react": { "label": "React (Vite)", "hint": "TypeScript が強制されます" }
+    },
+    "iac": {
+      "message": "Infrastructure as Code",
+      "hint": "クラウド IaC ツールを選択（不要なら None）",
+      "none": { "label": "なし" },
+      "cdk": { "label": "AWS CDK", "hint": "TypeScript が強制されます" },
+      "cloudformation": { "label": "CloudFormation" },
+      "terraform": { "label": "Terraform" }
+    }
+  },
+  "overwrite": {
+    "message": "ディレクトリ \"{{path}}\" は既に存在し、空ではありません。上書きしますか？"
+  },
+  "spinner": {
+    "start": "プロジェクトを生成中...",
+    "stop": "{{count}} ファイルを生成しました"
+  },
+  "nextSteps": {
+    "title": "次のステップ"
+  },
+  "outro": "完了！Happy coding."
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,32 @@
 #!/usr/bin/env node
 import fs from "node:fs";
 import path from "node:path";
+import { parseArgs } from "node:util";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { runWizard } from "./cli.js";
 import { generate } from "./generator.js";
+import { detectLocale, setLocale, t } from "./i18n/index.js";
 import { createDiskWriter } from "./utils.js";
 
 async function main(): Promise<void> {
-  const arg = process.argv[2];
-  const defaultName = arg ? path.basename(arg) : undefined;
-  const parentDir = arg ? path.resolve(process.cwd(), path.dirname(arg)) : process.cwd();
+  const { values, positionals } = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      lang: { type: "string" },
+    },
+    allowPositionals: true,
+    strict: false,
+  });
+
+  const langFlag = typeof values.lang === "string" ? values.lang : undefined;
+  setLocale(detectLocale(langFlag));
+
+  const positionalArg = positionals[0];
+  const defaultName = positionalArg ? path.basename(positionalArg) : undefined;
+  const parentDir = positionalArg
+    ? path.resolve(process.cwd(), path.dirname(positionalArg))
+    : process.cwd();
   const answers = await runWizard(defaultName);
 
   const outDir = path.resolve(parentDir, answers.projectName);
@@ -18,25 +34,25 @@ async function main(): Promise<void> {
 
   if (fs.existsSync(outDir) && fs.readdirSync(outDir).length > 0) {
     const overwrite = await p.confirm({
-      message: `Directory "${relPath}" already exists and is not empty. Overwrite?`,
+      message: t("overwrite.message", { path: relPath }),
     });
     if (p.isCancel(overwrite) || !overwrite) {
-      p.cancel("Operation cancelled.");
+      p.cancel(t("cancel"));
       process.exit(0);
     }
   }
 
   const s = p.spinner();
-  s.start("Generating project...");
+  s.start(t("spinner.start"));
 
   const writer = createDiskWriter(outDir);
   const result = generate(answers, { writer });
 
-  s.stop(`Generated ${result.fileList().length} files`);
+  s.stop(t("spinner.stop", { count: result.fileList().length }));
 
-  p.note([`cd ${relPath}`, "bash scripts/setup.sh"].join("\n"), "Next steps");
+  p.note([`cd ${relPath}`, "bash scripts/setup.sh"].join("\n"), t("nextSteps.title"));
 
-  p.outro(pc.green("Done! Happy coding."));
+  p.outro(pc.green(t("outro")));
 }
 
 main().catch((err) => {

--- a/tests/i18n.test.ts
+++ b/tests/i18n.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, expect, it } from "vitest";
 import en from "../src/i18n/en.json" with { type: "json" };
-import { detectLocale, getLocale, setLocale, t } from "../src/i18n/index.js";
+import { detectLocale, getLocale, resetLocale, setLocale, t } from "../src/i18n/index.js";
 import ja from "../src/i18n/ja.json" with { type: "json" };
 
 afterEach(() => {
-  setLocale("en");
+  resetLocale();
 });
 
 describe("t()", () => {

--- a/tests/i18n.test.ts
+++ b/tests/i18n.test.ts
@@ -1,0 +1,118 @@
+import { afterEach, describe, expect, it } from "vitest";
+import en from "../src/i18n/en.json" with { type: "json" };
+import { detectLocale, getLocale, setLocale, t } from "../src/i18n/index.js";
+import ja from "../src/i18n/ja.json" with { type: "json" };
+
+afterEach(() => {
+  setLocale("en");
+});
+
+describe("t()", () => {
+  it("returns English string by default", () => {
+    expect(t("cancel")).toBe("Operation cancelled.");
+  });
+
+  it("returns Japanese string when locale is ja", () => {
+    setLocale("ja");
+    expect(t("cancel")).toBe("操作がキャンセルされました。");
+  });
+
+  it("resolves nested keys", () => {
+    expect(t("wizard.projectName.message")).toBe("Project name");
+  });
+
+  it("resolves deeply nested keys", () => {
+    expect(t("wizard.frontend.react.hint")).toBe("forces TypeScript");
+  });
+
+  it("interpolates variables", () => {
+    expect(t("spinner.stop", { count: 42 })).toBe("Generated 42 files");
+  });
+
+  it("interpolates variables in Japanese", () => {
+    setLocale("ja");
+    expect(t("spinner.stop", { count: 42 })).toBe("42 ファイルを生成しました");
+  });
+
+  it("preserves unmatched placeholders", () => {
+    expect(t("overwrite.message", {})).toContain("{{path}}");
+  });
+
+  it("returns key for invalid path", () => {
+    // biome-ignore lint/suspicious/noExplicitAny: testing invalid key at runtime
+    expect(t("nonexistent.key" as any)).toBe("nonexistent.key");
+  });
+});
+
+describe("setLocale / getLocale", () => {
+  it("defaults to en", () => {
+    expect(getLocale()).toBe("en");
+  });
+
+  it("can be set to ja", () => {
+    setLocale("ja");
+    expect(getLocale()).toBe("ja");
+  });
+});
+
+describe("detectLocale()", () => {
+  const originalLang = process.env.LANG;
+  const originalLcAll = process.env.LC_ALL;
+
+  afterEach(() => {
+    process.env.LANG = originalLang;
+    process.env.LC_ALL = originalLcAll;
+  });
+
+  it("returns en by default", () => {
+    delete process.env.LANG;
+    delete process.env.LC_ALL;
+    expect(detectLocale()).toBe("en");
+  });
+
+  it("returns langFlag when valid", () => {
+    expect(detectLocale("ja")).toBe("ja");
+    expect(detectLocale("en")).toBe("en");
+  });
+
+  it("ignores invalid langFlag", () => {
+    delete process.env.LANG;
+    delete process.env.LC_ALL;
+    expect(detectLocale("fr")).toBe("en");
+  });
+
+  it("detects ja from LANG env var", () => {
+    delete process.env.LC_ALL;
+    process.env.LANG = "ja_JP.UTF-8";
+    expect(detectLocale()).toBe("ja");
+  });
+
+  it("LC_ALL takes priority over LANG", () => {
+    process.env.LANG = "en_US.UTF-8";
+    process.env.LC_ALL = "ja_JP.UTF-8";
+    expect(detectLocale()).toBe("ja");
+  });
+
+  it("langFlag takes priority over env vars", () => {
+    process.env.LANG = "ja_JP.UTF-8";
+    expect(detectLocale("en")).toBe("en");
+  });
+});
+
+describe("locale file consistency", () => {
+  function extractKeys(obj: unknown, prefix = ""): string[] {
+    if (typeof obj !== "object" || obj == null) return [prefix];
+    const keys: string[] = [];
+    for (const [key, value] of Object.entries(obj)) {
+      const path = prefix ? `${prefix}.${key}` : key;
+      keys.push(...extractKeys(value, path));
+    }
+    return keys;
+  }
+
+  it("ja.json has the same keys as en.json", () => {
+    const enKeys = extractKeys(en).sort();
+    const jaKeys = extractKeys(ja).sort();
+    expect(jaKeys).toEqual(enKeys);
+  });
+});


### PR DESCRIPTION
## Summary

CLI ウィザードに i18n（国際化）対応を追加。

- JSON ロケールファイル（`src/i18n/en.json`, `ja.json`）による英語/日本語対応
- 型安全な `t()` ヘルパー（`PathKeys<T>` 再帰型でドットパスキーを型チェック）
- `LANG`/`LC_ALL` 環境変数からの自動検出 + `--lang` フラグで明示的指定
- 各プロンプトに `pc.dim()` で説明ヒントを追加
- `node:util` の `parseArgs` で `--lang` フラグをパース（外部依存なし）

## Test plan

- [x] 新規テスト 17 件追加（`t()` 動作、ロケール検出、キー一貫性）
- [x] 既存テスト 129 件 + 新規 17 件 = 146 件全通過
- [x] lint / typecheck 通過
- [x] ビルド成功、英語・日本語・自動検出の動作確認済み

Closes #38