### PR TITLE
feat: add Google Cloud preset

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -18,12 +18,12 @@
 | 1 | Project name | Text input | — |
 | 2 | Language toolchains | Multi-select | TypeScript / Python |
 | 3 | Frontend app | Single-select | None / React + Vite / Next.js |
-| 4 | Cloud providers | Multi-select | AWS / Azure |
+| 4 | Cloud providers | Multi-select | AWS / Azure / Google Cloud |
 | 5 | Infrastructure as Code | Multi-select | None / CDK / CloudFormation / Terraform / Bicep (filtered by selected cloud providers) |
 
 ## Presets
 
-11 presets, mapped 1:1 to wizard selections.
+12 presets, mapped 1:1 to wizard selections.
 
 | Preset | Trigger | Requires |
 |--------|---------|----------|
@@ -34,9 +34,10 @@
 | `nextjs` | Frontend: Next.js | `typescript` (forced) |
 | `aws` | Cloud: AWS | — |
 | `azure` | Cloud: Azure | — |
+| `gcp` | Cloud: Google Cloud | — |
 | `cdk` | IaC: CDK (AWS) | `typescript` (forced) |
 | `cloudformation` | IaC: CloudFormation (AWS) | — |
-| `terraform` | IaC: Terraform (AWS, Azure) | — |
+| `terraform` | IaC: Terraform (AWS, Azure, Google Cloud) | — |
 | `bicep` | IaC: Bicep (Azure) | — |
 
 ### プリセットレイヤー
@@ -46,7 +47,7 @@
 | 0 | Base | 常に適用 | `base` |
 | 1 | Language | 複数選択可 | `typescript`, `python` |
 | 2 | Frontend | 単一選択（排他） | `react`, `nextjs` |
-| 3 | Cloud | 複数選択可 | `aws`, `azure` |
+| 3 | Cloud | 複数選択可 | `aws`, `azure`, `gcp` |
 | 4 | IaC | 複数選択可、Cloud に依存 | `cdk`, `cloudformation`, `terraform`, `bicep` |
 
 **相互作用ルール:**
@@ -57,7 +58,7 @@
 
 **新プリセット追加時** は、いずれかのレイヤーに割り当てる。既存レイヤーに該当しない場合は、新レイヤーの追加とウィザードフローの更新を検討する。
 
-Application order: `base → typescript → python → react → nextjs → aws → azure → cdk → cloudformation → terraform → bicep`
+Application order: `base → typescript → python → react → nextjs → aws → azure → gcp → cdk → cloudformation → terraform → bicep`
 
 ### Always Included (base)
 
@@ -131,6 +132,14 @@ Application order: `base → typescript → python → react → nextjs → aws 
 | MCP: Azure | `.mcp.json` (auto-added) |
 | devcontainer: ~/.azure mount | `.devcontainer/devcontainer.json` (merge) |
 
+**Google Cloud** — adds:
+
+| Element | Files |
+|---------|-------|
+| gcloud CLI | via mise |
+| MCP: Google Cloud | `.mcp.json` (auto-added) |
+| devcontainer: ~/.config/gcloud mount | `.devcontainer/devcontainer.json` (merge) |
+
 ### IaC Selection
 
 **CDK** (AWS, forces TypeScript) — adds:
@@ -183,14 +192,14 @@ Application order: `base → typescript → python → react → nextjs → aws 
 | Shared file | Modified by |
 |-------------|-------------|
 | `package.json` | base, typescript, python, react, nextjs, cdk, bicep |
-| `.mise.toml` | base, typescript, python, aws, azure, cdk, cloudformation, terraform |
+| `.mise.toml` | base, typescript, python, aws, azure, gcp, cdk, cloudformation, terraform |
 | `lefthook.yaml` | base, typescript, python |
 | `.github/workflows/ci.yaml` | base, typescript, python, cdk, cloudformation, terraform, bicep |
 | `.github/workflows/cd.yaml` | cdk, cloudformation, terraform, bicep |
