### PR TITLE
feat: add cloud provider selection and make IaC multi-select

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ bash scripts/setup.sh
 
 ## Wizard
 
-The interactive wizard asks 4 questions to configure your project:
+The interactive wizard asks 5 questions to configure your project:
 
 | # | Question | Options |
 |---|----------|---------|
 | 1 | Project name | Text input |
 | 2 | Language toolchains | TypeScript / Python (multi-select) |
 | 3 | Frontend app | None / React (Vite) |
-| 4 | Infrastructure as Code | None / AWS CDK / CloudFormation / Terraform / Bicep (Azure) |
+| 4 | Cloud providers | AWS / Azure (multi-select) |
+| 5 | Infrastructure as Code | None / AWS CDK / CloudFormation / Terraform / Bicep (Azure) (multi-select, filtered by cloud providers) |
 
 ## Presets
 
@@ -31,10 +32,12 @@ The interactive wizard asks 4 questions to configure your project:
 | **typescript** | Language: TypeScript | Biome, tsconfig, vitest, tsdown |
 | **python** | Language: Python | Ruff, mypy, uv, pytest |
 | **react** | Frontend: React | Vite, React 19 (forces TypeScript) |
+| **aws** | Cloud: AWS | AWS CLI, MCP: AWS IaC, ~/.aws mount |
+| **azure** | Cloud: Azure | Azure CLI, MCP: Azure, ~/.azure mount |
 | **cdk** | IaC: AWS CDK | CDK v2, cfn-lint, cdk-nag (forces TypeScript) |
 | **cloudformation** | IaC: CloudFormation | cfn-lint, template scaffold |
 | **terraform** | IaC: Terraform | tflint, terraform fmt |
