### PR TITLE
fix: improve generated project quality (gitignore, devcontainer, CDK, tflint, Renovate)

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -299,7 +299,9 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
 }`);
     }
     if (plugins.length > 0) {
-      allFiles.set(".tflint.hcl", `${plugins.join("\n\n")}\n`);
+      const header =
+        "# NOTE: Plugin versions are not managed by Renovate.\n# Update manually or use `tflint --init` to fetch the latest.\n";
+      allFiles.set(".tflint.hcl", `${header}\n${plugins.join("\n\n")}\n`);
     }
   }
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -300,7 +300,7 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
     }
     if (plugins.length > 0) {
       const header =
-        "# NOTE: Plugin versions are not managed by Renovate.\n# Update manually or use `tflint --init` to fetch the latest.\n";
+        "# NOTE: Plugin versions are not managed by Renovate.\n# Update version numbers manually, then run `tflint --init` to download them.\n";
       allFiles.set(".tflint.hcl", `${header}\n${plugins.join("\n\n")}\n`);
     }
   }

--- a/src/presets/cdk.ts
+++ b/src/presets/cdk.ts
@@ -38,6 +38,16 @@ export const cdkPreset: Preset = {
         },
       },
     },
+    "renovate.json": {
+      packageRules: [
+        {
+          matchPackageNames: ["aws-cdk-lib", "aws-cdk"],
+          groupName: "AWS CDK",
+          matchUpdateTypes: ["major"],
+          dependencyDashboardApproval: true,
+        },
+      ],
+    },
   },
   markdown: {
     "CLAUDE.md": [

--- a/src/presets/react.ts
+++ b/src/presets/react.ts
@@ -6,6 +6,7 @@ export const reactPreset: Preset = {
   requires: ["typescript"],
   files: readTemplateFiles("react"),
   merge: {
+    ".gitignore": "# React (Vite)\n!src/vite-env.d.ts",
     "tsconfig.json": {
       compilerOptions: {
         module: "ESNext",

--- a/templates/base/.devcontainer/post-create.sh
+++ b/templates/base/.devcontainer/post-create.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Replace broken symlinks with pre-resolved content from initialize.sh.
 # Sidecar files (*.__resolved__) contain the actual content that was
 # resolved on the host where symlink targets are accessible.
-for dir in ~/.aws ~/.config/gh; do
+for dir in ~/.aws ~/.azure ~/.config/gh; do
   for resolved in "$dir"/*.__resolved__; do
     [[ -f "$resolved" ]] || continue
     target="${resolved%.__resolved__}"

--- a/templates/cdk/infra/cdk.json
+++ b/templates/cdk/infra/cdk.json
@@ -17,6 +17,13 @@
     "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
     "@aws-cdk/core:checkSecretUsage": true,
     "@aws-cdk-containers/ecs-service-extensions:enableDefaultLogDriver": true,
-    "@aws-cdk/core:target-partitions": ["aws", "aws-cn"]
+    "@aws-cdk/core:target-partitions": ["aws", "aws-cn"],
+    "@aws-cdk/aws-ecs:arnFormatIncludesClusterName": true,
+    "@aws-cdk/aws-apigateway:usagePlanKeyOrderInsensitiveId": true,
+    "@aws-cdk/aws-rds:lowercaseDbIdentifier": true,
+    "@aws-cdk/aws-iam:standardizedServicePrincipal": true,
+    "@aws-cdk/aws-ecs:disableExplicitDeploymentControllerForCircuitBreaker": true,
+    "@aws-cdk/aws-s3:serverAccessLogsUseBucketPolicy": true,
+    "@aws-cdk/customresources:installLatestAwsSdkDefault": false
   }
 }

--- a/templates/cdk/infra/package.json
+++ b/templates/cdk/infra/package.json
@@ -17,7 +17,6 @@
     "constructs": "^10.0.0"
   },
   "devDependencies": {
-    "aws-cdk": "^2.170.0",
     "typescript": "^5.0.0",
     "vitest": "^4.0.0",
     "tsx": "^4.0.0"


### PR DESCRIPTION
## Summary

- React プリセットで `.gitignore` に `!src/vite-env.d.ts` を追加（`*.d.ts` ルールによる誤除外を修正）
- `post-create.sh` のシンボリックリンク解決ループに `~/.azure` を追加（`initialize.sh` との不整合を修正）
- `infra/package.json` から `aws-cdk` を削除（mise で一元管理に統一）
- CDK `cdk.json` の context フィーチャーフラグを最新の CDK v2 デフォルトに更新
- `.tflint.hcl` 生成にメンテナンス注意コメントを追加（Renovate 非対応のため）
- CDK プリセットで Renovate に `aws-cdk-lib` メジャー更新用の専用ルールを追加

Closes #59

## Test plan

- [x] `pnpm run build` 通過
- [x] `pnpm test` 全 259 テスト通過（verify テスト含む）
- [x] `pnpm run typecheck` 通過