### PR TITLE
feat: add verification tests for generated output validation

### DIFF
--- a/.claude/skills/test/SKILL.md
+++ b/.claude/skills/test/SKILL.md
@@ -10,7 +10,7 @@ allowed-tools: Bash, AskUserQuestion
 
 ## 手順
 
-1. `pnpm test` で vitest テスト実行
+1. `pnpm test` で vitest テスト実行（verify テストを含む全テスト）
 2. 全テスト結果のサマリーを報告する
 
 ## 次のアクション提案（スキル完了後）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,7 @@ pnpm run dev               # Watch mode build
 pnpm run build             # Production build
 pnpm test                  # Run tests
 pnpm run test:watch        # Watch mode tests
+pnpm run verify            # Verify generated output (required before commit)
 
 # Lint & Format
 pnpm run lint              # Biome check
@@ -64,6 +65,12 @@ pnpm run lint:secrets      # Secret detection (Gitleaks)
 - All code must pass `pnpm run lint:all` before committing
 - Shell: must pass shellcheck and shfmt
 - YAML file extension: `.yaml` (not `.yml`, unless required by tools)
+
+## Verification (Required)
+
+Any change to presets, templates, or generator logic **must** pass `pnpm run verify` before committing. This runs verification tests that validate generated output across all preset combinations: JSON validity, preset isolation, correct composition of shared files (VSCode, devcontainer, package.json), and extension consistency.
+
+`pnpm test` runs all tests including verify. `pnpm run verify` runs only the verification tests.
 
 ## Architecture
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -341,6 +341,7 @@ npm create agentic-dev [my-app]
 | Unit tests | `merge.ts`, preset definitions | Merge logic correctness, preset structure validation |
 | Integration tests | `generator.ts` | Verify generated output for each preset combination |
 | Snapshot tests | Generated file sets | Detect unintended changes in output |
+| Verification tests | `verify.test.ts` | Validate preset isolation, shared file composition, JSON validity |
 
 ### Integration test matrix
 
@@ -366,6 +367,18 @@ After applying dependency constraints, **10 representative patterns** to test:
 2. Excluded files do not exist
 3. Shared file contents are correct (merged dependencies, tools, scripts)
 4. Snapshot matches (file list)
