### PR TITLE
fix: improve generated project quality (Ruff select, Renovate biome schema)

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -8,6 +8,7 @@ pre-commit:
   commands:
     biome:
       glob: "*.{ts,tsx,js,jsx,json,jsonc}"
+      exclude: "templates/**"
       run: biome check --write {staged_files}
       stage_fixed: true
     shellcheck:

--- a/templates/base/renovate.json
+++ b/templates/base/renovate.json
@@ -3,6 +3,15 @@
   "extends": ["config:recommended"],
   "minimumReleaseAge": "3 days",
   "automergeType": "pr",
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^biome\\.json$"],
+      "matchStrings": ["\"\\$schema\":\\s*\"https://biomejs\\.dev/schemas/(?<currentValue>[\\d.]+)/schema\\.json\""],
+      "depNameTemplate": "@biomejs/biome",
+      "datasourceTemplate": "npm"
+    }
+  ],
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "minor"],

--- a/templates/python/pyproject.toml
+++ b/templates/python/pyproject.toml
@@ -10,12 +10,19 @@ dev = ["pytest"]
 line-length = 100
 
 [tool.ruff.lint]
-select = ["ALL"]
-ignore = [
-  "D",      # pydocstyle
-  "ANN",    # flake8-annotations (gradual adoption)
-  "ERA001", # commented-out code
-  "T201",   # print
+select = [
+  "E",   # pycodestyle errors
+  "W",   # pycodestyle warnings
+  "F",   # pyflakes
+  "I",   # isort
+  "S",   # flake8-bandit (security)
+  "B",   # flake8-bugbear
+  "A",   # flake8-builtins
+  "C4",  # flake8-comprehensions
+  "UP",  # pyupgrade
+  "SIM", # flake8-simplify
+  "TCH", # flake8-type-checking
+  "RUF", # Ruff-specific rules
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/templates/python/pyproject.toml
+++ b/templates/python/pyproject.toml
@@ -26,7 +26,7 @@ select = [
 ]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**/*.py" = ["S101", "PLR2004"]
+"tests/**/*.py" = ["S101"]
 
 [tool.mypy]
 python_version = "3.12"


### PR DESCRIPTION
## Summary

Closes #70

生成されるプロジェクトの品質改善:

- **Ruff ルール明示化**: `select = ["ALL"]` を明示的なルールセット（E, W, F, I, S, B, A, C4, UP, SIM, TCH, RUF）に変更。Ruff の新バージョンでルール追加時に CI が壊れるリスクを解消
- **Biome schema 自動更新**: Renovate の customManagers（regex）を追加し、`biome.json` の `$schema` URL バージョンを自動更新
- **lefthook biome exclude**: templates ディレクトリを biome pre-commit hook から除外（biome.json の exclude と整合）

## Test plan

- [x] `pnpm run build` 成功
- [x] `pnpm test` 全 292 テスト通過
- [x] `pnpm run typecheck` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)