### PR TITLE
refactor: rename wizard question labels for clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ The interactive wizard asks 4 questions to configure your project:
 | # | Question | Options |
 |---|----------|---------|
 | 1 | Project name | Text input |
-| 2 | Languages | TypeScript / Python (multi-select) |
-| 3 | Frontend framework | None / React (Vite) |
+| 2 | Language toolchains | TypeScript / Python (multi-select) |
+| 3 | Frontend app | None / React (Vite) |
 | 4 | Infrastructure as Code | None / AWS CDK / CloudFormation / Terraform |
 
 ## Presets

--- a/docs/design.md
+++ b/docs/design.md
@@ -16,8 +16,8 @@
 | # | Question | Type | Options |
 |---|----------|------|---------|
 | 1 | Project name | Text input | — |
-| 2 | Languages | Multi-select | TypeScript / Python |
-| 3 | Frontend framework | Single-select | None / React (Vite) |
+| 2 | Language toolchains | Multi-select | TypeScript / Python |
+| 3 | Frontend app | Single-select | None / React (Vite) |
 | 4 | Infrastructure as Code | Single-select | None / AWS CDK / CloudFormation / Terraform |
 
 ## Presets

--- a/docs/design.md
+++ b/docs/design.md
@@ -187,7 +187,7 @@ Terraform ──→ tflint
 
 | Element | Notes |
 |---------|-------|
-| Vue | Frontend framework option, to be added when needed |
+| Vue | Frontend app option, to be added when needed |
 | Next.js / Remix | React meta-frameworks; out of scope (app architecture, not dev tooling) |
 
 ## Project Structure

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -9,14 +9,14 @@
       "invalid": "Invalid project name. Use alphanumeric characters, hyphens, dots, or underscores."
     },
     "languages": {
-      "message": "Languages",
-      "hint": "Select languages for your project",
+      "message": "Language toolchains",
+      "hint": "Each selection adds linters, formatters, and test setup",
       "typescript": { "label": "TypeScript" },
       "python": { "label": "Python" }
     },
     "frontend": {
-      "message": "Frontend framework",
-      "hint": "Choose a frontend framework or skip",
+      "message": "Frontend app",
+      "hint": "Add a frontend application scaffold",
       "none": { "label": "None" },
       "react": { "label": "React (Vite)", "hint": "forces TypeScript" }
     },

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -9,14 +9,14 @@
       "invalid": "プロジェクト名が無効です。英数字、ハイフン、ドット、アンダースコアのみ使用できます。"
     },
     "languages": {
-      "message": "言語",
-      "hint": "プロジェクトで使用する言語を選択",
+      "message": "言語ツールチェイン",
+      "hint": "選択ごとにリンター・フォーマッター・テスト環境を追加",
       "typescript": { "label": "TypeScript" },
       "python": { "label": "Python" }
     },
     "frontend": {
-      "message": "フロントエンドフレームワーク",
-      "hint": "フレームワークを選択（不要なら None）",
+      "message": "フロントエンドアプリ",
+      "hint": "フロントエンドアプリの雛形を追加",
       "none": { "label": "なし" },
       "react": { "label": "React (Vite)", "hint": "TypeScript が強制されます" }
     },


### PR DESCRIPTION
## Summary

- Q2: "Languages" → "Language toolchains" (clarifies that each selection adds a full toolchain: linters, formatters, test setup)
- Q3: "Frontend framework" → "Frontend app" (clarifies it adds an app scaffold, not just a framework dependency)
- Updated hint text in both en/ja locales and design.md

Closes #41

## Test plan

- [x] `pnpm test` — 146 tests passed
- [x] `biome check` — no issues
- [x] `markdownlint-cli2` — no issues
- [x] `gitleaks` — no leaks
- [x] lefthook pre-commit / commit-msg / pre-push hooks all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)