-| **bicep** | IaC: Bicep (Azure) | Azure CLI, bicepconfig.json |
+| **bicep** | IaC: Bicep (Azure) | bicepconfig.json |
 
 Presets are composable: each provides owned files + merge contributions to shared files
 (package.json, .mise.toml, lefthook.yaml, .vscode/settings.json, .vscode/extensions.json,

--- a/docs/design.md
+++ b/docs/design.md
@@ -11,18 +11,19 @@
 
 ## Wizard Selections
 
-4 questions only. Only ask what fundamentally changes project structure.
+5 questions only. Only ask what fundamentally changes project structure.
 
 | # | Question | Type | Options |
 |---|----------|------|---------|
 | 1 | Project name | Text input | — |
 | 2 | Language toolchains | Multi-select | TypeScript / Python |
 | 3 | Frontend app | Single-select | None / React (Vite) |
-| 4 | Infrastructure as Code | Single-select | None / AWS CDK / CloudFormation / Terraform / Bicep (Azure) |
+| 4 | Cloud providers | Multi-select | AWS / Azure |
+| 5 | Infrastructure as Code | Multi-select | None / AWS CDK / CloudFormation / Terraform / Bicep (Azure) (filtered by selected cloud providers) |
 
 ## Presets
 
-8 presets, mapped 1:1 to wizard selections.
+10 presets, mapped 1:1 to wizard selections.
 
 | Preset | Trigger | Requires |
 |--------|---------|----------|
@@ -30,12 +31,14 @@
 | `typescript` | Language: TypeScript | — |
 | `python` | Language: Python | — |
 | `react` | Frontend: React | `typescript` (forced) |
+| `aws` | Cloud: AWS | — |
+| `azure` | Cloud: Azure | — |
 | `cdk` | IaC: AWS CDK | `typescript` (forced) |
 | `cloudformation` | IaC: CloudFormation | — |
 | `terraform` | IaC: Terraform | — |
 | `bicep` | IaC: Bicep (Azure) | — |
 
-Application order: `base → typescript → python → react → cdk / cloudformation / terraform / bicep`
+Application order: `base → typescript → python → react → aws → azure → cdk → cloudformation → terraform → bicep`
 
 ### Always Included (base)
 
@@ -89,6 +92,24 @@ Application order: `base → typescript → python → react → cdk / cloudform
 
 **React (Vite)** — adds: Vite + React dependencies, configuration, boilerplate
 
+### Cloud Provider Selection
+
+**AWS** — adds:
+
+| Element | Files |
+|---------|-------|
+| AWS CLI | via mise |
+| MCP: AWS IaC | `.mcp.json` (auto-added) |
+| devcontainer: ~/.aws mount | `.devcontainer/devcontainer.json` (merge) |
+
+**Azure** — adds:
+
+| Element | Files |
+|---------|-------|
+| Azure CLI | via mise (`pipx:azure-cli`) |
+| MCP: Azure | `.mcp.json` (auto-added) |
+| devcontainer: ~/.azure mount | `.devcontainer/devcontainer.json` (merge) |
+
 ### IaC Selection
 
 **AWS CDK** (forces TypeScript) — adds:
@@ -99,10 +120,9 @@ Application order: `base → typescript → python → react → cdk / cloudform
 | cfn-lint | `.cfnlintrc.yaml` |
 | cdk-nag | `infra/package.json` (dependency) |
 | CD workflow | `.github/workflows/cd.yaml` |
-| MCP: AWS IaC | `.mcp.json` (auto-added) |
 | VSCode: cdk.out search exclude | `.vscode/settings.json` (merge) |
 | VSCode: AWS Toolkit extension | `.vscode/extensions.json` (merge) |
-| devcontainer: AWS Toolkit extension, ~/.aws mount | `.devcontainer/devcontainer.json` (merge) |
+| devcontainer: AWS Toolkit extension | `.devcontainer/devcontainer.json` (merge) |
 
 **CloudFormation** — adds:
 
@@ -111,8 +131,6 @@ Application order: `base → typescript → python → react → cdk / cloudform
 | CFn templates directory | `infra/` (template files) |
 | cfn-lint | `.cfnlintrc.yaml` |
 | CD workflow | `.github/workflows/cd.yaml` |
-| MCP: AWS IaC | `.mcp.json` (auto-added) |
-| devcontainer: ~/.aws mount | `.devcontainer/devcontainer.json` (merge) |
 
 **Terraform** — adds:
 
@@ -121,8 +139,6 @@ Application order: `base → typescript → python → react → cdk / cloudform
 | tflint | `.tflint.hcl` |
 | terraform | via mise |
 | CD workflow | `.github/workflows/cd.yaml` |
-| MCP: AWS IaC | `.mcp.json` (auto-added) |
-| devcontainer: ~/.aws mount | `.devcontainer/devcontainer.json` (merge) |
 
 **Bicep (Azure)** — adds:
 
@@ -130,11 +146,9 @@ Application order: `base → typescript → python → react → cdk / cloudform
 |---------|-------|
 | Bicep templates directory | `infra/` (main.bicep) |
 | bicepconfig.json | `bicepconfig.json` |
-| Azure CLI | via mise (`pipx:azure-cli`) |
 | CD workflow | `.github/workflows/cd.yaml` |
-| MCP: Azure | `.mcp.json` (auto-added) |
 | VSCode: Bicep extension | `.vscode/extensions.json` (merge) |
-| devcontainer: Bicep extension, ~/.azure mount | `.devcontainer/devcontainer.json` (merge) |
+| devcontainer: Bicep extension | `.devcontainer/devcontainer.json` (merge) |
 
 ## Preset Composition
 
@@ -148,14 +162,14 @@ Application order: `base → typescript → python → react → cdk / cloudform
 | Shared file | Modified by |
 |-------------|-------------|
 | `package.json` | base, typescript, python, react, cdk, bicep |
-| `.mise.toml` | base, typescript, python, cdk, cloudformation, terraform, bicep |
+| `.mise.toml` | base, typescript, python, aws, azure, cdk, cloudformation, terraform |
 | `lefthook.yaml` | base, typescript, python |
 | `.github/workflows/ci.yaml` | base, typescript, python, cdk, cloudformation, terraform, bicep |
 | `.github/workflows/cd.yaml` | cdk, cloudformation, terraform, bicep |
-| `.mcp.json` | base, cdk, cloudformation, terraform, bicep |
+| `.mcp.json` | base, aws, azure |
 | `.vscode/settings.json` | typescript, python, cdk |
 | `.vscode/extensions.json` | typescript, python, cdk, bicep |
-| `.devcontainer/devcontainer.json` | typescript, python, cdk, cloudformation, terraform, bicep |
+| `.devcontainer/devcontainer.json` | typescript, python, aws, azure, cdk, bicep |
 | `CLAUDE.md` | all presets |
 | `README.md` | all presets |
 
@@ -194,13 +208,16 @@ React ──────→ TypeScript (forced)
 AWS CDK ────→ TypeScript (forced)
            └→ cfn-lint + cdk-nag
            └→ CD workflow
-           └→ MCP: AWS IaC
 CloudFormation → cfn-lint
               └→ CD workflow
-              └→ MCP: AWS IaC
 Terraform ──→ tflint
            └→ CD workflow
+AWS ────────→ AWS CLI
            └→ MCP: AWS IaC
+           └→ ~/.aws mount
+Azure ──────→ Azure CLI
+           └→ MCP: Azure
+           └→ ~/.azure mount
 ```
 
 ## Not Included (add manually later)
@@ -237,6 +254,8 @@ create-agentic-dev/
 │       ├── typescript.ts
 │       ├── python.ts
 │       ├── react.ts
+│       ├── aws.ts
+│       ├── azure.ts
 │       ├── cdk.ts
 │       ├── cloudformation.ts
 │       └── terraform.ts

--- a/docs/preset-authoring.md
+++ b/docs/preset-authoring.md
@@ -83,6 +83,7 @@ const ALL_PRESETS: Record<string, Preset> = {
 const PRESET_ORDER = [
   "base", "typescript", "python",
   "react", "vue",  // add in logical position
+  "aws", "azure",
   "cdk", "cloudformation", "terraform", "bicep",
 ];
 ```
@@ -355,7 +356,8 @@ function makeAnswers(overrides: Partial<WizardAnswers> = {}): WizardAnswers {
     projectName: "test-app",
     languages: [],
     frontend: "none",
-    iac: "none",
+    clouds: [],
+    iac: [],
     ...overrides,
   };
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,26 +49,55 @@ export async function runWizard(defaultName?: string): Promise<WizardAnswers> {
   });
   handleCancel(frontend);
 
