### PR TITLE
fix: improve generated project quality (bicep lint, lefthook glob, biome ignore)

### DIFF
--- a/src/presets/base.ts
+++ b/src/presets/base.ts
@@ -56,17 +56,17 @@ export const basePreset: Preset = {
       "pre-commit": {
         parallel: true,
         commands: {
-          shellcheck: { glob: "*.sh", run: "shellcheck {staged_files}" },
-          shfmt: { glob: "*.sh", run: "shfmt -w {staged_files}", stage_fixed: true },
-          taplo: { glob: "*.toml", run: "taplo format {staged_files}", stage_fixed: true },
-          markdownlint: { glob: "*.md", run: "markdownlint-cli2 {staged_files}" },
+          shellcheck: { glob: "**/*.sh", run: "shellcheck {staged_files}" },
+          shfmt: { glob: "**/*.sh", run: "shfmt -w {staged_files}", stage_fixed: true },
+          taplo: { glob: "**/*.toml", run: "taplo format {staged_files}", stage_fixed: true },
+          markdownlint: { glob: "**/*.md", run: "markdownlint-cli2 {staged_files}" },
           yamlfmt: {
-            glob: "*.{yaml,yml}",
+            glob: "**/*.{yaml,yml}",
             run: "yamlfmt {staged_files}",
             stage_fixed: true,
           },
           yamllint: {
-            glob: "*.{yaml,yml}",
+            glob: "**/*.{yaml,yml}",
             run: "yamllint -c .yamllint.yaml {staged_files}",
           },
           dockerfmt: {

--- a/src/presets/bicep.ts
+++ b/src/presets/bicep.ts
@@ -8,7 +8,7 @@ export const bicepPreset: Preset = {
     "package.json": {
       scripts: {
         "lint:bicep":
-          "find infra -name '*.bicep' -exec az bicep build --file {} --stdout ; > /dev/null",
+          "find infra -name '*.bicep' -print0 | xargs -0 -I{} az bicep build --file {} --stdout > /dev/null",
       },
     },
     ".vscode/extensions.json": {
@@ -75,7 +75,7 @@ export const bicepPreset: Preset = {
     lintSteps: [
       {
         name: "Lint (Bicep)",
-        run: "find infra -name '*.bicep' -exec az bicep build --file {} --stdout ; > /dev/null",
+        run: "find infra -name '*.bicep' -print0 | xargs -0 -I{} az bicep build --file {} --stdout > /dev/null",
       },
     ],
   },

--- a/src/presets/cdk.ts
+++ b/src/presets/cdk.ts
@@ -7,6 +7,11 @@ export const cdkPreset: Preset = {
   files: readTemplateFiles("cdk"),
   merge: {
     ".gitignore": "# CDK\ncdk.out/\ncdk.context.json\n!infra/**/*.d.ts",
+    "biome.json": {
+      files: {
+        ignore: ["cdk.out/", "infra/dist/"],
+      },
+    },
     ".cfnlintrc.yaml": {
       templates: ["infra/cdk.out/**/*.template.json"],
       ignore_templates: [],
@@ -34,6 +39,13 @@ export const cdkPreset: Preset = {
     },
     ".vscode/extensions.json": {
       recommendations: ["amazonwebservices.aws-toolkit-vscode"],
+    },
+    "lefthook.yaml": {
+      "pre-push": {
+        commands: {
+          "typecheck-infra": { run: "cd infra && tsc --noEmit" },
+        },
+      },
     },
     ".devcontainer/devcontainer.json": {
       customizations: {
@@ -83,6 +95,20 @@ export const cdkPreset: Preset = {
       {
         placeholder: "<!-- SECTION:CODING_CONVENTIONS -->",
         content: "- CDK: cdk-nag for security best practices",
+      },
+      {
+        placeholder: "<!-- SECTION:PRE_PUSH_HOOKS -->",
+        content: "typecheck-infra (CDK tsc)",
+      },
+      {
+        placeholder: "<!-- SECTION:GIT_WORKFLOW -->",
+        content: "- Lefthook `pre-push` runs CDK TypeScript typecheck (`cd infra && tsc --noEmit`)",
+      },
+    ],
+    ".claude/rules/git-workflow.md": [
+      {
+        placeholder: "<!-- SECTION:GIT_WORKFLOW_PRE_PUSH -->",
+        content: "typecheck-infra",
       },
     ],
     ".claude/skills/lint-rules/SKILL.md": [

--- a/src/presets/cloudformation.ts
+++ b/src/presets/cloudformation.ts
@@ -6,7 +6,7 @@ export const cloudformationPreset: Preset = {
   files: readTemplateFiles("cloudformation"),
   merge: {
     ".cfnlintrc.yaml": {
-      templates: ["infra/**/*.yaml"],
+      templates: ["infra/template.yaml"],
       ignore_templates: [],
     },
     "package.json": {

--- a/src/presets/python.ts
+++ b/src/presets/python.ts
@@ -47,12 +47,12 @@ export const pythonPreset: Preset = {
       "pre-commit": {
         commands: {
           "ruff-format": {
-            glob: "*.py",
+            glob: "**/*.py",
             run: "ruff format {staged_files}",
             stage_fixed: true,
           },
           "ruff-check": {
-            glob: "*.py",
+            glob: "**/*.py",
             run: "ruff check --fix {staged_files}",
             stage_fixed: true,
           },

--- a/src/presets/terraform.ts
+++ b/src/presets/terraform.ts
@@ -18,6 +18,16 @@ export const terraformPreset: Preset = {
         tflint: "0.55",
       },
     },
+    ".vscode/extensions.json": {
+      recommendations: ["hashicorp.terraform"],
+    },
+    ".devcontainer/devcontainer.json": {
+      customizations: {
+        vscode: {
+          extensions: ["hashicorp.terraform"],
+        },
+      },
+    },
   },
   markdown: {
     "CLAUDE.md": [

--- a/src/presets/typescript.ts
+++ b/src/presets/typescript.ts
@@ -67,7 +67,7 @@ export const typescriptPreset: Preset = {
       "pre-commit": {
         commands: {
           biome: {
-            glob: "*.{ts,tsx,js,jsx,json,jsonc}",
+            glob: "**/*.{ts,tsx,js,jsx,json,jsonc}",
             run: "biome check --write {staged_files}",
             stage_fixed: true,
           },

--- a/templates/bicep/.github/workflows/cd-bicep.yaml
+++ b/templates/bicep/.github/workflows/cd-bicep.yaml
@@ -28,6 +28,12 @@ jobs:
           install: "true"
           cache: "true"
 
+      # Required repository variables:
+      #   AZURE_CLIENT_ID       - Azure AD application client ID
+      #   AZURE_TENANT_ID       - Azure AD tenant ID
+      #   AZURE_SUBSCRIPTION_ID - Azure subscription ID
+      #   AZURE_RESOURCE_GROUP  - Target resource group name
+      # See: https://github.com/azure/login
       - name: Azure login (OIDC)
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5
         with:

--- a/templates/cdk/infra/package.json
+++ b/templates/cdk/infra/package.json
@@ -17,6 +17,7 @@
     "constructs": "^10.0.0"
   },
   "devDependencies": {
+    "@types/node": "^22.0.0",
     "typescript": "^5.0.0",
     "vitest": "^4.0.0",
     "tsx": "^4.0.0"

--- a/templates/cloudformation/.github/workflows/cd-cloudformation.yaml
+++ b/templates/cloudformation/.github/workflows/cd-cloudformation.yaml
@@ -28,6 +28,10 @@ jobs:
           install: "true"
           cache: "true"
 
+      # Required repository variables:
+      #   AWS_ROLE_ARN  - IAM role ARN for OIDC authentication
+      #   AWS_REGION    - AWS region (e.g., ap-northeast-1)
+      # See: https://github.com/aws-actions/configure-aws-credentials
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722
         with:

--- a/templates/terraform/.github/workflows/cd-terraform.yaml
+++ b/templates/terraform/.github/workflows/cd-terraform.yaml
@@ -28,6 +28,10 @@ jobs:
           install: "true"
           cache: "true"
 
+      # Required repository variables:
+      #   AWS_ROLE_ARN  - IAM role ARN for OIDC authentication
+      #   AWS_REGION    - AWS region (e.g., ap-northeast-1)
+      # See: https://github.com/aws-actions/configure-aws-credentials
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722
         with:

--- a/templates/terraform/main.tf
+++ b/templates/terraform/main.tf
@@ -2,4 +2,24 @@
 
 terraform {
   required_version = ">= 1.0"
+
+  # TODO: Configure remote backend for state management
+  # backend "s3" {
+  #   bucket = "your-terraform-state-bucket"
+  #   key    = "{{projectName}}/terraform.tfstate"
+  #   region = "ap-northeast-1"
+  # }
+
+  # TODO: Add required providers
+  # required_providers {
+  #   aws = {
+  #     source  = "hashicorp/aws"
+  #     version = "~> 5.0"
+  #   }
+  # }
 }
+
+# TODO: Configure provider
+# provider "aws" {
+#   region = var.region
+# }


### PR DESCRIPTION
## Summary

- Fix `lint:bicep` command syntax (`find -exec` → `xargs` pipeline)
- Fix lefthook glob patterns to `**/*` for all file types (sh, toml, md, yaml, ts, py)
- Add `cdk.out/`, `infra/dist/` to `biome.json` ignore via CDK preset
- Narrow `.cfnlintrc.yaml` templates path to `infra/template.yaml`
- Add `pre-push` `typecheck-infra` for CDK TypeScript
- Add `hashicorp.terraform` VSCode extension for Terraform preset
- Add `@types/node` to CDK `infra/package.json`
- Add provider/backend skeleton comments to Terraform `main.tf`
- Add required variables comments to all CD workflows

Closes #63

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm test` passes (259 tests)
- [x] `pnpm run typecheck` passes
- [x] `pnpm run verify` passes (96 tests)
- [x] Generated full-preset project reviewed — no issues found