### PR TITLE
feat: make VSCode and devcontainer settings preset-aware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ dist/
 *.swo
 *~
 
+# Override global gitignore for template assets
+!templates/**/.vscode/
+
 # AI agent local settings
 .claude/settings.local.json
 .claude/plans/

--- a/docs/design.md
+++ b/docs/design.md
@@ -150,7 +150,7 @@ Application order: `base → typescript → python → react → cdk / cloudform
 
 | File type | Strategy |
 |-----------|----------|
-| JSON (`package.json`, `.mcp.json`) | Deep merge. Arrays: unique union |
+| JSON (`package.json`, `.mcp.json`, `.vscode/*.json`, `devcontainer.json`) | Deep merge. Arrays: unique union |
 | YAML (`lefthook.yaml`, `ci.yaml`) | Deep merge. Arrays: unique union |
 | TOML (`.mise.toml`) | Deep merge |
 | Markdown (`CLAUDE.md`, `README.md`) | Template + section injection (exception: uses placeholder-based approach) |

--- a/docs/design.md
+++ b/docs/design.md
@@ -47,11 +47,11 @@ Application order: `base → typescript → python → react → cdk / cloudform
 | YAML | yamllint, yamlfmt | `.yamllint.yaml`, `.yamlfmt.yaml` |
 | TOML | taplo | via lefthook / CI |
 | GitHub Actions | actionlint | via lefthook / CI |
-| Docker | devcontainer, hadolint, dockerfmt, dclint | `.devcontainer/` (4 files), `.hadolint.yaml`, `.dockerignore` |
+| Docker | devcontainer (common only), hadolint, dockerfmt, dclint | `.devcontainer/` (4 files), `.hadolint.yaml`, `.dockerignore` |
 | Security | Trivy, Gitleaks | `trivy.yaml` |
 | Claude Code | Skills, Rules, Settings | `.claude/` (skills, rules, settings.json) |
 | GitHub | CI workflow, PR template, CODEOWNERS, rulesets | `.github/` |
-| VSCode | Editor settings, extensions | `.vscode/` |
+| VSCode | Editor settings (common only), extensions (common only) | `.vscode/` |
 | MCP | Context7, Fetch | `.mcp.json`, `.mcp.json.example` |
 | Docs | CLAUDE.md, README.md, adding-tools.md, branch-strategy.md | `CLAUDE.md`, `README.md`, `docs/` |
 | Scripts | setup, configure-repo, apply-rulesets | `scripts/` |
@@ -68,6 +68,9 @@ Application order: `base → typescript → python → react → cdk / cloudform
 | Node.js devDeps | `package.json` (devDependencies) |
 | Sample code | `src/index.ts` |
 | Tests | `tests/index.test.ts` |
+| VSCode: Biome formatter settings | `.vscode/settings.json` (merge) |
+| VSCode: Biome extension | `.vscode/extensions.json` (merge) |
+| devcontainer: Biome extension | `.devcontainer/devcontainer.json` (merge) |
 
 **Python** — adds:
 
@@ -77,6 +80,9 @@ Application order: `base → typescript → python → react → cdk / cloudform
 | mypy (type check) | `pyproject.toml` |
 | uv (package manager) | `uv.lock` |
 | Tests | `tests/test_placeholder.py`, `tests/__init__.py` |
+| VSCode: Ruff/mypy/Python settings | `.vscode/settings.json` (merge) |
+| VSCode: Ruff, mypy, Python extensions | `.vscode/extensions.json` (merge) |
+| devcontainer: Python extensions, uv-cache mount | `.devcontainer/devcontainer.json` (merge) |
 
 ### Frontend Selection (forces TypeScript)
 
@@ -93,6 +99,9 @@ Application order: `base → typescript → python → react → cdk / cloudform
 | cdk-nag | `infra/package.json` (dependency) |
 | CD workflow | `.github/workflows/cd.yaml` |
 | MCP: AWS IaC | `.mcp.json` (auto-added) |
+| VSCode: cdk.out search exclude | `.vscode/settings.json` (merge) |
+| VSCode: AWS Toolkit extension | `.vscode/extensions.json` (merge) |
+| devcontainer: AWS Toolkit extension, ~/.aws mount | `.devcontainer/devcontainer.json` (merge) |
 
 **CloudFormation** — adds:
 
@@ -102,6 +111,7 @@ Application order: `base → typescript → python → react → cdk / cloudform
 | cfn-lint | `.cfnlintrc.yaml` |
 | CD workflow | `.github/workflows/cd.yaml` |
 | MCP: AWS IaC | `.mcp.json` (auto-added) |
+| devcontainer: ~/.aws mount | `.devcontainer/devcontainer.json` (merge) |
 
 **Terraform** — adds:
 
@@ -111,6 +121,7 @@ Application order: `base → typescript → python → react → cdk / cloudform
 | terraform | via mise |
 | CD workflow | `.github/workflows/cd.yaml` |
 | MCP: AWS IaC | `.mcp.json` (auto-added) |
+| devcontainer: ~/.aws mount | `.devcontainer/devcontainer.json` (merge) |
 
 ## Preset Composition
 
@@ -129,6 +140,9 @@ Application order: `base → typescript → python → react → cdk / cloudform
 | `.github/workflows/ci.yaml` | base, typescript, python, cdk, cloudformation, terraform |
 | `.github/workflows/cd.yaml` | cdk, cloudformation, terraform |
 | `.mcp.json` | base, cdk, cloudformation, terraform |
+| `.vscode/settings.json` | typescript, python, cdk |
+| `.vscode/extensions.json` | typescript, python, cdk |
+| `.devcontainer/devcontainer.json` | typescript, python, cdk, cloudformation, terraform |
 | `CLAUDE.md` | all presets |
 | `README.md` | all presets |
 

--- a/src/presets/cdk.ts
+++ b/src/presets/cdk.ts
@@ -22,6 +22,25 @@ export const cdkPreset: Preset = {
         "pipx:cfn-lint": "1",
       },
     },
+    ".vscode/settings.json": {
+      "search.exclude": {
+        "**/cdk.out": true,
+      },
+    },
+    ".vscode/extensions.json": {
+      recommendations: ["amazonwebservices.aws-toolkit-vscode"],
+    },
+    ".devcontainer/devcontainer.json": {
+      customizations: {
+        vscode: {
+          extensions: ["amazonwebservices.aws-toolkit-vscode"],
+        },
+      },
+      mounts: [
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: devcontainer variable syntax
+        "source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,consistency=cached",
+      ],
+    },
     ".mcp.json": {
       mcpServers: {
         "aws-iac": {

--- a/src/presets/cloudformation.ts
+++ b/src/presets/cloudformation.ts
@@ -16,6 +16,12 @@ export const cloudformationPreset: Preset = {
         "pipx:cfn-lint": "1",
       },
     },
+    ".devcontainer/devcontainer.json": {
+      mounts: [
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: devcontainer variable syntax
+        "source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,consistency=cached",
+      ],
+    },
     ".mcp.json": {
       mcpServers: {
         "aws-iac": {

--- a/src/presets/python.ts
+++ b/src/presets/python.ts
@@ -19,6 +19,27 @@ export const pythonPreset: Preset = {
         "pipx:mypy": "1",
       },
     },
+    ".vscode/settings.json": {
+      "mypy-type-checker.importStrategy": "fromEnvironment",
+      "[python]": {
+        "editor.defaultFormatter": "charliermarsh.ruff",
+        "editor.codeActionsOnSave": {
+          "source.fixAll.ruff": "explicit",
+          "source.organizeImports.ruff": "explicit",
+        },
+      },
+    },
+    ".vscode/extensions.json": {
+      recommendations: ["charliermarsh.ruff", "ms-python.mypy-type-checker", "ms-python.python"],
+    },
+    ".devcontainer/devcontainer.json": {
+      customizations: {
+        vscode: {
+          extensions: ["charliermarsh.ruff", "ms-python.mypy-type-checker", "ms-python.python"],
+        },
+      },
+      mounts: ["source=agentic-dev-uv-cache,target=/home/vscode/.cache/uv,type=volume"],
+    },
     "lefthook.yaml": {
       "pre-commit": {
         commands: {

--- a/src/presets/terraform.ts
+++ b/src/presets/terraform.ts
@@ -17,6 +17,12 @@ export const terraformPreset: Preset = {
         tflint: "0.55",
       },
     },
+    ".devcontainer/devcontainer.json": {
+      mounts: [
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: devcontainer variable syntax
+        "source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,consistency=cached",
+      ],
+    },
     ".mcp.json": {
       mcpServers: {
         "aws-iac": {

--- a/src/presets/typescript.ts
+++ b/src/presets/typescript.ts
@@ -31,6 +31,7 @@ export const typescriptPreset: Preset = {
       "editor.codeActionsOnSave": {
         "source.fixAll.biome": "explicit",
       },
+      // Top-level default; language-specific overrides in base (md/yaml/toml/shell) and python take precedence
       "editor.defaultFormatter": "biomejs.biome",
       "search.exclude": {
         "**/dist": true,

--- a/src/presets/typescript.ts
+++ b/src/presets/typescript.ts
@@ -27,6 +27,40 @@ export const typescriptPreset: Preset = {
         "npm:@biomejs/biome": "2",
       },
     },
+    ".vscode/settings.json": {
+      "editor.codeActionsOnSave": {
+        "source.fixAll.biome": "explicit",
+      },
+      "editor.defaultFormatter": "biomejs.biome",
+      "search.exclude": {
+        "**/dist": true,
+      },
+      "[javascript]": {
+        "editor.defaultFormatter": "biomejs.biome",
+      },
+      "[json]": {
+        "editor.defaultFormatter": "biomejs.biome",
+      },
+      "[jsonc]": {
+        "editor.defaultFormatter": "biomejs.biome",
+      },
+      "[typescript]": {
+        "editor.defaultFormatter": "biomejs.biome",
+      },
+      "[typescriptreact]": {
+        "editor.defaultFormatter": "biomejs.biome",
+      },
+    },
+    ".vscode/extensions.json": {
+      recommendations: ["biomejs.biome"],
+    },
+    ".devcontainer/devcontainer.json": {
+      customizations: {
+        vscode: {
+          extensions: ["biomejs.biome"],
+        },
+      },
+    },
     "lefthook.yaml": {
       "pre-commit": {
         commands: {

--- a/templates/base/.devcontainer/devcontainer.json
+++ b/templates/base/.devcontainer/devcontainer.json
@@ -16,7 +16,6 @@
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
   "mounts": [
-    "source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.claude.json,target=/home/vscode/.claude.json,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.claude/.credentials.json,target=/home/vscode/.claude/.credentials.json,type=bind,readonly,consistency=cached",
     "source=${localEnv:HOME}/.claude/projects,target=/home/vscode/.claude/projects,type=bind,consistency=cached",
@@ -25,8 +24,7 @@
     "source=${localEnv:HOME}/.gitconfig,target=/home/vscode/.gitconfig,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.gitconfig.local,target=/home/vscode/.gitconfig.local,type=bind,consistency=cached",
     "source=${localEnv:HOME}/.zsh_history,target=/home/vscode/.zsh_history,type=bind,consistency=cached",
-    "source=agentic-dev-pnpm-store,target=/home/vscode/.local/share/pnpm/store,type=volume",
-    "source=agentic-dev-uv-cache,target=/home/vscode/.cache/uv,type=volume"
+    "source=agentic-dev-pnpm-store,target=/home/vscode/.local/share/pnpm/store,type=volume"
   ],
   "portsAttributes": {
     "*": {
@@ -38,16 +36,11 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "amazonwebservices.aws-toolkit-vscode",
-        "biomejs.biome",
-        "charliermarsh.ruff",
         "DavidAnson.vscode-markdownlint",
         "EditorConfig.EditorConfig",
         "foxundermoon.shell-format",
         "github.vscode-github-actions",
         "ms-azuretools.vscode-docker",
-        "ms-python.mypy-type-checker",
-        "ms-python.python",
         "redhat.vscode-yaml",
         "tamasfe.even-better-toml",
         "timonwong.shellcheck"

--- a/templates/base/.vscode/extensions.json
+++ b/templates/base/.vscode/extensions.json
@@ -1,0 +1,12 @@
+{
+  "recommendations": [
+    "DavidAnson.vscode-markdownlint",
+    "EditorConfig.EditorConfig",
+    "foxundermoon.shell-format",
+    "github.vscode-github-actions",
+    "ms-azuretools.vscode-docker",
+    "redhat.vscode-yaml",
+    "tamasfe.even-better-toml",
+    "timonwong.shellcheck"
+  ]
+}

--- a/templates/base/.vscode/settings.json
+++ b/templates/base/.vscode/settings.json
@@ -1,0 +1,20 @@
+{
+  "editor.formatOnSave": true,
+  "files.eol": "\n",
+  "files.trimTrailingWhitespace": true,
+  "[markdown]": {
+    "editor.formatOnSave": false,
+    "editor.codeActionsOnSave": {
+      "source.fixAll.markdownlint": "explicit"
+    }
+  },
+  "[shellscript]": {
+    "editor.defaultFormatter": "foxundermoon.shell-format"
+  },
+  "[toml]": {
+    "editor.defaultFormatter": "tamasfe.even-better-toml"
+  },
+  "[yaml]": {
+    "editor.defaultFormatter": "redhat.vscode-yaml"
+  }
+}

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -158,6 +158,44 @@ describe("generate (base only)", () => {
     expect(skill).not.toContain("infra");
   });
 
+  it("generates VSCode settings with common settings only", () => {
+    const settings = result.readJson(".vscode/settings.json") as Record<string, unknown>;
+    expect(settings["editor.formatOnSave"]).toBe(true);
+    expect(settings["files.eol"]).toBe("\n");
+    // No Biome or Python settings in base
+    expect(settings["editor.defaultFormatter"]).toBeUndefined();
+    expect(settings["editor.codeActionsOnSave"]).toBeUndefined();
+    expect(settings["[javascript]"]).toBeUndefined();
+    expect(settings["[python]"]).toBeUndefined();
+    expect(settings["search.exclude"]).toBeUndefined();
+    expect(settings["mypy-type-checker.importStrategy"]).toBeUndefined();
+  });
+
+  it("generates VSCode extensions with common extensions only", () => {
+    const ext = result.readJson(".vscode/extensions.json") as Record<string, string[]>;
+    expect(ext.recommendations).toContain("EditorConfig.EditorConfig");
+    expect(ext.recommendations).toContain("timonwong.shellcheck");
+    // No preset-specific extensions
+    expect(ext.recommendations).not.toContain("biomejs.biome");
+    expect(ext.recommendations).not.toContain("charliermarsh.ruff");
+    expect(ext.recommendations).not.toContain("amazonwebservices.aws-toolkit-vscode");
+  });
+
+  it("generates devcontainer with common extensions only", () => {
+    const dc = result.readJson(".devcontainer/devcontainer.json") as Record<string, unknown>;
+    const customizations = dc.customizations as Record<string, Record<string, string[]>>;
+    const extensions = customizations.vscode.extensions;
+    expect(extensions).toContain("EditorConfig.EditorConfig");
+    expect(extensions).not.toContain("biomejs.biome");
+    expect(extensions).not.toContain("charliermarsh.ruff");
+    expect(extensions).not.toContain("amazonwebservices.aws-toolkit-vscode");
+    // No preset-specific mounts
+    const mounts = dc.mounts as string[];
+    expect(mounts.some((m: string) => m.includes(".aws"))).toBe(false);
+    expect(mounts.some((m: string) => m.includes("uv-cache"))).toBe(false);
+    expect(mounts.some((m: string) => m.includes("pnpm-store"))).toBe(true);
+  });
+
   it("base only has no TypeScript/Python specific files", () => {
     expect(result.hasFile("biome.json")).toBe(false);
     expect(result.hasFile("tsconfig.json")).toBe(false);
@@ -279,6 +317,33 @@ describe("generate (typescript)", () => {
     expect(skill).not.toContain("<!-- SECTION:");
   });
 
+  it("merges Biome settings into VSCode settings", () => {
+    const settings = result.readJson(".vscode/settings.json") as Record<string, unknown>;
+    expect(settings["editor.defaultFormatter"]).toBe("biomejs.biome");
+    const codeActions = settings["editor.codeActionsOnSave"] as Record<string, string>;
+    expect(codeActions["source.fixAll.biome"]).toBe("explicit");
+    const searchExclude = settings["search.exclude"] as Record<string, boolean>;
+    expect(searchExclude["**/dist"]).toBe(true);
+    const jsSettings = settings["[javascript]"] as Record<string, string>;
+    expect(jsSettings["editor.defaultFormatter"]).toBe("biomejs.biome");
+    // No Python settings
+    expect(settings["[python]"]).toBeUndefined();
+    expect(settings["mypy-type-checker.importStrategy"]).toBeUndefined();
+  });
+
+  it("merges Biome extension into VSCode extensions", () => {
+    const ext = result.readJson(".vscode/extensions.json") as Record<string, string[]>;
+    expect(ext.recommendations).toContain("biomejs.biome");
+    expect(ext.recommendations).not.toContain("charliermarsh.ruff");
+  });
+
+  it("merges Biome extension into devcontainer", () => {
+    const dc = result.readJson(".devcontainer/devcontainer.json") as Record<string, unknown>;
+    const customizations = dc.customizations as Record<string, Record<string, string[]>>;
+    expect(customizations.vscode.extensions).toContain("biomejs.biome");
+    expect(customizations.vscode.extensions).not.toContain("charliermarsh.ruff");
+  });
+
   it("does not include Python files", () => {
     expect(result.hasFile("pyproject.toml")).toBe(false);
     expect(result.hasFile("uv.lock")).toBe(false);
@@ -352,6 +417,35 @@ describe("generate (python)", () => {
     expect(claude).toContain("Ruff");
     expect(claude).toContain("mypy");
     expect(claude).not.toContain("<!-- SECTION:");
+  });
+
+  it("merges Python settings into VSCode settings", () => {
+    const settings = result.readJson(".vscode/settings.json") as Record<string, unknown>;
+    expect(settings["mypy-type-checker.importStrategy"]).toBe("fromEnvironment");
+    const pySettings = settings["[python]"] as Record<string, unknown>;
+    expect(pySettings["editor.defaultFormatter"]).toBe("charliermarsh.ruff");
+    // No Biome settings
+    expect(settings["editor.defaultFormatter"]).toBeUndefined();
+    expect(settings["[javascript]"]).toBeUndefined();
+  });
+
+  it("merges Python extensions into VSCode extensions", () => {
+    const ext = result.readJson(".vscode/extensions.json") as Record<string, string[]>;
+    expect(ext.recommendations).toContain("charliermarsh.ruff");
+    expect(ext.recommendations).toContain("ms-python.mypy-type-checker");
+    expect(ext.recommendations).toContain("ms-python.python");
+    expect(ext.recommendations).not.toContain("biomejs.biome");
+  });
+
+  it("merges Python extensions and uv-cache mount into devcontainer", () => {
+    const dc = result.readJson(".devcontainer/devcontainer.json") as Record<string, unknown>;
+    const customizations = dc.customizations as Record<string, Record<string, string[]>>;
+    expect(customizations.vscode.extensions).toContain("charliermarsh.ruff");
+    expect(customizations.vscode.extensions).toContain("ms-python.python");
+    expect(customizations.vscode.extensions).not.toContain("biomejs.biome");
+    const mounts = dc.mounts as string[];
+    expect(mounts.some((m: string) => m.includes("uv-cache"))).toBe(true);
+    expect(mounts.some((m: string) => m.includes(".aws"))).toBe(false);
   });
 
   it("does not include TypeScript files", () => {
@@ -611,6 +705,28 @@ describe("generate (cdk)", () => {
     expect(appTs).not.toContain("source-map-support");
   });
 
+  it("merges CDK settings into VSCode settings", () => {
+    const settings = result.readJson(".vscode/settings.json") as Record<string, unknown>;
+    const searchExclude = settings["search.exclude"] as Record<string, boolean>;
+    expect(searchExclude["**/cdk.out"]).toBe(true);
+    // TypeScript settings also present (CDK forces TypeScript)
+    expect(searchExclude["**/dist"]).toBe(true);
+  });
+
+  it("merges AWS Toolkit into VSCode extensions", () => {
+    const ext = result.readJson(".vscode/extensions.json") as Record<string, string[]>;
+    expect(ext.recommendations).toContain("amazonwebservices.aws-toolkit-vscode");
+    expect(ext.recommendations).toContain("biomejs.biome");
+  });
+
+  it("merges AWS Toolkit and ~/.aws mount into devcontainer", () => {
+    const dc = result.readJson(".devcontainer/devcontainer.json") as Record<string, unknown>;
+    const customizations = dc.customizations as Record<string, Record<string, string[]>>;
+    expect(customizations.vscode.extensions).toContain("amazonwebservices.aws-toolkit-vscode");
+    const mounts = dc.mounts as string[];
+    expect(mounts.some((m: string) => m.includes(".aws"))).toBe(true);
+  });
+
   it("expands CLAUDE.md with CDK sections", () => {
     const claude = result.readText("CLAUDE.md");
     expect(claude).toContain("CDK");
@@ -647,6 +763,12 @@ describe("generate (cloudformation)", () => {
     const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
     const stepNames = steps.map((s) => s.name);
     expect(stepNames).toContain("Lint (cfn-lint)");
+  });
+
+  it("merges ~/.aws mount into devcontainer", () => {
+    const dc = result.readJson(".devcontainer/devcontainer.json") as Record<string, unknown>;
+    const mounts = dc.mounts as string[];
+    expect(mounts.some((m: string) => m.includes(".aws"))).toBe(true);
   });
 
   it("does not include CDK or Terraform files", () => {
@@ -689,6 +811,12 @@ describe("generate (terraform)", () => {
     const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
     const stepNames = steps.map((s) => s.name);
     expect(stepNames).toContain("Lint (Terraform)");
+  });
+
+  it("merges ~/.aws mount into devcontainer", () => {
+    const dc = result.readJson(".devcontainer/devcontainer.json") as Record<string, unknown>;
+    const mounts = dc.mounts as string[];
+    expect(mounts.some((m: string) => m.includes(".aws"))).toBe(true);
   });
 
   it("does not include CDK or CloudFormation files", () => {

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -517,6 +517,36 @@ describe("generate (typescript + python)", () => {
     expect(scripts["lint:all"]).toContain("pnpm run lint:mypy");
     expect(scripts["lint:all"]).toContain("pnpm run lint:secrets");
   });
+
+  it("merges both language settings into VSCode settings", () => {
+    const settings = result.readJson(".vscode/settings.json") as Record<string, unknown>;
+    // TypeScript settings
+    expect(settings["editor.defaultFormatter"]).toBe("biomejs.biome");
+    expect(settings["[typescript]"]).toBeDefined();
+    // Python settings
+    expect(settings["mypy-type-checker.importStrategy"]).toBe("fromEnvironment");
+    expect(settings["[python]"]).toBeDefined();
+  });
+
+  it("merges both language extensions into VSCode extensions", () => {
+    const ext = result.readJson(".vscode/extensions.json") as Record<string, string[]>;
+    expect(ext.recommendations).toContain("biomejs.biome");
+    expect(ext.recommendations).toContain("charliermarsh.ruff");
+    expect(ext.recommendations).toContain("ms-python.python");
+    // base extensions still present
+    expect(ext.recommendations).toContain("EditorConfig.EditorConfig");
+  });
+
+  it("merges both language extensions and mounts into devcontainer", () => {
+    const dc = result.readJson(".devcontainer/devcontainer.json") as Record<string, unknown>;
+    const customizations = dc.customizations as Record<string, Record<string, string[]>>;
+    expect(customizations.vscode.extensions).toContain("biomejs.biome");
+    expect(customizations.vscode.extensions).toContain("charliermarsh.ruff");
+    expect(customizations.vscode.extensions).toContain("ms-python.python");
+    const mounts = dc.mounts as string[];
+    expect(mounts.some((m: string) => m.includes("uv-cache"))).toBe(true);
+    expect(mounts.some((m: string) => m.includes("pnpm-store"))).toBe(true);
+  });
 });
 
 // --- Pattern 4: TypeScript + React ---


### PR DESCRIPTION
## Summary

- VSCode settings/extensions と devcontainer 設定をプリセット対応に変更
- base テンプレートから言語/IaC 固有の設定を分離し、各プリセットの `merge` で動的に構成
- `.vscode/settings.json`, `.vscode/extensions.json`, `.devcontainer/devcontainer.json` を Shared files として追加
- 14 テスト追加、`docs/design.md` 更新

### 変更の詳細

| プリセット | VSCode settings | VSCode extensions | devcontainer |
|-----------|----------------|-------------------|-------------|
| **base** | 共通設定のみ | 共通8拡張のみ | 共通設定 + pnpm-store |
| **typescript** | Biome formatter + dist除外 | biomejs.biome | biomejs.biome |
| **python** | Ruff/mypy設定 | ruff, mypy, python | python拡張 + uv-cache |
| **cdk** | cdk.out除外 | aws-toolkit | aws-toolkit + ~/.aws |
| **cloudformation** | — | — | ~/.aws |
| **terraform** | — | — | ~/.aws |

Closes #43

## Test plan

- [x] 全 160 テスト通過（14 テスト追加）
- [x] Biome lint 通過
- [x] TypeScript typecheck 通過
- [x] スナップショット更新済み