### PR TITLE
docs: update README and preset-authoring guide for preset-aware VSCode/devcontainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ The interactive wizard asks 4 questions to configure your project:
 | **terraform** | IaC: Terraform | tflint, terraform fmt |
 
 Presets are composable: each provides owned files + merge contributions to shared files
-(package.json, .mise.toml, lefthook.yaml, CLAUDE.md, README.md, CI workflow).
+(package.json, .mise.toml, lefthook.yaml, .vscode/settings.json, .vscode/extensions.json,
+.devcontainer/devcontainer.json, CLAUDE.md, README.md, CI workflow).
 
 ## What You Get
 
@@ -45,7 +46,7 @@ Every generated project includes:
 - **Claude Code integration** — CLAUDE.md, skills (/setup, /implement, /lint, /test, /commit, /pr, /review, /ship), MCP servers
 - **Git hooks** — commitlint (commit-msg), linters + Gitleaks (pre-commit), typecheck (pre-push)
 - **CI workflow** — All linters + tests + build on push/PR
-- **Dev Container** — VSCode devcontainer with all tools pre-installed
+- **Dev Container** — VSCode devcontainer with preset-specific tools, extensions, and mounts
 - **Renovate** — Automated dependency updates
 
 ## Development

--- a/docs/preset-authoring.md
+++ b/docs/preset-authoring.md
@@ -169,6 +169,37 @@ merge: {
 },
 ```
 
+### Example: Contributing to VSCode settings and extensions
+
+Presets can add editor settings, recommended extensions, and devcontainer
+configuration. Arrays (like `recommendations` and `mounts`) are deduplicated
+via unique-union merge.
+
+```typescript
+merge: {
+  ".vscode/settings.json": {
+    "editor.defaultFormatter": "biomejs.biome",
+    "[typescript]": {
+      "editor.defaultFormatter": "biomejs.biome",
+    },
+  },
+  ".vscode/extensions.json": {
+    recommendations: ["biomejs.biome"],
+  },
+  ".devcontainer/devcontainer.json": {
+    customizations: {
+      vscode: {
+        extensions: ["biomejs.biome"],
+      },
+    },
+    // Add mounts if needed (e.g., ~/.aws for AWS presets)
+    mounts: [
+      "source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,consistency=cached",
+    ],
+  },
+},
+```
+
 ## Markdown Section Injection
 
 Templates (`templates/base/CLAUDE.md`, `templates/base/README.md`) contain
@@ -348,8 +379,9 @@ const result = generate(makeAnswers({ languages: ["typescript"] }));
 1. **Required files exist** — owned files from your preset
 2. **Excluded files don't exist** — files that shouldn't appear for this config
 3. **Shared file contents** — merged scripts, dependencies, tools
-4. **CI workflow** — your lint/test/build steps appear
-5. **Markdown content** — CLAUDE.md and README.md contain your injected sections
+4. **VSCode/devcontainer** — extensions, settings, and mounts are preset-specific
+5. **CI workflow** — your lint/test/build steps appear
+6. **Markdown content** — CLAUDE.md and README.md contain your injected sections
 
 ### Example test
 


### PR DESCRIPTION
## Summary

- `README.md`: shared files リストに VSCode/devcontainer ファイルを追加、Dev Container の説明をプリセット対応に更新
- `docs/preset-authoring.md`: VSCode settings/extensions/devcontainer への merge 例を追加、テスト観点に VSCode/devcontainer を追加

#43 の関連ドキュメント更新漏れを修正。

## Test plan

- [x] markdownlint 通過
- [x] 全 163 テスト通過