### PR TITLE
feat: add mcpServers field to Preset interface

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,5 +1,5 @@
 import { buildCiWorkflow } from "./ci.js";
-import { expandMarkdown, mergeFile } from "./merge.js";
+import { expandMarkdown, formatMcpJson, mergeFile } from "./merge.js";
 import { awsPreset } from "./presets/aws.js";
 import { azurePreset } from "./presets/azure.js";
 import { basePreset } from "./presets/base.js";
@@ -19,6 +19,7 @@ import type {
   FileWriter,
   GenerateResult,
   MarkdownSection,
+  McpServerConfig,
   Preset,
   WizardAnswers,
 } from "./types.js";
@@ -249,6 +250,17 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
 
     pkg.scripts = scripts;
     allFiles.set("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
+  }
+
+  // 2.7. Collect MCP servers from all presets and write .mcp.json
+  const allMcpServers: Record<string, McpServerConfig> = {};
+  for (const preset of presets) {
+    if (preset.mcpServers) {
+      Object.assign(allMcpServers, preset.mcpServers);
+    }
+  }
+  if (Object.keys(allMcpServers).length > 0) {
+    allFiles.set(".mcp.json", formatMcpJson(allMcpServers));
   }
 
   // 3. Expand Markdown templates

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -1,7 +1,7 @@
 import { deepmergeCustom } from "deepmerge-ts";
 import { parse as parseToml, stringify as stringifyToml } from "smol-toml";
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
-import type { MarkdownSection } from "./types.js";
+import type { MarkdownSection, McpServerConfig } from "./types.js";
 
 /**
  * Deep merge with unique-union arrays.
@@ -94,6 +94,28 @@ export function mergeText(base: string, ...patches: unknown[]): string {
     }
   }
   return result;
+}
+
+/** Format MCP server configs as a JSON string (.mcp.json format). */
+export function formatMcpJson(servers: Record<string, McpServerConfig>): string {
+  return `${JSON.stringify({ mcpServers: servers }, null, 2)}\n`;
+}
+
+/** Format MCP server configs as a TOML string (Codex config.toml format). */
+export function formatMcpToml(servers: Record<string, McpServerConfig>): string {
+  const tables: Record<string, Record<string, unknown>> = {};
+  for (const [name, config] of Object.entries(servers)) {
+    const entry: Record<string, unknown> = {
+      command: config.command,
+      args: config.args,
+    };
+    if (config.env && Object.keys(config.env).length > 0) {
+      entry.env = config.env;
+    }
+    tables[name] = entry;
+  }
+  const result = stringifyToml({ mcp_servers: tables });
+  return result.endsWith("\n") ? result : `${result}\n`;
 }
 
 /** Files that support text-append merging (block-level dedup). */

--- a/src/presets/aws.ts
+++ b/src/presets/aws.ts
@@ -15,18 +15,16 @@ export const awsPreset: Preset = {
         "source=${localEnv:HOME}/.aws,target=/home/vscode/.aws,type=bind,consistency=cached",
       ],
     },
-    ".mcp.json": {
-      mcpServers: {
-        "aws-iac": {
-          command: "uvx",
-          args: ["awslabs.aws-iac-mcp@latest"],
-          env: {
-            // biome-ignore lint/suspicious/noTemplateCurlyInString: MCP env variable syntax
-            AWS_PROFILE: "${AWS_PROFILE:-default}",
-            // biome-ignore lint/suspicious/noTemplateCurlyInString: MCP env variable syntax
-            AWS_REGION: "${AWS_REGION:-ap-northeast-1}",
-          },
-        },
+  },
+  mcpServers: {
+    "aws-iac": {
+      command: "uvx",
+      args: ["awslabs.aws-iac-mcp@latest"],
+      env: {
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: MCP env variable syntax
+        AWS_PROFILE: "${AWS_PROFILE:-default}",
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: MCP env variable syntax
+        AWS_REGION: "${AWS_REGION:-ap-northeast-1}",
       },
     },
   },

--- a/src/presets/azure.ts
+++ b/src/presets/azure.ts
@@ -15,13 +15,11 @@ export const azurePreset: Preset = {
         "source=${localEnv:HOME}/.azure,target=/home/vscode/.azure,type=bind,consistency=cached",
       ],
     },
-    ".mcp.json": {
-      mcpServers: {
-        azure: {
-          command: "npx",
-          args: ["-y", "@azure/mcp@latest", "server", "start"],
-        },
-      },
+  },
+  mcpServers: {
+    azure: {
+      command: "npx",
+      args: ["-y", "@azure/mcp@latest", "server", "start"],
     },
   },
   markdown: {

--- a/src/presets/base.ts
+++ b/src/presets/base.ts
@@ -80,17 +80,15 @@ export const basePreset: Preset = {
         },
       },
     },
-    ".mcp.json": {
-      mcpServers: {
-        context7: {
-          command: "npx",
-          args: ["-y", "@upstash/context7-mcp@latest"],
-        },
-        fetch: {
-          command: "npx",
-          args: ["-y", "@modelcontextprotocol/server-fetch"],
-        },
-      },
+  },
+  mcpServers: {
+    context7: {
+      command: "npx",
+      args: ["-y", "@upstash/context7-mcp@latest"],
+    },
+    fetch: {
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-fetch"],
     },
   },
   markdown: {

--- a/src/presets/gcp.ts
+++ b/src/presets/gcp.ts
@@ -15,13 +15,11 @@ export const gcpPreset: Preset = {
         "source=${localEnv:HOME}/.config/gcloud,target=/home/vscode/.config/gcloud,type=bind,consistency=cached",
       ],
     },
-    ".mcp.json": {
-      mcpServers: {
-        "google-cloud": {
-          command: "npx",
-          args: ["-y", "@google-cloud/gcloud-mcp"],
-        },
-      },
+  },
+  mcpServers: {
+    "google-cloud": {
+      command: "npx",
+      args: ["-y", "@google-cloud/gcloud-mcp"],
     },
   },
   markdown: {

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,6 +34,14 @@ export interface CiContribution {
   buildSteps?: CiStep[];
 }
 
+// --- MCP ---
+
+export interface McpServerConfig {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
 // --- Preset ---
 
 export interface Preset {
@@ -51,6 +59,8 @@ export interface Preset {
   setupExtra?: string;
   /** devDependencies that should be removed if not referenced by any script */
   conditionalDevDeps?: string[];
+  /** MCP server definitions (distributed to agent config files by generator) */
+  mcpServers?: Record<string, McpServerConfig>;
 }
 
 // --- File I/O abstraction ---


### PR DESCRIPTION
## Summary

- Preset interface に `mcpServers` フィールドを追加し、MCP サーバー定義を構造化データに移行
- base, aws, azure, gcp プリセットの MCP 定義を `merge[".mcp.json"]` から `mcpServers` に移行
- Generator で全プリセットの MCP サーバーを収集し `.mcp.json` に出力するロジックを追加
- `formatMcpJson()` / `formatMcpToml()` 出力関数を追加（TOML は Codex 対応用に先行実装）

マルチエージェント対応（#88）の前提となるリファクタリング。MCP 定義をファイルパスから分離することで、エージェントごとに異なる設定ファイルへの配分が可能になる。

## Test plan

- [x] `pnpm run build` — ビルド成功
- [x] `pnpm test` — 437 テスト全通過（生成結果は同一を確認）
- [x] `pnpm run typecheck` — 型チェック通過
- [x] Biome lint — 通過

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)