### PR TITLE
fix: replace note box with log.step for next steps display

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ async function main(): Promise<void> {
 
   s.stop(t("spinner.stop", { count: result.fileList().length }));
 
-  p.note([`cd ${relPath}`, "bash scripts/setup.sh"].join("\n"), t("nextSteps.title"));
+  p.log.step(`${t("nextSteps.title")}:\n  cd ${relPath}\n  bash scripts/setup.sh`);
 
   p.outro(pc.green(t("outro")));
 }


### PR DESCRIPTION
## Summary

プロジェクト生成完了時の「Next steps」表示を `p.note()`（枠付き）から `p.log.step()`（枠なし）に変更。日本語表示時の枠ズレを解消。

## Test plan

- [x] lint / typecheck / 146 テスト全通過
- [x] ビルド＆日本語表示で枠なし確認済み