### PR TITLE
feat: add Express preset

### DIFF
--- a/src/presets/express.ts
+++ b/src/presets/express.ts
@@ -1,8 +1,130 @@
 import type { Preset } from "../types.js";
+import { readTemplateFiles } from "../utils.js";
 
 export const expressPreset: Preset = {
   name: "express",
   requires: ["typescript"],
-  files: {},
-  merge: {},
+  files: readTemplateFiles("express"),
+  merge: {
+    "package.json": {
+      scripts: {
+        "dev:api": "cd api && pnpm run dev",
+        "test:api": "cd api && pnpm test",
+        "build:api": "cd api && pnpm run build",
+        "typecheck:api": "cd api && tsc --noEmit",
+      },
+    },
+    "biome.json": {
+      files: {
+        includes: ["!**/api/dist/"],
+      },
+    },
+    ".devcontainer/devcontainer.json": {
+      forwardPorts: [3000],
+    },
+    "lefthook.yaml": {
+      "pre-push": {
+        commands: {
+          "typecheck-api": { run: "cd api && tsc --noEmit" },
+        },
+      },
+    },
+  },
+  markdown: {
+    "CLAUDE.md": [
+      {
+        placeholder: "<!-- SECTION:TECH_STACK -->",
+        content: "- **Backend**: Express (TypeScript, tsdown)",
+      },
+      {
+        placeholder: "<!-- SECTION:PROJECT_STRUCTURE -->",
+        content: "api/          -> Backend API (Express)",
+      },
+      {
+        placeholder: "<!-- SECTION:SETUP_COMMANDS -->",
+        content: "cd api && pnpm install    # Install API dependencies",
+      },
+      {
+        placeholder: "<!-- SECTION:LINT_COMMANDS -->",
+        content:
+          "pnpm run typecheck:api     # API TypeScript type check\npnpm run test:api          # Express tests (vitest)",
+      },
+      {
+        placeholder: "<!-- SECTION:TEST_COMMANDS -->",
+        content: "cd api && pnpm test        # Run API tests",
+      },
+      {
+        placeholder: "<!-- SECTION:CODING_CONVENTIONS -->",
+        content:
+          "- Express: export `app` from app.ts, `app.listen()` only in index.ts\n- API tests: supertest with imported app instance",
+      },
+      {
+        placeholder: "<!-- SECTION:PRE_PUSH_HOOKS -->",
+        content: "typecheck-api (API tsc)",
+      },
+      {
+        placeholder: "<!-- SECTION:GIT_WORKFLOW -->",
+        content: "- Lefthook `pre-push` runs API TypeScript typecheck (`cd api && tsc --noEmit`)",
+      },
+    ],
+    ".claude/rules/git-workflow.md": [
+      {
+        placeholder: "<!-- SECTION:GIT_WORKFLOW_PRE_PUSH -->",
+        content: "typecheck-api",
+      },
+    ],
+    ".claude/skills/lint-rules/SKILL.md": [
+      {
+        placeholder: "<!-- SECTION:LINT_RULES_TABLE -->",
+        content: "| `api/**/*.ts` | `biome check --fix <files>` (root biome.json) |",
+      },
+      {
+        placeholder: "<!-- SECTION:LINT_RULES_TYPECHECK -->",
+        content:
+          "## 型チェック（API）\n\n- 変更ファイルに `api/` 配下の TypeScript を含む場合は `cd api && tsc --noEmit` も実行する",
+      },
+    ],
+    ".claude/skills/test/SKILL.md": [
+      {
+        placeholder: "<!-- SECTION:TEST_STEPS -->",
+        content: "1. `cd api && pnpm test` で API テスト実行",
+      },
+    ],
+    "README.md": [
+      {
+        placeholder: "<!-- SECTION:DIR_STRUCTURE -->",
+        content: "├── api/                 # バックエンド API (Express)",
+      },
+      {
+        placeholder: "<!-- SECTION:ROOT_FILES -->",
+        content: "├── api/package.json     # API 依存・スクリプト",
+      },
+      {
+        placeholder: "<!-- SECTION:SETUP_STEPS -->",
+        content: "1. `cd api && pnpm install`（API 依存パッケージ）",
+      },
+      {
+        placeholder: "<!-- SECTION:SETUP_COMMANDS -->",
+        content: "| `cd api && pnpm install` | API 依存パッケージインストール |",
+      },
+      {
+        placeholder: "<!-- SECTION:LINT_COMMANDS -->",
+        content: "| `pnpm run typecheck:api` | API TypeScript 型チェック |",
+      },
+      {
+        placeholder: "<!-- SECTION:TEST_COMMANDS -->",
+        content:
+          "| `pnpm run test:api` | API テスト（vitest） |\n| `pnpm run dev:api` | API 開発サーバー起動（port 3000） |",
+      },
+    ],
+  },
+  ciSteps: {
+    setupSteps: [
+      { name: "Install API dependencies", run: "cd api && pnpm install --frozen-lockfile" },
+    ],
+    lintSteps: [{ name: "Typecheck (API tsc)", run: "cd api && tsc --noEmit" }],
+    testSteps: [{ name: "Test (API vitest)", run: "cd api && pnpm test" }],
+    buildSteps: [{ name: "Build (API)", run: "cd api && pnpm run build" }],
+  },
+  setupExtra: "cd api && pnpm install",
 };