+
+### Verification tests (`pnpm run verify`)
+
+Cross-cutting validation across 8 representative patterns:
+
+1. All generated JSON files are valid
+2. Preset-specific settings appear only when the preset is active (preset isolation)
+3. Shared files (VSCode, devcontainer, package.json) correctly compose contributions
+4. `lint:all` dynamically includes all `lint:*` scripts
+5. VSCode extensions and devcontainer extensions are consistent
+
+**Required before committing** any change to presets, templates, or generator logic.
 
 ### Test infrastructure
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "lint:secrets": "gitleaks detect --no-banner",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "verify": "vitest run tests/verify.test.ts"
   },
   "engines": {
     "node": ">=22"

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -1,0 +1,373 @@
+/**
+ * Verification tests — generate representative patterns and validate output.
+ *
+ * These tests go beyond unit/integration tests by verifying the actual merged
+ * output of generated projects: JSON validity, preset isolation, and correct
+ * composition of shared files (VSCode, devcontainer, package.json, etc.).
+ *
+ * Run with: pnpm run verify
+ */
+import { describe, expect, it } from "vitest";
+import { generate } from "../src/generator.js";
+import type { WizardAnswers } from "../src/types.js";
+
+function makeAnswers(overrides: Partial<WizardAnswers> = {}): WizardAnswers {
+  return { projectName: "verify-app", languages: [], frontend: "none", iac: "none", ...overrides };
+}
+
+// Helper to parse and validate JSON files
+function readValidJson(result: ReturnType<typeof generate>, path: string): Record<string, unknown> {
+  const text = result.readText(path);
+  expect(() => JSON.parse(text), `${path} should be valid JSON`).not.toThrow();
+  return JSON.parse(text) as Record<string, unknown>;
+}
+
+// --- Shared file composition checks across all patterns ---
+
+interface PatternDef {
+  name: string;
+  answers: Partial<WizardAnswers>;
+  vscodeSettings: {
+    mustInclude: string[];
+    mustExclude: string[];
+  };
+  vscodeExtensions: {
+    mustInclude: string[];
+    mustExclude: string[];
+  };
+  devcontainer: {
+    extensionsMustInclude: string[];
+    extensionsMustExclude: string[];
+    mountsMustInclude: string[];
+    mountsMustExclude: string[];
+  };
+  packageJson: {
+    scriptsMustInclude: string[];
+    scriptsMustExclude: string[];
+  };
+}
+
+const COMMON_EXTENSIONS = [
+  "DavidAnson.vscode-markdownlint",
+  "EditorConfig.EditorConfig",
+  "foxundermoon.shell-format",
+  "github.vscode-github-actions",
+  "ms-azuretools.vscode-docker",
+  "redhat.vscode-yaml",
+  "tamasfe.even-better-toml",
+  "timonwong.shellcheck",
+];
+
+const patterns: PatternDef[] = [
+  {
+    name: "base only",
+    answers: {},
+    vscodeSettings: {
+      mustInclude: ["editor.formatOnSave", "files.eol"],
+      mustExclude: ["biomejs.biome", "charliermarsh.ruff", "cdk.out", "mypy-type-checker"],
+    },
+    vscodeExtensions: {
+      mustInclude: COMMON_EXTENSIONS,
+      mustExclude: ["biomejs.biome", "charliermarsh.ruff", "amazonwebservices.aws-toolkit-vscode"],
+    },
+    devcontainer: {
+      extensionsMustInclude: COMMON_EXTENSIONS,
+      extensionsMustExclude: [
+        "biomejs.biome",
+        "charliermarsh.ruff",
+        "amazonwebservices.aws-toolkit-vscode",
+      ],
+      mountsMustInclude: ["pnpm-store"],
+      mountsMustExclude: [".aws", "uv-cache"],
+    },
+    packageJson: {
+      scriptsMustInclude: ["prepare", "lint:md", "lint:yaml", "lint:secrets"],
+      scriptsMustExclude: ["lint", "typecheck", "lint:python", "lint:cfn", "lint:tf"],
+    },
+  },
+  {
+    name: "typescript",
+    answers: { languages: ["typescript"] },
+    vscodeSettings: {
+      mustInclude: ["biomejs.biome", "source.fixAll.biome", "**/dist"],
+      mustExclude: ["charliermarsh.ruff", "mypy-type-checker", "cdk.out"],
+    },
+    vscodeExtensions: {
+      mustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
+      mustExclude: ["charliermarsh.ruff", "amazonwebservices.aws-toolkit-vscode"],
+    },
+    devcontainer: {
+      extensionsMustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
+      extensionsMustExclude: ["charliermarsh.ruff", "amazonwebservices.aws-toolkit-vscode"],
+      mountsMustInclude: ["pnpm-store"],
+      mountsMustExclude: [".aws", "uv-cache"],
+    },
+    packageJson: {
+      scriptsMustInclude: ["lint", "typecheck", "test", "build"],
+      scriptsMustExclude: ["lint:python", "lint:mypy", "lint:cfn", "lint:tf"],
+    },
+  },
+  {
+    name: "python",
+    answers: { languages: ["python"] },
+    vscodeSettings: {
+      mustInclude: ["charliermarsh.ruff", "mypy-type-checker.importStrategy"],
+      mustExclude: ["biomejs.biome", "cdk.out"],
+    },
+    vscodeExtensions: {
+      mustInclude: [
+        ...COMMON_EXTENSIONS,
+        "charliermarsh.ruff",
+        "ms-python.mypy-type-checker",
+        "ms-python.python",
+      ],
+      mustExclude: ["biomejs.biome", "amazonwebservices.aws-toolkit-vscode"],
+    },
+    devcontainer: {
+      extensionsMustInclude: [
+        ...COMMON_EXTENSIONS,
+        "charliermarsh.ruff",
+        "ms-python.mypy-type-checker",
+        "ms-python.python",
+      ],
+      extensionsMustExclude: ["biomejs.biome", "amazonwebservices.aws-toolkit-vscode"],
+      mountsMustInclude: ["pnpm-store", "uv-cache"],
+      mountsMustExclude: [".aws"],
+    },
+    packageJson: {
+      scriptsMustInclude: ["lint:python", "lint:mypy"],
+      scriptsMustExclude: ["lint", "typecheck", "lint:cfn", "lint:tf"],
+    },
+  },
+  {
+    name: "typescript + python",
+    answers: { languages: ["typescript", "python"] },
+    vscodeSettings: {
+      mustInclude: ["biomejs.biome", "charliermarsh.ruff", "mypy-type-checker.importStrategy"],
+      mustExclude: ["cdk.out"],
+    },
+    vscodeExtensions: {
+      mustInclude: [
+        ...COMMON_EXTENSIONS,
+        "biomejs.biome",
+        "charliermarsh.ruff",
+        "ms-python.python",
+      ],
+      mustExclude: ["amazonwebservices.aws-toolkit-vscode"],
+    },
+    devcontainer: {
+      extensionsMustInclude: [...COMMON_EXTENSIONS, "biomejs.biome", "charliermarsh.ruff"],
+      extensionsMustExclude: ["amazonwebservices.aws-toolkit-vscode"],
+      mountsMustInclude: ["pnpm-store", "uv-cache"],
+      mountsMustExclude: [".aws"],
+    },
+    packageJson: {
+      scriptsMustInclude: ["lint", "typecheck", "lint:python", "lint:mypy"],
+      scriptsMustExclude: ["lint:cfn", "lint:tf"],
+    },
+  },
+  {
+    name: "cdk",
+    answers: { iac: "cdk" },
+    vscodeSettings: {
+      mustInclude: ["biomejs.biome", "**/cdk.out", "**/dist"],
+      mustExclude: ["charliermarsh.ruff", "mypy-type-checker"],
+    },
+    vscodeExtensions: {
+      mustInclude: [...COMMON_EXTENSIONS, "biomejs.biome", "amazonwebservices.aws-toolkit-vscode"],
+      mustExclude: ["charliermarsh.ruff"],
+    },
+    devcontainer: {
+      extensionsMustInclude: [
+        ...COMMON_EXTENSIONS,
+        "biomejs.biome",
+        "amazonwebservices.aws-toolkit-vscode",
+      ],
+      extensionsMustExclude: ["charliermarsh.ruff"],
+      mountsMustInclude: ["pnpm-store", ".aws"],
+      mountsMustExclude: ["uv-cache"],
+    },
+    packageJson: {
+      scriptsMustInclude: ["lint", "typecheck", "lint:cfn", "cdk:synth"],
+      scriptsMustExclude: ["lint:python", "lint:tf"],
+    },
+  },
+  {
+    name: "cloudformation (ts)",
+    answers: { languages: ["typescript"], iac: "cloudformation" },
+    vscodeSettings: {
+      mustInclude: ["biomejs.biome"],
+      mustExclude: ["cdk.out", "charliermarsh.ruff"],
+    },
+    vscodeExtensions: {
+      mustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
+      mustExclude: ["amazonwebservices.aws-toolkit-vscode"],
+    },
+    devcontainer: {
+      extensionsMustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
+      extensionsMustExclude: ["amazonwebservices.aws-toolkit-vscode"],
+      mountsMustInclude: ["pnpm-store", ".aws"],
+      mountsMustExclude: ["uv-cache"],
+    },
+    packageJson: {
+      scriptsMustInclude: ["lint", "typecheck", "lint:cfn"],
+      scriptsMustExclude: ["lint:python", "lint:tf", "cdk:synth"],
+    },
+  },
+  {
+    name: "terraform (ts)",
+    answers: { languages: ["typescript"], iac: "terraform" },
+    vscodeSettings: {
+      mustInclude: ["biomejs.biome"],
+      mustExclude: ["cdk.out", "charliermarsh.ruff"],
+    },
+    vscodeExtensions: {
+      mustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
+      mustExclude: ["amazonwebservices.aws-toolkit-vscode"],
+    },
+    devcontainer: {
+      extensionsMustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
+      extensionsMustExclude: ["amazonwebservices.aws-toolkit-vscode"],
+      mountsMustInclude: ["pnpm-store", ".aws"],
+      mountsMustExclude: ["uv-cache"],
+    },
+    packageJson: {
+      scriptsMustInclude: ["lint", "typecheck", "lint:tf"],
+      scriptsMustExclude: ["lint:python", "lint:cfn", "cdk:synth"],
+    },
+  },
+  {
+    name: "full config (ts + python + react + cdk)",
+    answers: { languages: ["typescript", "python"], frontend: "react", iac: "cdk" },
+    vscodeSettings: {
+      mustInclude: ["biomejs.biome", "charliermarsh.ruff", "**/cdk.out", "**/dist"],
+      mustExclude: [],
+    },
+    vscodeExtensions: {
+      mustInclude: [
+        ...COMMON_EXTENSIONS,
+        "biomejs.biome",
+        "charliermarsh.ruff",
+        "ms-python.python",
+        "amazonwebservices.aws-toolkit-vscode",
+      ],
+      mustExclude: [],
+    },
+    devcontainer: {
+      extensionsMustInclude: [
+        ...COMMON_EXTENSIONS,
+        "biomejs.biome",
+        "charliermarsh.ruff",
+        "amazonwebservices.aws-toolkit-vscode",
+      ],
+      extensionsMustExclude: [],
+      mountsMustInclude: ["pnpm-store", "uv-cache", ".aws"],
+      mountsMustExclude: [],
+    },
+    packageJson: {
+      scriptsMustInclude: ["lint", "typecheck", "lint:python", "lint:cfn", "lint:all"],
+      scriptsMustExclude: ["lint:tf"],
+    },
+  },
+];
+
+describe("verify: generated output", () => {
+  for (const p of patterns) {
+    describe(p.name, () => {
+      const result = generate(makeAnswers(p.answers));
+
+      it("generates valid JSON for all JSON files", () => {
+        for (const file of result.fileList()) {
+          if (file.endsWith(".json")) {
+            readValidJson(result, file);
+          }
+        }
+      });
+
+      it(".vscode/settings.json has correct preset-specific settings", () => {
+        const text = JSON.stringify(readValidJson(result, ".vscode/settings.json"));
+        for (const s of p.vscodeSettings.mustInclude) {
+          expect(text, `settings.json should contain "${s}"`).toContain(s);
+        }
+        for (const s of p.vscodeSettings.mustExclude) {
+          expect(text, `settings.json should NOT contain "${s}"`).not.toContain(s);
+        }
+      });
+
+      it(".vscode/extensions.json has correct preset-specific extensions", () => {
+        const ext = readValidJson(result, ".vscode/extensions.json");
+        const recs = ext.recommendations as string[];
+        for (const e of p.vscodeExtensions.mustInclude) {
+          expect(recs, `extensions.json should contain "${e}"`).toContain(e);
+        }
+        for (const e of p.vscodeExtensions.mustExclude) {
+          expect(recs, `extensions.json should NOT contain "${e}"`).not.toContain(e);
+        }
+      });
+
+      it("devcontainer.json has correct preset-specific extensions and mounts", () => {
+        const dc = readValidJson(result, ".devcontainer/devcontainer.json");
+        const customizations = dc.customizations as Record<string, Record<string, string[]>>;
+        const extensions = customizations.vscode.extensions;
+        const mounts = dc.mounts as string[];
+
+        for (const e of p.devcontainer.extensionsMustInclude) {
+          expect(extensions, `devcontainer extensions should contain "${e}"`).toContain(e);
+        }
+        for (const e of p.devcontainer.extensionsMustExclude) {
+          expect(extensions, `devcontainer extensions should NOT contain "${e}"`).not.toContain(e);
+        }
+        for (const m of p.devcontainer.mountsMustInclude) {
+          expect(
+            mounts.some((mount: string) => mount.includes(m)),
+            `devcontainer mounts should contain "${m}"`,
+          ).toBe(true);
+        }
+        for (const m of p.devcontainer.mountsMustExclude) {
+          expect(
+            mounts.some((mount: string) => mount.includes(m)),
+            `devcontainer mounts should NOT contain "${m}"`,
+          ).toBe(false);
+        }
+      });
+
+      it("package.json has correct preset-specific scripts", () => {
+        const pkg = readValidJson(result, "package.json");
+        const scripts = pkg.scripts as Record<string, string>;
+        for (const s of p.packageJson.scriptsMustInclude) {
+          expect(scripts, `package.json scripts should have "${s}"`).toHaveProperty(s);
+        }
+        for (const s of p.packageJson.scriptsMustExclude) {
+          expect(scripts, `package.json scripts should NOT have "${s}"`).not.toHaveProperty(s);
+        }
+      });
+
+      it("package.json lint:all includes all lint scripts", () => {
+        const pkg = readValidJson(result, "package.json");
+        const scripts = pkg.scripts as Record<string, string>;
+        if (!scripts["lint:all"]) return; // base-only may not have lint:all
+        const lintAll = scripts["lint:all"];
+        for (const key of Object.keys(scripts).sort()) {
+          if (key.startsWith("lint:") && key !== "lint:all" && key !== "lint:fix") {
+            expect(lintAll, `lint:all should include "pnpm run ${key}"`).toContain(
+              `pnpm run ${key}`,
+            );
+          }
+        }
+      });
+
+      it("devcontainer.json extensions match .vscode/extensions.json", () => {
+        const ext = readValidJson(result, ".vscode/extensions.json");
+        const dc = readValidJson(result, ".devcontainer/devcontainer.json");
+        const vscodeRecs = ext.recommendations as string[];
+        const dcExtensions = (dc.customizations as Record<string, Record<string, string[]>>).vscode
+          .extensions;
+
+        // Every VSCode recommended extension should also be in devcontainer
+        for (const e of vscodeRecs) {
+          expect(dcExtensions, `devcontainer should include VSCode extension "${e}"`).toContain(e);
+        }
+      });
+    });
+  }
+});


### PR DESCRIPTION
## Summary

- 生成出力の動作確認テスト (`tests/verify.test.ts`) を追加（8パターン × 7観点 = 56テスト）
- `pnpm run verify` コマンドを追加
- CLAUDE.md に動作確認必須ルールを追記
- docs/design.md の Testing Strategy に verification tests レベルを追加
- /test スキルに verify テストが含まれる旨を明記

### 検証テストの観点

| 観点 | 内容 |
|------|------|
| JSON validity | 生成される全 JSON ファイルが valid か |
| VSCode settings | プリセット固有の設定が正しく含まれ/除外されるか |
| VSCode extensions | プリセット固有の拡張が正しく含まれ/除外されるか |
| devcontainer extensions | 拡張が正しく構成されるか |
| devcontainer mounts | マウントが正しく構成されるか |
| package.json scripts | プリセット固有のスクリプトが正しく含まれ/除外されるか |
| extension consistency | VSCode 拡張と devcontainer 拡張が一致するか |

## Test plan

- [x] 全 219 テスト通過（163 既存 + 56 verify）
- [x] Biome lint 通過
- [x] Markdown lint 通過
- [x] TypeScript typecheck 通過