### PR TITLE
fix: unify IaC option labels to use hint for cloud provider names

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The interactive wizard asks 5 questions to configure your project:
 | 2 | Language toolchains | TypeScript / Python (multi-select) |
 | 3 | Frontend app | None / React (Vite) |
 | 4 | Cloud providers | AWS / Azure (multi-select) |
-| 5 | Infrastructure as Code | None / AWS CDK / CloudFormation / Terraform / Bicep (Azure) (multi-select, filtered by cloud providers) |
+| 5 | Infrastructure as Code | None / CDK / CloudFormation / Terraform / Bicep (multi-select, filtered by cloud providers) |
 
 ## Presets
 
@@ -34,10 +34,10 @@ The interactive wizard asks 5 questions to configure your project:
 | **react** | Frontend: React | Vite, React 19 (forces TypeScript) |
 | **aws** | Cloud: AWS | AWS CLI, MCP: AWS IaC, ~/.aws mount |
 | **azure** | Cloud: Azure | Azure CLI, MCP: Azure, ~/.azure mount |
-| **cdk** | IaC: AWS CDK | CDK v2, cfn-lint, cdk-nag (forces TypeScript) |
-| **cloudformation** | IaC: CloudFormation | cfn-lint, template scaffold |
-| **terraform** | IaC: Terraform | tflint, terraform fmt |
-| **bicep** | IaC: Bicep (Azure) | bicepconfig.json |
+| **cdk** | IaC: CDK | CDK v2, cfn-lint, cdk-nag (AWS, forces TypeScript) |
+| **cloudformation** | IaC: CloudFormation | cfn-lint, template scaffold (AWS) |
+| **terraform** | IaC: Terraform | tflint, terraform fmt (AWS, Azure) |
+| **bicep** | IaC: Bicep | bicepconfig.json (Azure) |
 
 Presets are composable: each provides owned files + merge contributions to shared files
 (package.json, .mise.toml, lefthook.yaml, .vscode/settings.json, .vscode/extensions.json,

--- a/docs/design.md
+++ b/docs/design.md
@@ -19,7 +19,7 @@
 | 2 | Language toolchains | Multi-select | TypeScript / Python |
 | 3 | Frontend app | Single-select | None / React (Vite) |
 | 4 | Cloud providers | Multi-select | AWS / Azure |
-| 5 | Infrastructure as Code | Multi-select | None / AWS CDK / CloudFormation / Terraform / Bicep (Azure) (filtered by selected cloud providers) |
+| 5 | Infrastructure as Code | Multi-select | None / CDK / CloudFormation / Terraform / Bicep (filtered by selected cloud providers) |
 
 ## Presets
 
@@ -33,9 +33,9 @@
 | `react` | Frontend: React | `typescript` (forced) |
 | `aws` | Cloud: AWS | — |
 | `azure` | Cloud: Azure | — |
-| `cdk` | IaC: AWS CDK | `typescript` (forced) |
-| `cloudformation` | IaC: CloudFormation | — |
-| `terraform` | IaC: Terraform | — |
+| `cdk` | IaC: CDK (AWS) | `typescript` (forced) |
+| `cloudformation` | IaC: CloudFormation (AWS) | — |
+| `terraform` | IaC: Terraform (AWS, Azure) | — |
 | `bicep` | IaC: Bicep (Azure) | — |
 
 Application order: `base → typescript → python → react → aws → azure → cdk → cloudformation → terraform → bicep`
@@ -112,7 +112,7 @@ Application order: `base → typescript → python → react → aws → azure �
 
 ### IaC Selection
 
-**AWS CDK** (forces TypeScript) — adds:
+**CDK** (AWS, forces TypeScript) — adds:
 
 | Element | Files |
 |---------|-------|
@@ -140,7 +140,7 @@ Application order: `base → typescript → python → react → aws → azure �
 | terraform | via mise |
 | CD workflow | `.github/workflows/cd.yaml` |
 
-**Bicep (Azure)** — adds:
+**Bicep** (Azure) — adds:
 
 | Element | Files |
 |---------|-------|
@@ -205,7 +205,7 @@ interface Preset {
 
 ```text
 React ──────→ TypeScript (forced)
-AWS CDK ────→ TypeScript (forced)
+CDK ────────→ TypeScript (forced)
            └→ cfn-lint + cdk-nag
            └→ CD workflow
 CloudFormation → cfn-lint

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -18,15 +18,24 @@ function buildIacOptions(clouds: Array<"aws" | "azure">): Array<{
   if (clouds.includes("aws")) {
     options.push(
       { value: "cdk", label: t("wizard.iac.cdk.label"), hint: t("wizard.iac.cdk.hint") },
-      { value: "cloudformation", label: t("wizard.iac.cloudformation.label") },
+      {
+        value: "cloudformation",
+        label: t("wizard.iac.cloudformation.label"),
+        hint: t("wizard.iac.cloudformation.hint"),
+      },
     );
   }
   // Terraform is available for both AWS and Azure
   if (clouds.includes("aws") || clouds.includes("azure")) {
-    options.push({ value: "terraform", label: t("wizard.iac.terraform.label") });
+    const tfClouds = clouds.map((c) => t(`wizard.clouds.${c}.label`)).join(", ");
+    options.push({ value: "terraform", label: t("wizard.iac.terraform.label"), hint: tfClouds });
   }
   if (clouds.includes("azure")) {
-    options.push({ value: "bicep", label: t("wizard.iac.bicep.label") });
+    options.push({
+      value: "bicep",
+      label: t("wizard.iac.bicep.label"),
+      hint: t("wizard.iac.bicep.hint"),
+    });
   }
 
   return options;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -29,10 +29,10 @@
     "iac": {
       "message": "Infrastructure as Code",
       "hint": "Select IaC tools",
-      "cdk": { "label": "AWS CDK", "hint": "forces TypeScript" },
-      "cloudformation": { "label": "CloudFormation" },
+      "cdk": { "label": "CDK", "hint": "AWS, forces TypeScript" },
+      "cloudformation": { "label": "CloudFormation", "hint": "AWS" },
       "terraform": { "label": "Terraform" },
-      "bicep": { "label": "Bicep (Azure)" }
+      "bicep": { "label": "Bicep", "hint": "Azure" }
     }
   },
   "overwrite": {

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -29,10 +29,10 @@
     "iac": {
       "message": "Infrastructure as Code",
       "hint": "IaC ツールを選択",
-      "cdk": { "label": "AWS CDK", "hint": "TypeScript が強制されます" },
-      "cloudformation": { "label": "CloudFormation" },
+      "cdk": { "label": "CDK", "hint": "AWS, TypeScript が強制されます" },
+      "cloudformation": { "label": "CloudFormation", "hint": "AWS" },
       "terraform": { "label": "Terraform" },
-      "bicep": { "label": "Bicep (Azure)" }
+      "bicep": { "label": "Bicep", "hint": "Azure" }
     }
   },
   "overwrite": {


### PR DESCRIPTION
## Summary
- IaC 選択肢のクラウドプロバイダー名をラベルのプレフィックス/サフィックスから hint に統一
- CDK: `AWS CDK` → `CDK` *(AWS, forces TypeScript)*
- CloudFormation: `AWS CloudFormation` → `CloudFormation` *(AWS)*
- Bicep: `Azure Bicep` → `Bicep` *(Azure)*
- Terraform: hint なし → 選択されたクラウドに応じて動的に *(AWS)* / *(Azure)* / *(AWS, Azure)* を表示

## Test plan
- [x] `pnpm run build` 通過
- [x] `pnpm test` 全247テスト通過
- [x] `pnpm run typecheck` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)