--- a/templates/express/.claude/rules/express.md
+++ b/templates/express/.claude/rules/express.md
@@ -1,0 +1,42 @@
+# Express Rules
+
+## Project Structure
+
+```text
+api/
+  src/
+    app.ts        -> Express application definition
+    index.ts      -> Server entrypoint (app.listen)
+  tests/
+    app.test.ts   -> API tests (supertest)
+  package.json    -> API dependencies and scripts
+  tsconfig.json   -> API TypeScript config
+```
+
+## Routing
+
+- Define the Express app in `api/src/app.ts`, server startup in `api/src/index.ts`
+- Use `express.Router()` for grouping related endpoints
+- Export the `app` instance for testing (do not call `app.listen()` in app.ts)
+
+## Middleware
+
+- Register middleware with `app.use()` in `api/src/app.ts`
+- Use `express.json()` for JSON body parsing
+- Place error-handling middleware last (4 parameters: `err, req, res, next`)
+
+## Testing
+
+- Use `supertest` to test HTTP endpoints without starting the server
+- Import the `app` from `api/src/app.ts` (not `index.ts`)
+- Test both success and error response codes
+- Run tests: `cd api && pnpm test`
+
+## Commands
+
+```bash
+cd api && pnpm run dev      # Dev server (tsx watch, port 3000)
+cd api && pnpm test         # Run tests (vitest)
+cd api && pnpm run build    # Build (tsdown)
+cd api && tsc --noEmit      # Type check
+```

--- a/templates/express/api/package.json
+++ b/templates/express/api/package.json
@@ -13,7 +13,6 @@
     "express": "^5.0.0"
   },
   "devDependencies": {
-    "@types/express": "^5.0.0",
     "@types/node": "^22.0.0",
     "supertest": "^7.0.0",
     "tsdown": "^0.12.0",

--- a/templates/express/api/package.json
+++ b/templates/express/api/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "{{projectName}}-api",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsdown src/index.ts --format esm --dts",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "express": "^5.0.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "@types/node": "^22.0.0",
+    "supertest": "^7.0.0",
+    "tsdown": "^0.12.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.0.0",
+    "vitest": "^4.0.0"
+  }
+}

--- a/templates/express/api/src/app.ts
+++ b/templates/express/api/src/app.ts
@@ -1,0 +1,9 @@
+import express from "express";
+
+export const app = express();
+
+app.use(express.json());
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok" });
+});