-| `.mcp.json` | base, aws, azure |
+| `.mcp.json` | base, aws, azure, gcp |
 | `.vscode/settings.json` | typescript, python, nextjs, cdk |
 | `.vscode/extensions.json` | typescript, python, cdk, bicep |
-| `.devcontainer/devcontainer.json` | typescript, python, aws, azure, cdk, bicep |
+| `.devcontainer/devcontainer.json` | typescript, python, aws, azure, gcp, cdk, bicep |
 | `CLAUDE.md` | all presets |
 | `README.md` | all presets |
 
@@ -240,6 +249,9 @@ AWS ────────→ AWS CLI
 Azure ──────→ Azure CLI
            └→ MCP: Azure
            └→ ~/.azure mount
+GCP ────────→ gcloud CLI
+           └→ MCP: Google Cloud
+           └→ ~/.config/gcloud mount
 ```
 
 ## Not Included (add manually later)
@@ -253,7 +265,6 @@ Azure ──────→ Azure CLI
 
 | 要素 | レイヤー | 備考 |
 |-----|---------|------|
-| Google Cloud | 3 (Cloud) | 次に実装予定（#67） |
 | マルチエージェント対応（Codex 等） | — | 保留。base プリセットから Claude Code 設定を分離する設計変更が前提 |
 | バックエンドFW（Express, FastAPI 等） | — | 保留。モノレポ対応とテスト戦略の見直しが前提 |
 | Vue / Nuxt | 2 (Frontend) | 必要になったら追加 |
@@ -294,6 +305,7 @@ create-agentic-dev/
 │       ├── nextjs.ts
 │       ├── aws.ts
 │       ├── azure.ts
+│       ├── gcp.ts
 │       ├── cdk.ts
 │       ├── cloudformation.ts
 │       └── terraform.ts

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,7 @@ import { t } from "./i18n/index.js";
 import type { WizardAnswers } from "./types.js";
 
 /** Build IaC options filtered by selected cloud providers. */
-function buildIacOptions(clouds: Array<"aws" | "azure">): Array<{
+function buildIacOptions(clouds: Array<"aws" | "azure" | "gcp">): Array<{
   value: "cdk" | "cloudformation" | "terraform" | "bicep";
   label: string;
   hint?: string;
@@ -25,8 +25,8 @@ function buildIacOptions(clouds: Array<"aws" | "azure">): Array<{
       },
     );
   }
-  // Terraform is available for both AWS and Azure
-  if (clouds.includes("aws") || clouds.includes("azure")) {
+  // Terraform is available for AWS, Azure, and Google Cloud
+  if (clouds.includes("aws") || clouds.includes("azure") || clouds.includes("gcp")) {
     const tfClouds = clouds.map((c) => t(`wizard.clouds.${c}.label`)).join(", ");
     options.push({ value: "terraform", label: t("wizard.iac.terraform.label"), hint: tfClouds });
   }
@@ -90,6 +90,7 @@ export async function runWizard(defaultName?: string): Promise<WizardAnswers> {
           options: [
             { value: "aws" as const, label: t("wizard.clouds.aws.label") },
             { value: "azure" as const, label: t("wizard.clouds.azure.label") },
+            { value: "gcp" as const, label: t("wizard.clouds.gcp.label") },
           ],
           required: false,
         }),

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -6,6 +6,7 @@ import { basePreset } from "./presets/base.js";
 import { bicepPreset } from "./presets/bicep.js";
 import { cdkPreset } from "./presets/cdk.js";
 import { cloudformationPreset } from "./presets/cloudformation.js";
+import { gcpPreset } from "./presets/gcp.js";
 import { nextjsPreset } from "./presets/nextjs.js";
 import { pythonPreset } from "./presets/python.js";
 import { reactPreset } from "./presets/react.js";
@@ -29,6 +30,7 @@ const ALL_PRESETS: Record<string, Preset> = {
   nextjs: nextjsPreset,
   aws: awsPreset,
   azure: azurePreset,
+  gcp: gcpPreset,
   cdk: cdkPreset,
   cloudformation: cloudformationPreset,
   terraform: terraformPreset,
@@ -68,6 +70,7 @@ const PRESET_ORDER = [
   "nextjs",
   "aws",
   "azure",
+  "gcp",
   "cdk",
   "cloudformation",
   "terraform",
@@ -299,6 +302,13 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
   enabled = true
   version = "0.27.0"
   source  = "github.com/terraform-linters/tflint-ruleset-azurerm"
+}`);
+    }
+    if (answers.clouds.includes("gcp")) {
+      plugins.push(`plugin "google" {
+  enabled = true
+  version = "0.38.0"
+  source  = "github.com/terraform-linters/tflint-ruleset-google"
 }`);
     }
     if (plugins.length > 0) {

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -25,7 +25,8 @@
       "message": "Cloud providers",
       "hint": "Select cloud providers to use",
       "aws": { "label": "AWS" },
-      "azure": { "label": "Azure" }
+      "azure": { "label": "Azure" },
+      "gcp": { "label": "Google Cloud" }
     },
     "iac": {
       "message": "Infrastructure as Code",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -25,7 +25,8 @@
       "message": "クラウドプロバイダー",
       "hint": "使用するクラウドプロバイダーを選択",
       "aws": { "label": "AWS" },
-      "azure": { "label": "Azure" }
+      "azure": { "label": "Azure" },
+      "gcp": { "label": "Google Cloud" }
     },
     "iac": {
       "message": "Infrastructure as Code",

--- a/src/presets/gcp.ts
+++ b/src/presets/gcp.ts
@@ -1,0 +1,35 @@
+import type { Preset } from "../types.js";
+
+export const gcpPreset: Preset = {
+  name: "gcp",
+  files: {},
+  merge: {
+    ".mise.toml": {
+      tools: {
+        gcloud: "latest",
+      },
+    },
+    ".devcontainer/devcontainer.json": {
+      mounts: [
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: devcontainer variable syntax
+        "source=${localEnv:HOME}/.config/gcloud,target=/home/vscode/.config/gcloud,type=bind,consistency=cached",
+      ],
+    },
+    ".mcp.json": {
+      mcpServers: {
+        "google-cloud": {
+          command: "npx",
+          args: ["-y", "@google-cloud/gcloud-mcp"],
+        },
+      },
+    },
+  },
+  markdown: {
+    "CLAUDE.md": [
+      {
+        placeholder: "<!-- SECTION:TECH_STACK_MCP -->",
+        content: "Google Cloud",
+      },
+    ],
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export interface WizardAnswers {
   projectName: string;
   languages: Array<"typescript" | "python">;
   frontend: "none" | "react" | "nextjs";
-  clouds: Array<"aws" | "azure">;
+  clouds: Array<"aws" | "azure" | "gcp">;
   iac: Array<"cdk" | "cloudformation" | "terraform" | "bicep">;
 }
 

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -43,6 +43,11 @@ describe("resolvePresets", () => {
     expect(result).toContain("cdk");
   });
 
+  it("includes gcp when selected", () => {
+    const result = resolvePresets(makeAnswers({ clouds: ["gcp"] }));
+    expect(result).toContain("gcp");
+  });
+
   it("maintains canonical order", () => {
     const result = resolvePresets(
       makeAnswers({
@@ -53,6 +58,17 @@ describe("resolvePresets", () => {
       }),
     );
     expect(result).toEqual(["base", "typescript", "python", "react", "aws", "cdk"]);
+  });
+
+  it("maintains canonical order with gcp", () => {
+    const result = resolvePresets(
+      makeAnswers({
+        languages: ["typescript"],
+        clouds: ["aws", "azure", "gcp"],
+        iac: ["terraform"],
+      }),
+    );
+    expect(result).toEqual(["base", "typescript", "aws", "azure", "gcp", "terraform"]);
   });
 
   it("deduplicates typescript when forced by multiple selections", () => {

--- a/tests/verify.test.ts
+++ b/tests/verify.test.ts
@@ -91,7 +91,7 @@ const patterns: PatternDef[] = [
         "ms-azuretools.vscode-bicep",
       ],
       mountsMustInclude: ["pnpm-store"],
-      mountsMustExclude: [".aws", ".azure", "uv-cache"],
+      mountsMustExclude: [".aws", ".azure", ".config/gcloud", "uv-cache"],
     },
     packageJson: {
       scriptsMustInclude: ["prepare", "lint:md", "lint:yaml", "lint:secrets"],
@@ -121,7 +121,7 @@ const patterns: PatternDef[] = [
         "ms-azuretools.vscode-bicep",
       ],
       mountsMustInclude: ["pnpm-store"],
-      mountsMustExclude: [".aws", ".azure", "uv-cache"],
+      mountsMustExclude: [".aws", ".azure", ".config/gcloud", "uv-cache"],
     },
     packageJson: {
       scriptsMustInclude: ["lint", "typecheck", "test", "build"],
@@ -161,7 +161,7 @@ const patterns: PatternDef[] = [
         "ms-azuretools.vscode-bicep",
       ],
       mountsMustInclude: ["pnpm-store", "uv-cache"],
-      mountsMustExclude: [".aws", ".azure"],
+      mountsMustExclude: [".aws", ".azure", ".config/gcloud"],
     },
     packageJson: {
       scriptsMustInclude: ["lint:python", "lint:mypy"],
@@ -188,7 +188,7 @@ const patterns: PatternDef[] = [
       extensionsMustInclude: [...COMMON_EXTENSIONS, "biomejs.biome", "charliermarsh.ruff"],
       extensionsMustExclude: ["amazonwebservices.aws-toolkit-vscode", "ms-azuretools.vscode-bicep"],
       mountsMustInclude: ["pnpm-store", "uv-cache"],
-      mountsMustExclude: [".aws", ".azure"],
+      mountsMustExclude: [".aws", ".azure", ".config/gcloud"],
     },
     packageJson: {
       scriptsMustInclude: ["lint", "typecheck", "lint:python", "lint:mypy"],
@@ -214,7 +214,7 @@ const patterns: PatternDef[] = [
       ],
       extensionsMustExclude: ["charliermarsh.ruff", "ms-azuretools.vscode-bicep"],
       mountsMustInclude: ["pnpm-store", ".aws"],
-      mountsMustExclude: ["uv-cache", ".azure"],
+      mountsMustExclude: ["uv-cache", ".azure", ".config/gcloud"],
     },
     packageJson: {
       scriptsMustInclude: ["lint", "typecheck", "lint:cfn", "cdk:synth"],
@@ -236,7 +236,7 @@ const patterns: PatternDef[] = [
       extensionsMustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
       extensionsMustExclude: ["amazonwebservices.aws-toolkit-vscode", "ms-azuretools.vscode-bicep"],
       mountsMustInclude: ["pnpm-store", ".aws"],
-      mountsMustExclude: ["uv-cache", ".azure"],
+      mountsMustExclude: ["uv-cache", ".azure", ".config/gcloud"],
     },
     packageJson: {
       scriptsMustInclude: ["lint", "typecheck", "lint:cfn"],
@@ -258,7 +258,7 @@ const patterns: PatternDef[] = [
       extensionsMustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
       extensionsMustExclude: ["amazonwebservices.aws-toolkit-vscode", "ms-azuretools.vscode-bicep"],
       mountsMustInclude: ["pnpm-store", ".aws"],
-      mountsMustExclude: ["uv-cache", ".azure"],
+      mountsMustExclude: ["uv-cache", ".azure", ".config/gcloud"],
     },
     packageJson: {
       scriptsMustInclude: ["lint", "typecheck", "lint:tf"],
@@ -280,11 +280,33 @@ const patterns: PatternDef[] = [
       extensionsMustInclude: [...COMMON_EXTENSIONS, "biomejs.biome", "ms-azuretools.vscode-bicep"],
       extensionsMustExclude: ["amazonwebservices.aws-toolkit-vscode"],
       mountsMustInclude: ["pnpm-store", ".azure"],
-      mountsMustExclude: [".aws", "uv-cache"],
+      mountsMustExclude: [".aws", ".config/gcloud", "uv-cache"],
     },
     packageJson: {
       scriptsMustInclude: ["lint", "typecheck", "lint:bicep"],
       scriptsMustExclude: ["lint:python", "lint:cfn", "lint:tf", "cdk:synth"],
+    },
+  },
+  {
+    name: "gcp + terraform (ts)",
+    answers: { languages: ["typescript"], clouds: ["gcp"], iac: ["terraform"] },
+    vscodeSettings: {
+      mustInclude: ["biomejs.biome"],
+      mustExclude: ["cdk.out", "charliermarsh.ruff"],
+    },
+    vscodeExtensions: {
+      mustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
+      mustExclude: ["amazonwebservices.aws-toolkit-vscode", "ms-azuretools.vscode-bicep"],
+    },
+    devcontainer: {
+      extensionsMustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
+      extensionsMustExclude: ["amazonwebservices.aws-toolkit-vscode", "ms-azuretools.vscode-bicep"],
+      mountsMustInclude: ["pnpm-store", ".config/gcloud"],
+      mountsMustExclude: [".aws", ".azure", "uv-cache"],
+    },
+    packageJson: {
+      scriptsMustInclude: ["lint", "typecheck", "lint:tf"],
+      scriptsMustExclude: ["lint:python", "lint:cfn", "cdk:synth", "lint:bicep"],
     },
   },
   {
@@ -302,7 +324,7 @@ const patterns: PatternDef[] = [
       extensionsMustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
       extensionsMustExclude: ["amazonwebservices.aws-toolkit-vscode", "ms-azuretools.vscode-bicep"],
       mountsMustInclude: ["pnpm-store", ".azure"],
-      mountsMustExclude: [".aws", "uv-cache"],
+      mountsMustExclude: [".aws", ".config/gcloud", "uv-cache"],
     },
     packageJson: {
       scriptsMustInclude: ["lint", "typecheck", "lint:tf"],
@@ -328,7 +350,7 @@ const patterns: PatternDef[] = [
       ],
       extensionsMustExclude: ["biomejs.biome", "amazonwebservices.aws-toolkit-vscode"],
       mountsMustInclude: ["pnpm-store", "uv-cache", ".azure"],
-      mountsMustExclude: [".aws"],
+      mountsMustExclude: [".aws", ".config/gcloud"],
     },
     packageJson: {
       scriptsMustInclude: ["lint:python", "lint:bicep"],
@@ -350,7 +372,7 @@ const patterns: PatternDef[] = [
       extensionsMustInclude: [...COMMON_EXTENSIONS, "biomejs.biome", "ms-azuretools.vscode-bicep"],
       extensionsMustExclude: [],
       mountsMustInclude: ["pnpm-store", ".aws", ".azure"],
-      mountsMustExclude: ["uv-cache"],
+      mountsMustExclude: [".config/gcloud", "uv-cache"],
     },
     packageJson: {
       scriptsMustInclude: ["lint", "typecheck", "lint:tf", "lint:bicep"],
@@ -380,7 +402,7 @@ const patterns: PatternDef[] = [
         "ms-azuretools.vscode-bicep",
       ],
       mountsMustInclude: ["pnpm-store"],
-      mountsMustExclude: [".aws", ".azure", "uv-cache"],
+      mountsMustExclude: [".aws", ".azure", ".config/gcloud", "uv-cache"],
     },
     packageJson: {
       scriptsMustInclude: ["lint", "typecheck", "test", "build"],
@@ -388,12 +410,12 @@ const patterns: PatternDef[] = [
     },
   },
   {
-    name: "full config (ts + python + react + aws + cdk)",
+    name: "full config (ts + python + react + aws + gcp + cdk + terraform)",
     answers: {
       languages: ["typescript", "python"],
       frontend: "react",
-      clouds: ["aws"],
-      iac: ["cdk"],
+      clouds: ["aws", "gcp"],
+      iac: ["cdk", "terraform"],
     },
     vscodeSettings: {
       mustInclude: ["biomejs.biome", "charliermarsh.ruff", "**/cdk.out", "**/dist"],
@@ -417,12 +439,12 @@ const patterns: PatternDef[] = [
         "amazonwebservices.aws-toolkit-vscode",
       ],
       extensionsMustExclude: [],
-      mountsMustInclude: ["pnpm-store", "uv-cache", ".aws"],
+      mountsMustInclude: ["pnpm-store", "uv-cache", ".aws", ".config/gcloud"],
       mountsMustExclude: [],
     },
     packageJson: {
-      scriptsMustInclude: ["lint", "typecheck", "lint:python", "lint:cfn", "lint:all"],
-      scriptsMustExclude: ["lint:tf", "lint:bicep"],
+      scriptsMustInclude: ["lint", "typecheck", "lint:python", "lint:cfn", "lint:tf", "lint:all"],
+      scriptsMustExclude: ["lint:bicep"],
     },
   },
 ];
@@ -634,6 +656,16 @@ describe("verify: CLAUDE.md MCP servers", () => {
     expect(mcpLine).not.toMatch(/, ,/);
     expect(mcpLine).toContain("AWS IaC");
     expect(mcpLine).toContain("Azure");
+  });
+
+  it("has Google Cloud in MCP servers when gcp is selected", () => {
+    const result = generate(
+      makeAnswers({ languages: ["typescript"], clouds: ["gcp"], iac: ["terraform"] }),
+    );
+    const claude = result.readText("CLAUDE.md");
+    const mcpLine = claude.split("\n").find((l) => l.includes("MCP servers"));
+    expect(mcpLine).toBeDefined();
+    expect(mcpLine).toContain("Google Cloud");
   });
 
   it("has comma separator between base and injected MCP servers", () => {


### PR DESCRIPTION
## Summary

Closes #67

- Cloud カテゴリに Google Cloud プリセットを追加（AWS/Azure と同構造の merge-only プリセット）
- ウィザード Q4 に Google Cloud 選択肢を追加、Q5 で GCP 選択時に Terraform を利用可能に
- tflint に `tflint-ruleset-google` プラグインを追加（GCP + Terraform 選択時）
- devcontainer に `~/.config/gcloud` マウントを追加
- MCP サーバーに `@google-cloud/gcloud-mcp`（Google 公式）を追加

## Changes

- `src/types.ts` — `clouds` 型に `"gcp"` 追加
- `src/presets/gcp.ts` — Google Cloud プリセット（新規）
- `src/generator.ts` — import, ALL_PRESETS, PRESET_ORDER, tflint プラグイン追加
- `src/cli.ts` — ウィザードに Google Cloud 選択肢追加、IaC フィルタリング更新
- `src/i18n/en.json`, `src/i18n/ja.json` — `wizard.clouds.gcp.label` 追加
- `tests/generator.test.ts` — resolvePresets テスト追加
- `tests/verify.test.ts` — `gcp + terraform (ts)` パターン追加、full config 拡張、既存パターンの mountsMustExclude 更新
- `docs/design.md` — 各テーブルに Google Cloud 追加

## Test plan

- [x] `pnpm run build` — ビルド成功
- [x] `pnpm test` — 全 292 テスト通過
- [x] `pnpm run typecheck` — 型チェック通過
- [x] Biome lint 通過
- [x] gitleaks 通過