-  const iac = await p.select({
-    message: `${t("wizard.iac.message")} ${pc.dim(t("wizard.iac.hint"))}`,
+  const clouds = await p.multiselect({
+    message: `${t("wizard.clouds.message")} ${pc.dim(t("wizard.clouds.hint"))}`,
     options: [
-      { value: "none" as const, label: t("wizard.iac.none.label") },
-      {
-        value: "cdk" as const,
-        label: t("wizard.iac.cdk.label"),
-        hint: t("wizard.iac.cdk.hint"),
-      },
-      { value: "cloudformation" as const, label: t("wizard.iac.cloudformation.label") },
-      { value: "terraform" as const, label: t("wizard.iac.terraform.label") },
-      { value: "bicep" as const, label: t("wizard.iac.bicep.label") },
+      { value: "aws" as const, label: t("wizard.clouds.aws.label") },
+      { value: "azure" as const, label: t("wizard.clouds.azure.label") },
     ],
+    required: false,
   });
-  handleCancel(iac);
+  handleCancel(clouds);
+
+  const selectedClouds = clouds as WizardAnswers["clouds"];
+  let iac: WizardAnswers["iac"] = [];
+
+  if (selectedClouds.length > 0) {
+    type IacValue = "cdk" | "cloudformation" | "terraform" | "bicep";
+    const iacOptions: Array<{ value: IacValue; label: string; hint?: string }> = [];
+
+    if (selectedClouds.includes("aws")) {
+      iacOptions.push(
+        { value: "cdk", label: t("wizard.iac.cdk.label"), hint: t("wizard.iac.cdk.hint") },
+        { value: "cloudformation", label: t("wizard.iac.cloudformation.label") },
+      );
+    }
+    if (selectedClouds.includes("aws") || selectedClouds.includes("azure")) {
+      // Avoid duplicate if both clouds selected
+      if (!iacOptions.some((o) => o.value === "terraform")) {
+        iacOptions.push({ value: "terraform", label: t("wizard.iac.terraform.label") });
+      }
+    }
+    if (selectedClouds.includes("azure")) {
+      iacOptions.push({ value: "bicep", label: t("wizard.iac.bicep.label") });
+    }
+
+    if (iacOptions.length > 0) {
+      const iacAnswer = await p.multiselect({
+        message: `${t("wizard.iac.message")} ${pc.dim(t("wizard.iac.hint"))}`,
+        options: iacOptions,
+        required: false,
+      });
+      handleCancel(iacAnswer);
+      iac = iacAnswer as WizardAnswers["iac"];
+    }
+  }
 
   return {
     projectName: (projectName as string).trim(),
     languages: languages as WizardAnswers["languages"],
     frontend: frontend as WizardAnswers["frontend"],
-    iac: iac as WizardAnswers["iac"],
+    clouds: selectedClouds,
+    iac,
   };
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,5 +1,7 @@
 import { buildCiWorkflow } from "./ci.js";
 import { expandMarkdown, mergeFile } from "./merge.js";
+import { awsPreset } from "./presets/aws.js";
+import { azurePreset } from "./presets/azure.js";
 import { basePreset } from "./presets/base.js";
 import { bicepPreset } from "./presets/bicep.js";
 import { cdkPreset } from "./presets/cdk.js";
@@ -23,6 +25,8 @@ const ALL_PRESETS: Record<string, Preset> = {
   typescript: typescriptPreset,
   python: pythonPreset,
   react: reactPreset,
+  aws: awsPreset,
+  azure: azurePreset,
   cdk: cdkPreset,
   cloudformation: cloudformationPreset,
   terraform: terraformPreset,
@@ -35,6 +39,8 @@ const PRESET_ORDER = [
   "typescript",
   "python",
   "react",
+  "aws",
+  "azure",
   "cdk",
   "cloudformation",
   "terraform",
@@ -54,11 +60,15 @@ export function resolvePresets(answers: WizardAnswers): string[] {
     selected.add("typescript"); // React forces TypeScript
   }
 
-  if (answers.iac === "cdk") {
-    selected.add("cdk");
-    selected.add("typescript"); // CDK forces TypeScript
-  } else if (answers.iac !== "none") {
-    selected.add(answers.iac);
+  for (const cloud of answers.clouds) {
+    selected.add(cloud);
+  }
+
+  for (const iac of answers.iac) {
+    selected.add(iac);
+    if (iac === "cdk") {
+      selected.add("typescript"); // CDK forces TypeScript
+    }
   }
 
   // Resolve `requires` chains
@@ -195,6 +205,28 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
         .replaceAll(/<!-- SECTION:\w+ -->\n?/g, "")
         .replaceAll(/^(?:\d+\.|-)\s+\*\*[^*]+\*\*:\s*\n(?=\n|#|$)/gm, "");
       allFiles.set(filePath, cleaned);
+    }
+  }
+
+  // 3.5. Generate .tflint.hcl based on cloud providers (if terraform is selected)
+  if (presetNames.includes("terraform")) {
+    const plugins: string[] = [];
+    if (answers.clouds.includes("aws")) {
+      plugins.push(`plugin "aws" {
+  enabled = true
+  version = "0.38.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-aws"
+}`);
+    }
+    if (answers.clouds.includes("azure")) {
+      plugins.push(`plugin "azurerm" {
+  enabled = true
+  version = "0.27.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
+}`);
+    }
+    if (plugins.length > 0) {
+      allFiles.set(".tflint.hcl", `${plugins.join("\n\n")}\n`);
     }
   }
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -20,10 +20,15 @@
       "none": { "label": "None" },
       "react": { "label": "React (Vite)", "hint": "forces TypeScript" }
     },
+    "clouds": {
+      "message": "Cloud providers",
+      "hint": "Select cloud providers to use",
+      "aws": { "label": "AWS" },
+      "azure": { "label": "Azure" }
+    },
     "iac": {
       "message": "Infrastructure as Code",
-      "hint": "Choose a cloud IaC tool or skip",
-      "none": { "label": "None" },
+      "hint": "Select IaC tools",
       "cdk": { "label": "AWS CDK", "hint": "forces TypeScript" },
       "cloudformation": { "label": "CloudFormation" },
       "terraform": { "label": "Terraform" },

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -20,10 +20,15 @@
       "none": { "label": "なし" },
       "react": { "label": "React (Vite)", "hint": "TypeScript が強制されます" }
     },
+    "clouds": {
+      "message": "クラウドプロバイダー",
+      "hint": "使用するクラウドプロバイダーを選択",
+      "aws": { "label": "AWS" },
+      "azure": { "label": "Azure" }
+    },
     "iac": {
       "message": "Infrastructure as Code",
-      "hint": "クラウド IaC ツールを選択（不要なら None）",
-      "none": { "label": "なし" },
+      "hint": "IaC ツールを選択",
       "cdk": { "label": "AWS CDK", "hint": "TypeScript が強制されます" },
       "cloudformation": { "label": "CloudFormation" },
       "terraform": { "label": "Terraform" },

--- a/src/presets/aws.ts
+++ b/src/presets/aws.ts
@@ -1,0 +1,35 @@
+import type { Preset } from "../types.js";
+
+export const awsPreset: Preset = {
+  name: "aws",
+  files: {},
+  merge: {
+    ".mise.toml": {
+      tools: {
+        awscli: "2",
+      },
+    },
+    ".devcontainer/devcontainer.json": {
+      mounts: [
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: devcontainer variable syntax
+        "source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,consistency=cached",
+      ],
+    },
+    ".mcp.json": {
+      mcpServers: {
+        "aws-iac": {
+          command: "uvx",
+          args: ["awslabs.aws-iac-mcp@latest"],
+        },
+      },
+    },
+  },
+  markdown: {
+    "CLAUDE.md": [
+      {
+        placeholder: "<!-- SECTION:TECH_STACK_MCP -->",
+        content: ", AWS IaC",
+      },
+    ],
+  },
+};

--- a/src/presets/azure.ts
+++ b/src/presets/azure.ts
@@ -1,0 +1,35 @@
+import type { Preset } from "../types.js";
+
+export const azurePreset: Preset = {
+  name: "azure",
+  files: {},
+  merge: {
+    ".mise.toml": {
+      tools: {
+        "pipx:azure-cli": "2",
+      },
+    },
+    ".devcontainer/devcontainer.json": {
+      mounts: [
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: devcontainer variable syntax
+        "source=${localEnv:HOME}/.azure,target=/home/vscode/.azure,type=bind,consistency=cached",
+      ],
+    },
+    ".mcp.json": {
+      mcpServers: {
+        azure: {
+          command: "npx",
+          args: ["-y", "@azure/mcp@latest", "server", "start"],
+        },
+      },
+    },
+  },
+  markdown: {
+    "CLAUDE.md": [
+      {
+        placeholder: "<!-- SECTION:TECH_STACK_MCP -->",
+        content: ", Azure",
+      },
+    ],
+  },
+};

--- a/src/presets/bicep.ts
+++ b/src/presets/bicep.ts
@@ -11,11 +11,6 @@ export const bicepPreset: Preset = {
           "find infra -name '*.bicep' -exec az bicep build --file {} --stdout ; > /dev/null",
       },
     },
-    ".mise.toml": {
-      tools: {
-        "pipx:azure-cli": "2",
-      },
-    },
     ".vscode/extensions.json": {
       recommendations: ["ms-azuretools.vscode-bicep"],
     },
@@ -23,18 +18,6 @@ export const bicepPreset: Preset = {
       customizations: {
         vscode: {
           extensions: ["ms-azuretools.vscode-bicep"],
-        },
-      },
-      mounts: [
-        // biome-ignore lint/suspicious/noTemplateCurlyInString: devcontainer variable syntax
-        "source=${localEnv:HOME}/.azure,target=/home/vscode/.azure,type=bind,consistency=cached",
-      ],
-    },
-    ".mcp.json": {
-      mcpServers: {
-        azure: {
-          command: "npx",
-          args: ["-y", "@azure/mcp@latest", "server", "start"],
         },
       },
     },
@@ -48,10 +31,6 @@ export const bicepPreset: Preset = {
       {
         placeholder: "<!-- SECTION:TECH_STACK_LINTING -->",
         content: "  - az bicep build (Bicep)",
-      },
-      {
-        placeholder: "<!-- SECTION:TECH_STACK_MCP -->",
-        content: "- **MCP servers**: Azure — configured in `.mcp.json`",
       },
       {
         placeholder: "<!-- SECTION:PROJECT_STRUCTURE -->",

--- a/src/presets/cdk.ts
+++ b/src/presets/cdk.ts
@@ -17,7 +17,6 @@ export const cdkPreset: Preset = {
     },
     ".mise.toml": {
       tools: {
-        awscli: "2",
         "npm:aws-cdk": "2",
         "pipx:cfn-lint": "1",
       },
@@ -36,18 +35,6 @@ export const cdkPreset: Preset = {
           extensions: ["amazonwebservices.aws-toolkit-vscode"],
         },
       },
-      mounts: [
-        // biome-ignore lint/suspicious/noTemplateCurlyInString: devcontainer variable syntax
-        "source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,consistency=cached",
-      ],
-    },
-    ".mcp.json": {
-      mcpServers: {
-        "aws-iac": {
-          command: "uvx",
-          args: ["awslabs.aws-iac-mcp@latest"],
-        },
-      },
     },
   },
   markdown: {
@@ -59,10 +46,6 @@ export const cdkPreset: Preset = {
       {
         placeholder: "<!-- SECTION:TECH_STACK_LINTING -->",
         content: "  - cfn-lint (CloudFormation)",
-      },
-      {
-        placeholder: "<!-- SECTION:TECH_STACK_MCP -->",
-        content: ", AWS IaC",
       },
       {
         placeholder: "<!-- SECTION:PROJECT_STRUCTURE -->",

--- a/src/presets/cloudformation.ts
+++ b/src/presets/cloudformation.ts
@@ -12,22 +12,7 @@ export const cloudformationPreset: Preset = {
     },
     ".mise.toml": {
       tools: {
-        awscli: "2",
         "pipx:cfn-lint": "1",
-      },
-    },
-    ".devcontainer/devcontainer.json": {
-      mounts: [
-        // biome-ignore lint/suspicious/noTemplateCurlyInString: devcontainer variable syntax
-        "source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,consistency=cached",
-      ],
-    },
-    ".mcp.json": {
-      mcpServers: {
-        "aws-iac": {
-          command: "uvx",
-          args: ["awslabs.aws-iac-mcp@latest"],
-        },
       },
     },
   },
@@ -40,10 +25,6 @@ export const cloudformationPreset: Preset = {
       {
         placeholder: "<!-- SECTION:TECH_STACK_LINTING -->",
         content: "  - cfn-lint (CloudFormation)",
-      },
-      {
-        placeholder: "<!-- SECTION:TECH_STACK_MCP -->",
-        content: "- **MCP servers**: AWS IaC — configured in `.mcp.json`",
       },
       {
         placeholder: "<!-- SECTION:PROJECT_STRUCTURE -->",

--- a/src/presets/terraform.ts
+++ b/src/presets/terraform.ts
@@ -12,23 +12,8 @@ export const terraformPreset: Preset = {
     },
     ".mise.toml": {
       tools: {
-        awscli: "2",
         terraform: "1",
         tflint: "0.55",
-      },
-    },
-    ".devcontainer/devcontainer.json": {
-      mounts: [
-        // biome-ignore lint/suspicious/noTemplateCurlyInString: devcontainer variable syntax
-        "source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,consistency=cached",
-      ],
-    },
-    ".mcp.json": {
-      mcpServers: {
-        "aws-iac": {
-          command: "uvx",
-          args: ["awslabs.aws-iac-mcp@latest"],
-        },
       },
     },
   },
@@ -41,10 +26,6 @@ export const terraformPreset: Preset = {
       {
         placeholder: "<!-- SECTION:TECH_STACK_LINTING -->",
         content: "  - tflint (Terraform)",
-      },
-      {
-        placeholder: "<!-- SECTION:TECH_STACK_MCP -->",
-        content: "- **MCP servers**: AWS IaC — configured in `.mcp.json`",
       },
       {
         placeholder: "<!-- SECTION:PROJECT_STRUCTURE -->",

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,8 @@ export interface WizardAnswers {
   projectName: string;
   languages: Array<"typescript" | "python">;
   frontend: "none" | "react";
-  iac: "none" | "cdk" | "cloudformation" | "terraform" | "bicep";
+  clouds: Array<"aws" | "azure">;
+  iac: Array<"cdk" | "cloudformation" | "terraform" | "bicep">;
 }
 
 // --- Markdown template ---

--- a/templates/terraform/.tflint.hcl
+++ b/templates/terraform/.tflint.hcl
@@ -1,5 +1,0 @@
-plugin "aws" {
-  enabled = true
-  version = "0.38.0"
-  source  = "github.com/terraform-linters/tflint-ruleset-aws"
-}

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -8,7 +8,8 @@ function makeAnswers(overrides: Partial<WizardAnswers> = {}): WizardAnswers {
     projectName: "test-app",
     languages: [],
     frontend: "none",
-    iac: "none",
+    clouds: [],
+    iac: [],
     ...overrides,
   };
 }
@@ -31,21 +32,26 @@ describe("resolvePresets", () => {
   });
 
   it("forces typescript when cdk is selected", () => {
-    const result = resolvePresets(makeAnswers({ iac: "cdk" }));
+    const result = resolvePresets(makeAnswers({ clouds: ["aws"], iac: ["cdk"] }));
     expect(result).toContain("typescript");
     expect(result).toContain("cdk");
   });
 
   it("maintains canonical order", () => {
     const result = resolvePresets(
-      makeAnswers({ languages: ["python", "typescript"], frontend: "react", iac: "cdk" }),
+      makeAnswers({
+        languages: ["python", "typescript"],
+        frontend: "react",
+        clouds: ["aws"],
+        iac: ["cdk"],
+      }),
     );
-    expect(result).toEqual(["base", "typescript", "python", "react", "cdk"]);
+    expect(result).toEqual(["base", "typescript", "python", "react", "aws", "cdk"]);
   });
 
   it("deduplicates typescript when forced by multiple selections", () => {
     const result = resolvePresets(
-      makeAnswers({ languages: ["typescript"], frontend: "react", iac: "cdk" }),
+      makeAnswers({ languages: ["typescript"], frontend: "react", clouds: ["aws"], iac: ["cdk"] }),
     );
     const tsCount = result.filter((p) => p === "typescript").length;
     expect(tsCount).toBe(1);
@@ -648,7 +654,7 @@ describe("generate (react)", () => {
 
 // --- Pattern 5: TypeScript + CDK ---
 describe("generate (cdk)", () => {
-  const answers = makeAnswers({ iac: "cdk" });
+  const answers = makeAnswers({ clouds: ["aws"], iac: ["cdk"] });
   const result = generate(answers);
 
   it("forces TypeScript preset inclusion", () => {
@@ -767,7 +773,11 @@ describe("generate (cdk)", () => {
 
 // --- Pattern 6: TypeScript + CloudFormation ---
 describe("generate (cloudformation)", () => {
-  const answers = makeAnswers({ languages: ["typescript"], iac: "cloudformation" });
+  const answers = makeAnswers({
+    languages: ["typescript"],
+    clouds: ["aws"],
+    iac: ["cloudformation"],
+  });
   const result = generate(answers);
 
   it("includes CloudFormation owned files", () => {
@@ -815,7 +825,7 @@ describe("generate (cloudformation)", () => {
 
 // --- Pattern 7: TypeScript + Terraform ---
 describe("generate (terraform)", () => {
-  const answers = makeAnswers({ languages: ["typescript"], iac: "terraform" });
+  const answers = makeAnswers({ languages: ["typescript"], clouds: ["aws"], iac: ["terraform"] });
   const result = generate(answers);
 
   it("includes Terraform owned files", () => {
@@ -873,7 +883,8 @@ describe("generate (full config)", () => {
   const answers = makeAnswers({
     languages: ["typescript", "python"],
     frontend: "react",
-    iac: "cdk",
+    clouds: ["aws"],
+    iac: ["cdk"],
   });
   const result = generate(answers);
 
@@ -927,7 +938,7 @@ describe("generate (full config)", () => {
 
 // --- Pattern 9: Python + Terraform ---
 describe("generate (python + terraform)", () => {
-  const answers = makeAnswers({ languages: ["python"], iac: "terraform" });
+  const answers = makeAnswers({ languages: ["python"], clouds: ["aws"], iac: ["terraform"] });
   const result = generate(answers);
 
   it("includes Python and Terraform files", () => {
@@ -959,7 +970,7 @@ describe("generate (python + terraform)", () => {
 
 // --- Pattern 10: Python + CloudFormation ---
 describe("generate (python + cloudformation)", () => {
-  const answers = makeAnswers({ languages: ["python"], iac: "cloudformation" });
+  const answers = makeAnswers({ languages: ["python"], clouds: ["aws"], iac: ["cloudformation"] });
   const result = generate(answers);
 
   it("includes Python and CloudFormation files", () => {
@@ -1003,15 +1014,32 @@ describe("file list snapshots", () => {
     { name: "python", answers: { languages: ["python"] } },
     { name: "typescript + python", answers: { languages: ["typescript", "python"] } },
     { name: "react", answers: { frontend: "react" } },
-    { name: "cdk", answers: { iac: "cdk" } },
-    { name: "cloudformation (ts)", answers: { languages: ["typescript"], iac: "cloudformation" } },
-    { name: "terraform (ts)", answers: { languages: ["typescript"], iac: "terraform" } },
+    { name: "cdk", answers: { clouds: ["aws"], iac: ["cdk"] } },
+    {
+      name: "cloudformation (ts)",
+      answers: { languages: ["typescript"], clouds: ["aws"], iac: ["cloudformation"] },
+    },
+    {
+      name: "terraform (ts)",
+      answers: { languages: ["typescript"], clouds: ["aws"], iac: ["terraform"] },
+    },
     {
       name: "full config",
-      answers: { languages: ["typescript", "python"], frontend: "react", iac: "cdk" },
+      answers: {
+        languages: ["typescript", "python"],
+        frontend: "react",
+        clouds: ["aws"],
+        iac: ["cdk"],
+      },
     },
-    { name: "python + terraform", answers: { languages: ["python"], iac: "terraform" } },
-    { name: "python + cloudformation", answers: { languages: ["python"], iac: "cloudformation" } },
+    {
+      name: "python + terraform",
+      answers: { languages: ["python"], clouds: ["aws"], iac: ["terraform"] },
+    },
+    {
+      name: "python + cloudformation",
+      answers: { languages: ["python"], clouds: ["aws"], iac: ["cloudformation"] },
+    },
   ];
 
   for (const { name, answers } of patterns) {

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -12,7 +12,14 @@ import { generate } from "../src/generator.js";
 import type { WizardAnswers } from "../src/types.js";
 
 function makeAnswers(overrides: Partial<WizardAnswers> = {}): WizardAnswers {
-  return { projectName: "verify-app", languages: [], frontend: "none", iac: "none", ...overrides };
+  return {
+    projectName: "verify-app",
+    languages: [],
+    frontend: "none",
+    clouds: [],
+    iac: [],
+    ...overrides,
+  };
 }
 
 // Helper to parse and validate JSON files
@@ -189,8 +196,8 @@ const patterns: PatternDef[] = [
     },
   },
   {
-    name: "cdk",
-    answers: { iac: "cdk" },
+    name: "aws + cdk",
+    answers: { clouds: ["aws"], iac: ["cdk"] },
     vscodeSettings: {
       mustInclude: ["biomejs.biome", "**/cdk.out", "**/dist"],
       mustExclude: ["charliermarsh.ruff", "mypy-type-checker"],
@@ -215,8 +222,8 @@ const patterns: PatternDef[] = [
     },
   },
   {
-    name: "cloudformation (ts)",
-    answers: { languages: ["typescript"], iac: "cloudformation" },
+    name: "aws + cloudformation (ts)",
+    answers: { languages: ["typescript"], clouds: ["aws"], iac: ["cloudformation"] },
     vscodeSettings: {
       mustInclude: ["biomejs.biome"],
       mustExclude: ["cdk.out", "charliermarsh.ruff"],
@@ -237,8 +244,8 @@ const patterns: PatternDef[] = [
     },
   },
   {
-    name: "terraform (ts)",
-    answers: { languages: ["typescript"], iac: "terraform" },
+    name: "aws + terraform (ts)",
+    answers: { languages: ["typescript"], clouds: ["aws"], iac: ["terraform"] },
     vscodeSettings: {
       mustInclude: ["biomejs.biome"],
       mustExclude: ["cdk.out", "charliermarsh.ruff"],
@@ -259,8 +266,8 @@ const patterns: PatternDef[] = [
     },
   },
   {
-    name: "bicep (ts)",
-    answers: { languages: ["typescript"], iac: "bicep" },
+    name: "azure + bicep (ts)",
+    answers: { languages: ["typescript"], clouds: ["azure"], iac: ["bicep"] },
     vscodeSettings: {
       mustInclude: ["biomejs.biome"],
       mustExclude: ["cdk.out", "charliermarsh.ruff"],
@@ -281,8 +288,30 @@ const patterns: PatternDef[] = [
     },
   },
   {
-    name: "bicep (python)",
-    answers: { languages: ["python"], iac: "bicep" },
+    name: "azure + terraform (ts)",
+    answers: { languages: ["typescript"], clouds: ["azure"], iac: ["terraform"] },
+    vscodeSettings: {
+      mustInclude: ["biomejs.biome"],
+      mustExclude: ["cdk.out", "charliermarsh.ruff"],
+    },
+    vscodeExtensions: {
+      mustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
+      mustExclude: ["amazonwebservices.aws-toolkit-vscode", "ms-azuretools.vscode-bicep"],
+    },
+    devcontainer: {
+      extensionsMustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
+      extensionsMustExclude: ["amazonwebservices.aws-toolkit-vscode", "ms-azuretools.vscode-bicep"],
+      mountsMustInclude: ["pnpm-store", ".azure"],
+      mountsMustExclude: [".aws", "uv-cache"],
+    },
+    packageJson: {
+      scriptsMustInclude: ["lint", "typecheck", "lint:tf"],
+      scriptsMustExclude: ["lint:python", "lint:cfn", "cdk:synth", "lint:bicep"],
+    },
+  },
+  {
+    name: "azure + bicep (python)",
+    answers: { languages: ["python"], clouds: ["azure"], iac: ["bicep"] },
     vscodeSettings: {
       mustInclude: ["charliermarsh.ruff"],
       mustExclude: ["biomejs.biome", "cdk.out"],
@@ -307,8 +336,35 @@ const patterns: PatternDef[] = [
     },
   },
   {
-    name: "full config (ts + python + react + cdk)",
-    answers: { languages: ["typescript", "python"], frontend: "react", iac: "cdk" },
+    name: "aws + azure + terraform + bicep (ts)",
+    answers: { languages: ["typescript"], clouds: ["aws", "azure"], iac: ["terraform", "bicep"] },
+    vscodeSettings: {
+      mustInclude: ["biomejs.biome"],
+      mustExclude: ["cdk.out", "charliermarsh.ruff"],
+    },
+    vscodeExtensions: {
+      mustInclude: [...COMMON_EXTENSIONS, "biomejs.biome", "ms-azuretools.vscode-bicep"],
+      mustExclude: [],
+    },
+    devcontainer: {
+      extensionsMustInclude: [...COMMON_EXTENSIONS, "biomejs.biome", "ms-azuretools.vscode-bicep"],
+      extensionsMustExclude: [],
+      mountsMustInclude: ["pnpm-store", ".aws", ".azure"],
+      mountsMustExclude: ["uv-cache"],
+    },
+    packageJson: {
+      scriptsMustInclude: ["lint", "typecheck", "lint:tf", "lint:bicep"],
+      scriptsMustExclude: ["lint:python", "lint:cfn"],
+    },
+  },
+  {
+    name: "full config (ts + python + react + aws + cdk)",
+    answers: {
+      languages: ["typescript", "python"],
+      frontend: "react",
+      clouds: ["aws"],
+      iac: ["cdk"],
+    },
     vscodeSettings: {
       mustInclude: ["biomejs.biome", "charliermarsh.ruff", "**/cdk.out", "**/dist"],
       mustExclude: [],


### PR DESCRIPTION
## Summary

- クラウドプロバイダー（AWS / Azure）の multi-select 質問をウィザードに追加
- IaC 選択を single-select から multi-select に変更し、選択したクラウドプロバイダーに応じてフィルタリング
- クラウド固有ツール（CLI、認証マウント、MCP サーバー）を IaC プリセットから新設の `aws` / `azure` クラウドプリセットに抽出
- Terraform を Azure 対応に（`.tflint.hcl` をクラウド選択に応じて動的生成）

## Changes

### New files
- `src/presets/aws.ts` — AWS クラウドプリセット（awscli, ~/.aws マウント, aws-iac MCP）
- `src/presets/azure.ts` — Azure クラウドプリセット（azure-cli, ~/.azure マウント, azure MCP）

### Modified files
- `src/types.ts` — `clouds` 追加、`iac` を配列型に変更
- `src/generator.ts` — クラウドプリセット登録、resolvePresets 更新、.tflint.hcl 動的生成
- `src/cli.ts` — クラウドプロバイダー質問追加、IaC を multi-select + フィルタリング
- `src/presets/{cdk,cloudformation,terraform,bicep}.ts` — クラウド固有ツールを削除
- `src/i18n/{en,ja}.json` — clouds セクション追加
- `tests/{generator,verify}.test.ts` — 全パターンを新形式に更新
- `docs/design.md`, `README.md`, `docs/preset-authoring.md` — ドキュメント更新

### Deleted files
- `templates/terraform/.tflint.hcl` — ジェネレーターで動的生成に移行

## Test plan

- [x] `pnpm run build` — ビルド成功
- [x] `pnpm test` — 全 247 テスト通過
- [x] `pnpm run verify` — 全 84 検証テスト通過
- [x] `pnpm run typecheck` — 型チェック通過
- [x] 全リンター通過（Biome, markdownlint, gitleaks）