--- a/templates/express/api/src/index.ts
+++ b/templates/express/api/src/index.ts
@@ -1,0 +1,7 @@
+import { app } from "./app.js";
+
+const port = Number(process.env.PORT) || 3000;
+
+app.listen(port, () => {
+  console.log(`Server listening on http://localhost:${port}`);
+});

--- a/templates/express/api/tests/app.test.ts
+++ b/templates/express/api/tests/app.test.ts
@@ -1,0 +1,12 @@
+import request from "supertest";
+import { describe, expect, it } from "vitest";
+
+import { app } from "../src/app.js";
+
+describe("GET /health", () => {
+  it("returns status ok", async () => {
+    const response = await request(app).get("/health");
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ status: "ok" });
+  });
+});

--- a/templates/express/api/tsconfig.json
+++ b/templates/express/api/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src", "tests"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/tests/__snapshots__/generator.test.ts.snap
+++ b/tests/__snapshots__/generator.test.ts.snap
@@ -177,6 +177,7 @@ exports[`file list snapshots > cloudformation (ts) 1`] = `
 
 exports[`file list snapshots > express 1`] = `
 [
+  ".claude/rules/express.md",
   ".claude/rules/git-workflow.md",
   ".claude/settings.json",
   ".claude/skills/commit-conventions/SKILL.md",
@@ -216,6 +217,11 @@ exports[`file list snapshots > express 1`] = `
   ".yamllint.yaml",
   "CLAUDE.md",
   "README.md",
+  "api/package.json",
+  "api/src/app.ts",
+  "api/src/index.ts",
+  "api/tests/app.test.ts",
+  "api/tsconfig.json",
   "biome.json",
   "docs/adding-tools.md",
   "docs/branch-strategy.md",
@@ -608,6 +614,7 @@ exports[`file list snapshots > python 1`] = `
 
 exports[`file list snapshots > react + express 1`] = `
 [
+  ".claude/rules/express.md",
   ".claude/rules/git-workflow.md",
   ".claude/settings.json",
   ".claude/skills/commit-conventions/SKILL.md",
@@ -647,6 +654,11 @@ exports[`file list snapshots > react + express 1`] = `
   ".yamllint.yaml",
   "CLAUDE.md",
   "README.md",
+  "api/package.json",
+  "api/src/app.ts",
+  "api/src/index.ts",
+  "api/tests/app.test.ts",
+  "api/tsconfig.json",
   "biome.json",
   "docs/adding-tools.md",
   "docs/branch-strategy.md",

--- a/tests/pairwise.test.ts
+++ b/tests/pairwise.test.ts
@@ -298,3 +298,130 @@ describe("pairwise: fastapi + react", () => {
     expect(claude).not.toContain("<!-- SECTION:");
   });
 });
