### PR TITLE
fix: improve generated project quality (MCP example, cfn-lint, CD docs, mypy scope)

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -247,6 +247,19 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
     collapseInfraPlaceholders(sections, "<!-- SECTION:INFRA_DIR_STRUCTURE -->", (names) => {
       return `├── infra/               # インフラストラクチャ (${names})`;
     });
+
+    // Collapse CD_SECTION: wrap table rows with section header
+    const cdSections = sections.filter((s) => s.placeholder === "<!-- SECTION:CD_SECTION -->");
+    if (cdSections.length > 0) {
+      const remaining = sections.filter((s) => s.placeholder !== "<!-- SECTION:CD_SECTION -->");
+      const rows = [...new Set(cdSections.map((s) => s.content))].join("\n");
+      remaining.push({
+        placeholder: "<!-- SECTION:CD_SECTION -->",
+        content: `## デプロイ設定（CD）\n\nCD ワークフローを利用するには、GitHub リポジトリの **Settings → Secrets and variables → Actions → Variables** で以下を設定してください:\n\n| 変数名 | 説明 |\n|--------|------|\n${rows}`,
+      });
+      sections.length = 0;
+      sections.push(...remaining);
+    }
   }
 
   for (const [filePath, sections] of markdownSections) {

--- a/src/presets/bicep.ts
+++ b/src/presets/bicep.ts
@@ -64,6 +64,11 @@ export const bicepPreset: Preset = {
         placeholder: "<!-- SECTION:LINT_COMMANDS -->",
         content: "| `pnpm run lint:bicep` | Bicep リント |",
       },
+      {
+        placeholder: "<!-- SECTION:CD_SECTION -->",
+        content:
+          "| `AZURE_CLIENT_ID` | Azure OIDC 認証用クライアント ID |\n| `AZURE_TENANT_ID` | Azure テナント ID |\n| `AZURE_SUBSCRIPTION_ID` | Azure サブスクリプション ID |\n| `AZURE_RESOURCE_GROUP` | デプロイ先リソースグループ名 |",
+      },
     ],
   },
   ciSteps: {

--- a/src/presets/cdk.ts
+++ b/src/presets/cdk.ts
@@ -14,7 +14,7 @@ export const cdkPreset: Preset = {
         "cdk:diff": "cd infra && npx cdk diff",
         "test:infra": "cd infra && pnpm test",
         "typecheck:infra": "cd infra && tsc --noEmit",
-        "lint:cfn": "cfn-lint",
+        "lint:cfn": "cfn-lint cdk.out/**/*.template.json",
       },
     },
     ".mise.toml": {
@@ -110,6 +110,11 @@ export const cdkPreset: Preset = {
         content:
           "| `pnpm run test:infra` | CDK インフラテスト |\n| `pnpm run cdk:synth` | CDK テンプレート合成 |\n| `pnpm run cdk:diff` | CDK 差分確認 |",
       },
+      {
+        placeholder: "<!-- SECTION:CD_SECTION -->",
+        content:
+          "| `AWS_ROLE_ARN` | CDK デプロイ用 IAM ロール ARN（OIDC 認証） |\n| `AWS_REGION` | AWS リージョン（例: `ap-northeast-1`） |",
+      },
     ],
   },
   ciSteps: {
@@ -117,7 +122,7 @@ export const cdkPreset: Preset = {
       { name: "Install infra dependencies", run: "cd infra && pnpm install --frozen-lockfile" },
       { name: "CDK synth", run: "cd infra && npx cdk synth" },
     ],
-    lintSteps: [{ name: "Lint (cfn-lint)", run: "cfn-lint" }],
+    lintSteps: [{ name: "Lint (cfn-lint)", run: "cfn-lint cdk.out/**/*.template.json" }],
     testSteps: [{ name: "Test (CDK)", run: "cd infra && pnpm test" }],
   },
   setupExtra: "cd infra && pnpm install",

--- a/src/presets/cdk.ts
+++ b/src/presets/cdk.ts
@@ -113,7 +113,7 @@ export const cdkPreset: Preset = {
       {
         placeholder: "<!-- SECTION:CD_SECTION -->",
         content:
-          "| `AWS_ROLE_ARN` | CDK デプロイ用 IAM ロール ARN（OIDC 認証） |\n| `AWS_REGION` | AWS リージョン（例: `ap-northeast-1`） |",
+          "| `AWS_ROLE_ARN` | デプロイ用 IAM ロール ARN（OIDC 認証） |\n| `AWS_REGION` | AWS リージョン（例: `ap-northeast-1`） |",
       },
     ],
   },

