### PR TITLE
fix: improve generated project quality (cfn-lint conflict, cdk-nag usage)

### DIFF
--- a/src/presets/cdk.ts
+++ b/src/presets/cdk.ts
@@ -7,6 +7,10 @@ export const cdkPreset: Preset = {
   files: readTemplateFiles("cdk"),
   merge: {
     ".gitignore": "# CDK\ncdk.out/\ncdk.context.json\n!infra/**/*.d.ts",
+    ".cfnlintrc.yaml": {
+      templates: ["infra/cdk.out/**/*.template.json"],
+      ignore_templates: [],
+    },
     "package.json": {
       scripts: {
         "cdk:synth": "cd infra && npx cdk synth",
@@ -14,7 +18,7 @@ export const cdkPreset: Preset = {
         "cdk:diff": "cd infra && npx cdk diff",
         "test:infra": "cd infra && pnpm test",
         "typecheck:infra": "cd infra && tsc --noEmit",
-        "lint:cfn": "cfn-lint cdk.out/**/*.template.json",
+        "lint:cfn": "cfn-lint",
       },
     },
     ".mise.toml": {
@@ -132,7 +136,7 @@ export const cdkPreset: Preset = {
       { name: "Install infra dependencies", run: "cd infra && pnpm install --frozen-lockfile" },
       { name: "CDK synth", run: "cd infra && npx cdk synth" },
     ],
-    lintSteps: [{ name: "Lint (cfn-lint)", run: "cfn-lint cdk.out/**/*.template.json" }],
+    lintSteps: [{ name: "Lint (cfn-lint)", run: "cfn-lint" }],
     testSteps: [{ name: "Test (CDK)", run: "cd infra && pnpm test" }],
   },
   setupExtra: "cd infra && pnpm install",

--- a/src/presets/cloudformation.ts
+++ b/src/presets/cloudformation.ts
@@ -5,9 +5,13 @@ export const cloudformationPreset: Preset = {
   name: "cloudformation",
   files: readTemplateFiles("cloudformation"),
   merge: {
+    ".cfnlintrc.yaml": {
+      templates: ["infra/**/*.yaml"],
+      ignore_templates: [],
+    },
     "package.json": {
       scripts: {
-        "lint:cfn": "cfn-lint infra/template.yaml",
+        "lint:cfn": "cfn-lint",
       },
     },
     ".mise.toml": {
@@ -66,6 +70,6 @@ export const cloudformationPreset: Preset = {
     ],
   },
   ciSteps: {
-    lintSteps: [{ name: "Lint (cfn-lint)", run: "cfn-lint infra/template.yaml" }],
+    lintSteps: [{ name: "Lint (cfn-lint)", run: "cfn-lint" }],
   },
 };

--- a/templates/cdk/.cfnlintrc.yaml
+++ b/templates/cdk/.cfnlintrc.yaml
@@ -1,3 +1,0 @@
-templates:
-  - cdk.out/**/*.template.json
-ignore_templates: []

--- a/templates/cdk/infra/bin/app.ts
+++ b/templates/cdk/infra/bin/app.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import * as cdk from "aws-cdk-lib";
+import { AwsSolutionsChecks } from "cdk-nag";
 import { AppStack } from "../lib/app-stack.js";
 
 const app = new cdk.App();
@@ -10,3 +11,5 @@ new AppStack(app, "{{projectName}}", {
     region: process.env.CDK_DEFAULT_REGION,
   },
 });
+
+cdk.Aspects.of(app).add(new AwsSolutionsChecks({ verbose: true }));

--- a/templates/cloudformation/.cfnlintrc.yaml
+++ b/templates/cloudformation/.cfnlintrc.yaml
@@ -1,3 +1,0 @@
-templates:
-  - infra/**/*.yaml
-ignore_templates: []

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -686,7 +686,7 @@ describe("generate (cdk)", () => {
     expect(scripts["cdk:synth"]).toContain("cdk synth");
     expect(scripts["cdk:deploy"]).toContain("cdk deploy");
     expect(scripts["test:infra"]).toContain("pnpm test");
-    expect(scripts["lint:cfn"]).toBe("cfn-lint cdk.out/**/*.template.json");
+    expect(scripts["lint:cfn"]).toBe("cfn-lint");
   });
 
   it("merges aws-iac MCP server into .mcp.json", () => {


### PR DESCRIPTION
## Summary

- `.cfnlintrc.yaml` を owned ファイルからマージ貢献に移行し、CDK + CloudFormation 併用時に両方のテンプレートパスが自動合成されるように修正
- CDK の cfn-lint パスを修正（`cdk.out/` → `infra/cdk.out/`、プロジェクトルートからの相対パス）
- `lint:cfn` スクリプトと CI ステップを引数なし `cfn-lint` に統一（`.cfnlintrc.yaml` でパス管理）
- CDK テンプレートに `cdk-nag` の `AwsSolutionsChecks` を追加（依存のみで未使用だった）

Closes #61

## Test plan

- [x] `pnpm run build` 通過
- [x] `pnpm test` 全 259 テスト通過（verify テスト含む）
- [x] `pnpm run typecheck` 通過
- [x] 生成プロジェクトで `.cfnlintrc.yaml` に CDK + CFn 両パスが含まれることを確認