+
+// --- Express + React (web/ + api/ coexistence, both in pnpm workspace) ---
+
+describe("pairwise: express + react", () => {
+  const answers = makeAnswers({ frontend: "react", backend: "express" });
+  const result = generate(answers);
+
+  it("includes both web/ and api/ directories", () => {
+    expect(result.hasFile("web/vite.config.ts")).toBe(true);
+    expect(result.hasFile("web/package.json")).toBe(true);
+    expect(result.hasFile("api/src/app.ts")).toBe(true);
+    expect(result.hasFile("api/package.json")).toBe(true);
+  });
+
+  it("workspace includes both web and api (Express uses pnpm)", () => {
+    const workspace = result.readText("pnpm-workspace.yaml");
+    expect(workspace).toContain("- web");
+    expect(workspace).toContain("- api");
+  });
+
+  it("root package.json has both orchestration and API scripts", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const scripts = pkg.scripts as Record<string, string>;
+    expect(scripts["build:web"]).toBe("pnpm --filter web build");
+    expect(scripts["dev:api"]).toBeDefined();
+    expect(scripts["test:api"]).toBeDefined();
+    expect(scripts["build:api"]).toBeDefined();
+  });
+
+  it("both use TypeScript tools (single set)", () => {
+    const toml = result.readToml(".mise.toml") as Record<string, Record<string, string>>;
+    expect(toml.tools["npm:@biomejs/biome"]).toBe("2");
+  });
+
+  it("devcontainer forwards port 3000", () => {
+    const dc = result.readJson(".devcontainer/devcontainer.json") as Record<string, unknown>;
+    const ports = dc.forwardPorts as number[];
+    expect(ports).toContain(3000);
+  });
+
+  it("has CI steps from both presets", () => {
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name);
+    expect(stepNames).toContain("Lint (Biome)");
+    expect(stepNames).toContain("Typecheck (API tsc)");
+    expect(stepNames).toContain("Test (API vitest)");
+    expect(stepNames).toContain("Build (API)");
+  });
+
+  it("CLAUDE.md contains both React and Express sections", () => {
+    const claude = result.readText("CLAUDE.md");
+    expect(claude).toContain("React");
+    expect(claude).toContain("Express");
+    expect(claude).not.toContain("<!-- SECTION:");
+  });
+});
+
+// --- Express + CDK (api/ + infra/ coexistence) ---
+
+describe("pairwise: express + cdk", () => {
+  const answers = makeAnswers({ backend: "express", clouds: ["aws"], iac: ["cdk"] });
+  const result = generate(answers);
+
+  it("includes both api/ and infra/ directories", () => {
+    expect(result.hasFile("api/src/app.ts")).toBe(true);
+    expect(result.hasFile("api/package.json")).toBe(true);
+    expect(result.hasFile("infra/bin/app.ts")).toBe(true);
+    expect(result.hasFile("infra/package.json")).toBe(true);
+  });
+
+  it("workspace includes api only (infra uses independent npm)", () => {
+    const workspace = result.readText("pnpm-workspace.yaml");
+    expect(workspace).toContain("- api");
+    expect(workspace).not.toContain("- infra");
+  });
+
+  it("biome.json excludes both api/dist/ and cdk.out/", () => {
+    const biome = result.readJson("biome.json") as Record<string, unknown>;
+    const files = biome.files as Record<string, string[]>;
+    expect(files.includes).toContain("!**/api/dist/");
+    expect(files.includes).toContain("!**/cdk.out/");
+  });
+
+  it("root package.json has both API and CDK scripts", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const scripts = pkg.scripts as Record<string, string>;
+    expect(scripts["dev:api"]).toBeDefined();
+    expect(scripts["cdk:synth"]).toBeDefined();
+  });
+
+  it("has CI steps from both presets", () => {
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name);
+    expect(stepNames).toContain("Typecheck (API tsc)");
+    expect(stepNames).toContain("Test (API vitest)");
+    expect(stepNames).toContain("Test (CDK)");
+  });
+});
+
+// --- Express + React + CDK (web/ + api/ + infra/ triple coexistence) ---
+
+describe("pairwise: express + react + cdk", () => {
+  const answers = makeAnswers({
+    frontend: "react",
+    backend: "express",
+    clouds: ["aws"],
+    iac: ["cdk"],
+  });
+  const result = generate(answers);
+
+  it("includes web/, api/, and infra/ directories", () => {
+    expect(result.hasFile("web/vite.config.ts")).toBe(true);
+    expect(result.hasFile("api/src/app.ts")).toBe(true);
+    expect(result.hasFile("infra/bin/app.ts")).toBe(true);
+  });
+
+  it("workspace includes web and api (not infra)", () => {
+    const workspace = result.readText("pnpm-workspace.yaml");
+    expect(workspace).toContain("- web");
+    expect(workspace).toContain("- api");
+    expect(workspace).not.toContain("- infra");
+  });
+});