--- a/src/presets/cloudformation.ts
+++ b/src/presets/cloudformation.ts
@@ -61,7 +61,7 @@ export const cloudformationPreset: Preset = {
       {
         placeholder: "<!-- SECTION:CD_SECTION -->",
         content:
-          "| `AWS_ROLE_ARN` | CloudFormation デプロイ用 IAM ロール ARN（OIDC 認証） |\n| `AWS_REGION` | AWS リージョン（例: `ap-northeast-1`） |",
+          "| `AWS_ROLE_ARN` | デプロイ用 IAM ロール ARN（OIDC 認証） |\n| `AWS_REGION` | AWS リージョン（例: `ap-northeast-1`） |",
       },
     ],
   },

--- a/src/presets/cloudformation.ts
+++ b/src/presets/cloudformation.ts
@@ -7,7 +7,7 @@ export const cloudformationPreset: Preset = {
   merge: {
     "package.json": {
       scripts: {
-        "lint:cfn": "cfn-lint",
+        "lint:cfn": "cfn-lint infra/template.yaml",
       },
     },
     ".mise.toml": {
@@ -58,9 +58,14 @@ export const cloudformationPreset: Preset = {
         placeholder: "<!-- SECTION:LINT_COMMANDS -->",
         content: "| `pnpm run lint:cfn` | CloudFormation リント |",
       },
+      {
+        placeholder: "<!-- SECTION:CD_SECTION -->",
+        content:
+          "| `AWS_ROLE_ARN` | CloudFormation デプロイ用 IAM ロール ARN（OIDC 認証） |\n| `AWS_REGION` | AWS リージョン（例: `ap-northeast-1`） |",
+      },
     ],
   },
   ciSteps: {
-    lintSteps: [{ name: "Lint (cfn-lint)", run: "cfn-lint" }],
+    lintSteps: [{ name: "Lint (cfn-lint)", run: "cfn-lint infra/template.yaml" }],
   },
 };

--- a/src/presets/python.ts
+++ b/src/presets/python.ts
@@ -9,7 +9,7 @@ export const pythonPreset: Preset = {
       scripts: {
         "test:python": "uv run pytest",
         "lint:python": "ruff check . && ruff format --check .",
-        "lint:mypy": "uv run mypy tests/",
+        "lint:mypy": "uv run mypy .",
       },
     },
     ".gitignore":
@@ -60,7 +60,7 @@ export const pythonPreset: Preset = {
       },
       "pre-push": {
         commands: {
-          mypy: { run: "uv run mypy tests/" },
+          mypy: { run: "uv run mypy ." },
         },
       },
     },
@@ -103,7 +103,7 @@ export const pythonPreset: Preset = {
       },
       {
         placeholder: "<!-- SECTION:GIT_WORKFLOW -->",
-        content: "- Lefthook `pre-push` runs mypy type check (`uv run mypy tests/`)",
+        content: "- Lefthook `pre-push` runs mypy type check (`uv run mypy .`)",
       },
     ],
     ".claude/skills/lint-rules/SKILL.md": [
@@ -113,8 +113,7 @@ export const pythonPreset: Preset = {
       },
       {
         placeholder: "<!-- SECTION:LINT_RULES_TYPECHECK -->",
-        content:
-          "## 型チェック\n\n- 変更ファイルに Python を含む場合は `uv run mypy tests/` も実行する",
+        content: "## 型チェック\n\n- 変更ファイルに Python を含む場合は `uv run mypy .` も実行する",
       },
     ],
     ".claude/skills/test/SKILL.md": [
@@ -179,7 +178,7 @@ export const pythonPreset: Preset = {
     ],
     lintSteps: [
       { name: "Lint (Ruff)", run: "ruff check . && ruff format --check ." },
-      { name: "Typecheck (mypy)", run: "uv run mypy tests/" },
+      { name: "Typecheck (mypy)", run: "uv run mypy ." },
     ],
     testSteps: [{ name: "Test (pytest)", run: "uv run pytest" }],
   },

--- a/src/presets/terraform.ts
+++ b/src/presets/terraform.ts
@@ -64,7 +64,7 @@ export const terraformPreset: Preset = {
       {
         placeholder: "<!-- SECTION:CD_SECTION -->",
         content:
-          "| `AWS_ROLE_ARN` | Terraform デプロイ用 IAM ロール ARN（OIDC 認証） |\n| `AWS_REGION` | AWS リージョン（例: `ap-northeast-1`） |",
+          "| `AWS_ROLE_ARN` | デプロイ用 IAM ロール ARN（OIDC 認証） |\n| `AWS_REGION` | AWS リージョン（例: `ap-northeast-1`） |",
       },
     ],
   },

--- a/src/presets/terraform.ts
+++ b/src/presets/terraform.ts
@@ -61,6 +61,11 @@ export const terraformPreset: Preset = {
         placeholder: "<!-- SECTION:LINT_COMMANDS -->",
         content: "| `pnpm run lint:tf` | Terraform フォーマット + tflint |",
       },