--- a/tests/presets/express.test.ts
+++ b/tests/presets/express.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import { generate } from "../../src/generator.js";
+import { makeAnswers } from "../helpers.js";
+
+describe("generate (express)", () => {
+  const answers = makeAnswers({ backend: "express" });
+  const result = generate(answers);
+
+  it("forces TypeScript preset inclusion", () => {
+    expect(result.hasFile("biome.json")).toBe(true);
+    expect(result.hasFile("tsconfig.json")).toBe(true);
+  });
+
+  it("includes Express owned files", () => {
+    expect(result.hasFile("api/src/app.ts")).toBe(true);
+    expect(result.hasFile("api/src/index.ts")).toBe(true);
+    expect(result.hasFile("api/tests/app.test.ts")).toBe(true);
+    expect(result.hasFile("api/tsconfig.json")).toBe(true);
+    expect(result.hasFile("api/package.json")).toBe(true);
+    expect(result.hasFile(".claude/rules/express.md")).toBe(true);
+  });
+
+  it("does not include Python files", () => {
+    expect(result.hasFile("pyproject.toml")).toBe(false);
+    expect(result.hasFile("uv.lock")).toBe(false);
+  });
+
+  it("merges Express scripts into package.json", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const scripts = pkg.scripts as Record<string, string>;
+    expect(scripts["dev:api"]).toContain("pnpm run dev");
+    expect(scripts["test:api"]).toContain("pnpm test");
+    expect(scripts["build:api"]).toContain("pnpm run build");
+    expect(scripts["typecheck:api"]).toContain("tsc --noEmit");
+  });
+
+  it("merges TypeScript tools into .mise.toml (via TypeScript preset)", () => {
+    const toml = result.readToml(".mise.toml") as Record<string, Record<string, string>>;
+    expect(toml.tools["npm:@biomejs/biome"]).toBe("2");
+  });
+
+  it("adds port 3000 to devcontainer", () => {
+    const dc = result.readJson(".devcontainer/devcontainer.json") as Record<string, unknown>;
+    const ports = dc.forwardPorts as number[];
+    expect(ports).toContain(3000);
+  });
+
+  it("adds api/dist/ exclusion to biome.json", () => {
+    const biome = result.readJson("biome.json") as Record<string, unknown>;
+    const files = biome.files as Record<string, string[]>;
+    expect(files.includes).toContain("!**/api/dist/");
+  });
+
+  it("adds typecheck-api hook to lefthook", () => {
+    const hook = result.readYaml("lefthook.yaml") as Record<string, unknown>;
+    const prePush = hook["pre-push"] as Record<string, unknown>;
+    const pushCmds = prePush.commands as Record<string, unknown>;
+    expect(pushCmds["typecheck-api"]).toBeDefined();
+  });
+
+  it("adds API CI steps", () => {
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name);
+    expect(stepNames).toContain("Install API dependencies");
+    expect(stepNames).toContain("Typecheck (API tsc)");
+    expect(stepNames).toContain("Test (API vitest)");
+    expect(stepNames).toContain("Build (API)");
+  });
+
+  it("adds API install to setup.sh", () => {
+    const setup = result.readText("scripts/setup.sh");
+    expect(setup).toContain("cd api && pnpm install");
+  });
+
+  it("replaces {{projectName}} in API package.json", () => {
+    const apiPkg = result.readText("api/package.json");
+    expect(apiPkg).toContain("test-app-api");
+    expect(apiPkg).not.toContain("{{projectName}}");
+  });
+
+  it("generates pnpm-workspace.yaml with api (Express uses pnpm)", () => {
+    const workspace = result.readText("pnpm-workspace.yaml");
+    expect(workspace).toContain("- api");
+  });
+
+  it("expands CLAUDE.md with Express sections", () => {
+    const claude = result.readText("CLAUDE.md");
+    expect(claude).toContain("Express");
+    expect(claude).toContain("api/");
+    expect(claude).not.toContain("<!-- SECTION:");
+  });
+
+  it("expands README.md with Express sections", () => {
+    const readme = result.readText("README.md");
+    expect(readme).toContain("Express");
+    expect(readme).toContain("api/");
+    expect(readme).not.toContain("<!-- SECTION:");
+  });
+});

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -489,6 +489,73 @@ const patterns: PatternDef[] = [
     },
   },
   {
+    name: "express",
+    answers: { backend: "express" },
+    vscodeSettings: {
+      mustInclude: ["biomejs.biome", "source.fixAll.biome", "**/dist"],
+      mustExclude: ["charliermarsh.ruff", "mypy-type-checker", "cdk.out"],
+    },
+    vscodeExtensions: {
+      mustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
+      mustExclude: [
+        "charliermarsh.ruff",
+        "amazonwebservices.aws-toolkit-vscode",
+        "ms-azuretools.vscode-bicep",
+      ],
+    },
+    devcontainer: {
+      extensionsMustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
+      extensionsMustExclude: [
+        "charliermarsh.ruff",
+        "amazonwebservices.aws-toolkit-vscode",
+        "ms-azuretools.vscode-bicep",
+      ],
+      mountsMustInclude: ["pnpm-store"],
+      mountsMustExclude: [".aws", ".azure", ".config/gcloud", "uv-cache"],
+    },
+    packageJson: {
+      scriptsMustInclude: [
+        "lint",
+        "typecheck",
+        "dev:api",
+        "test:api",
+        "build:api",
+        "typecheck:api",
+      ],
+      scriptsMustExclude: ["lint:python", "lint:mypy", "lint:cfn", "lint:tf", "lint:bicep"],
+    },
+  },
+  {
+    name: "react + express",
+    answers: { frontend: "react", backend: "express" },
+    vscodeSettings: {
+      mustInclude: ["biomejs.biome", "source.fixAll.biome", "**/dist"],
+      mustExclude: ["charliermarsh.ruff", "mypy-type-checker", "cdk.out"],
+    },
+    vscodeExtensions: {
+      mustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
+      mustExclude: [
+        "charliermarsh.ruff",
+        "amazonwebservices.aws-toolkit-vscode",
+        "ms-azuretools.vscode-bicep",
+      ],
+    },
+    devcontainer: {
+      extensionsMustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
+      extensionsMustExclude: [
+        "charliermarsh.ruff",
+        "amazonwebservices.aws-toolkit-vscode",
+        "ms-azuretools.vscode-bicep",
+      ],
+      mountsMustInclude: ["pnpm-store"],
+      mountsMustExclude: [".aws", ".azure", ".config/gcloud", "uv-cache"],
+    },
+    packageJson: {
+      scriptsMustInclude: ["lint", "typecheck", "dev:api", "test:api", "build:api", "build:web"],
+      scriptsMustExclude: ["lint:python", "lint:mypy", "lint:cfn", "lint:tf", "lint:bicep"],
+    },
+  },
+  {
     name: "full config (ts + python + react + aws + gcp + cdk + terraform)",
     answers: {
       languages: ["typescript", "python"],


### PR DESCRIPTION
## Summary

Express バックエンドプリセットを追加。`api/` ディレクトリにエージェント向け設定を生成する。

- Express テンプレート（app.ts + index.ts + supertest テスト + tsdown ビルド）
- `.claude/rules/express.md` エージェントルール
- pnpm workspace 統合（`api/` を workspace に含める）
- Biome `api/dist/` 除外、devcontainer port 3000
- CI steps（install, typecheck, test, build）
- Lefthook pre-push `typecheck-api` フック
- CLAUDE.md / README.md セクション注入

## Test plan

- [x] Layer A: `tests/presets/express.test.ts`（14テスト）
- [x] Layer B: `tests/pairwise.test.ts`（express+react, express+cdk, express+react+cdk）
- [x] Layer C: `tests/smoke.test.ts`（express, react+express パターン）
- [x] 全393テスト通過
- [x] `pnpm run build && pnpm test && pnpm run typecheck` 全通過

Closes #77