+      {
+        placeholder: "<!-- SECTION:CD_SECTION -->",
+        content:
+          "| `AWS_ROLE_ARN` | Terraform デプロイ用 IAM ロール ARN（OIDC 認証） |\n| `AWS_REGION` | AWS リージョン（例: `ap-northeast-1`） |",
+      },
     ],
   },
   ciSteps: {

--- a/templates/base/.mcp.json.example
+++ b/templates/base/.mcp.json.example
@@ -27,6 +27,10 @@
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-postgres", "${DATABASE_URL}"]
     },
+    "azure": {
+      "command": "npx",
+      "args": ["-y", "@azure/mcp@latest", "server", "start"]
+    },
     "playwright": {
       "command": "npx",
       "args": ["-y", "@anthropic-ai/mcp-server-playwright"]

--- a/templates/base/CLAUDE.md
+++ b/templates/base/CLAUDE.md
@@ -58,7 +58,7 @@ docs/         -> Documentation (branch strategy, etc.)
 
 ```bash
 # Setup
-scripts/setup.sh          # Full environment setup
+scripts/setup.sh          # Full environment setup (初回はロックファイルのコミットも必要)
 mise install               # Install all tools
 <!-- SECTION:SETUP_COMMANDS -->
 

--- a/templates/base/README.md
+++ b/templates/base/README.md
@@ -7,6 +7,7 @@ AI エージェント連携を前提とした開発プロジェクト。
 - WSL2 / Ubuntu 24.04（または互換環境）
 - Git
 - [mise](https://mise.jdx.dev/)（未インストールの場合、setup.sh が自動インストール）
+- `GITHUB_TOKEN` 環境変数（Dev Container ビルド時に mise の GitHub API レートリミット回避に使用）
 
 ## クイックスタート
 
@@ -20,6 +21,8 @@ bash scripts/setup.sh
 1. mise 未インストール時の自動インストール
 1. `mise trust` + `mise install`（全開発ツール）
 <!-- SECTION:SETUP_STEPS -->
+
+> **Note:** 初回セットアップ後、生成されたロックファイル（`pnpm-lock.yaml` 等）を最初のコミットに含めてください。CI の `--frozen-lockfile` が正常に動作するために必要です。
 
 ## ディレクトリ構成
 
@@ -67,6 +70,8 @@ bash scripts/setup.sh
 | コマンド | 説明 |
 |---------|------|
 <!-- SECTION:TEST_COMMANDS -->
+
+<!-- SECTION:CD_SECTION -->
 
 ## Conventional Commits
 

--- a/templates/cdk/infra/bin/app.ts
+++ b/templates/cdk/infra/bin/app.ts
@@ -4,7 +4,7 @@ import { AppStack } from "../lib/app-stack.js";
 
 const app = new cdk.App();
 
-new AppStack(app, "AppStack", {
+new AppStack(app, "{{projectName}}", {
   env: {
     account: process.env.CDK_DEFAULT_ACCOUNT,
     region: process.env.CDK_DEFAULT_REGION,

--- a/templates/terraform/.github/workflows/cd-terraform.yaml
+++ b/templates/terraform/.github/workflows/cd-terraform.yaml
@@ -37,5 +37,8 @@ jobs:
       - name: Terraform init
         run: terraform init
 
+      - name: Terraform plan
+        run: terraform plan -out=tfplan
+
       - name: Terraform apply
-        run: terraform apply -auto-approve
+        run: terraform apply tfplan

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -686,7 +686,7 @@ describe("generate (cdk)", () => {
     expect(scripts["cdk:synth"]).toContain("cdk synth");
     expect(scripts["cdk:deploy"]).toContain("cdk deploy");
     expect(scripts["test:infra"]).toContain("pnpm test");
-    expect(scripts["lint:cfn"]).toBe("cfn-lint");
+    expect(scripts["lint:cfn"]).toBe("cfn-lint cdk.out/**/*.template.json");
   });
 
   it("merges aws-iac MCP server into .mcp.json", () => {


### PR DESCRIPTION
## Summary

- `.mcp.json.example` に Azure MCP サーバーを追加（Bicep プリセット選択時との整合性）
- `cfn-lint` の CI・package.json で明示的にテンプレートパスを指定
- README テンプレートに CD ワークフローの必要変数セクションを追加
- Terraform CD の `terraform apply -auto-approve` を plan 経由に変更
- `mypy` のチェック範囲を `tests/` からプロジェクト全体に拡大
- CDK スタック名にプロジェクト名を反映
- README/CLAUDE.md に lockfile コミットの注記と GITHUB_TOKEN の前提条件を追加

Closes #57

## Test plan

- [x] `pnpm run build` — ビルド成功
- [x] `pnpm test` — 全テスト通過（verify 含む）
- [x] `pnpm run typecheck` — 型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)