### PR TITLE
refactor: generalize markdown injection to agent-instructions key

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -267,11 +267,24 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
   const markdownSections = new Map<string, MarkdownSection[]>();
   for (const preset of presets) {
     if (!preset.markdown) continue;
-    for (const [filePath, sections] of Object.entries(preset.markdown)) {
-      const existing = markdownSections.get(filePath) ?? [];
+    for (const [key, sections] of Object.entries(preset.markdown)) {
+      const existing = markdownSections.get(key) ?? [];
       existing.push(...sections);
-      markdownSections.set(filePath, existing);
+      markdownSections.set(key, existing);
     }
+  }
+
+  // 3.1. Distribute "agent-instructions" sections to instruction file templates.
+  // Currently only CLAUDE.md; future agent presets will register additional targets.
+  const INSTRUCTION_TARGETS = ["CLAUDE.md"];
+  const agentSections = markdownSections.get("agent-instructions");
+  if (agentSections) {
+    for (const target of INSTRUCTION_TARGETS) {
+      const existing = markdownSections.get(target) ?? [];
+      existing.push(...agentSections);
+      markdownSections.set(target, existing);
+    }
+    markdownSections.delete("agent-instructions");
   }
 
   // Pre-process: collapse INFRA_STRUCTURE / INFRA_DIR_STRUCTURE into single lines

--- a/src/presets/aws.ts
+++ b/src/presets/aws.ts
@@ -29,7 +29,7 @@ export const awsPreset: Preset = {
     },
   },
   markdown: {
-    "CLAUDE.md": [
+    "agent-instructions": [
       {
         placeholder: "<!-- SECTION:TECH_STACK_MCP -->",
         content: "AWS IaC",

--- a/src/presets/azure.ts
+++ b/src/presets/azure.ts
@@ -23,7 +23,7 @@ export const azurePreset: Preset = {
     },
   },
   markdown: {
-    "CLAUDE.md": [
+    "agent-instructions": [
       {
         placeholder: "<!-- SECTION:TECH_STACK_MCP -->",
         content: "Azure",

--- a/src/presets/base.ts
+++ b/src/presets/base.ts
@@ -92,7 +92,7 @@ export const basePreset: Preset = {
     },
   },
   markdown: {
-    "CLAUDE.md": [],
+    "agent-instructions": [],
     "README.md": [],
   },
   ciSteps: {

--- a/src/presets/bicep.ts
+++ b/src/presets/bicep.ts
@@ -23,7 +23,7 @@ export const bicepPreset: Preset = {
     },
   },
   markdown: {
-    "CLAUDE.md": [
+    "agent-instructions": [
       {
         placeholder: "<!-- SECTION:TECH_STACK -->",
         content: "- **IaC**: Azure Bicep",

--- a/src/presets/cdk.ts
+++ b/src/presets/cdk.ts
@@ -66,7 +66,7 @@ export const cdkPreset: Preset = {
     },
   },
   markdown: {
-    "CLAUDE.md": [
+    "agent-instructions": [
       {
         placeholder: "<!-- SECTION:TECH_STACK -->",
         content: "- **IaC**: AWS CDK v2 (TypeScript)",

--- a/src/presets/cloudformation.ts
+++ b/src/presets/cloudformation.ts
@@ -21,7 +21,7 @@ export const cloudformationPreset: Preset = {
     },
   },
   markdown: {
-    "CLAUDE.md": [
+    "agent-instructions": [
       {
         placeholder: "<!-- SECTION:TECH_STACK -->",
         content: "- **IaC**: AWS CloudFormation",

--- a/src/presets/express.ts
+++ b/src/presets/express.ts
@@ -31,7 +31,7 @@ export const expressPreset: Preset = {
     },
   },
   markdown: {
-    "CLAUDE.md": [
+    "agent-instructions": [
       {
         placeholder: "<!-- SECTION:TECH_STACK -->",
         content: "- **Backend**: Express (TypeScript, tsdown)",

--- a/src/presets/fastapi.ts
+++ b/src/presets/fastapi.ts
@@ -39,7 +39,7 @@ export const fastapiPreset: Preset = {
     },
   },
   markdown: {
-    "CLAUDE.md": [
+    "agent-instructions": [
       {
         placeholder: "<!-- SECTION:TECH_STACK -->",
         content: "- **Backend**: FastAPI (Python, uvicorn)",

--- a/src/presets/gcp.ts
+++ b/src/presets/gcp.ts
@@ -23,7 +23,7 @@ export const gcpPreset: Preset = {
     },
   },
   markdown: {
-    "CLAUDE.md": [
+    "agent-instructions": [
       {
         placeholder: "<!-- SECTION:TECH_STACK_MCP -->",
         content: "Google Cloud",

--- a/src/presets/nextjs.ts
+++ b/src/presets/nextjs.ts
@@ -24,7 +24,7 @@ export const nextjsPreset: Preset = {
     },
   },
   markdown: {
-    "CLAUDE.md": [
+    "agent-instructions": [
       {
         placeholder: "<!-- SECTION:TECH_STACK -->",
         content: "- **Frontend**: Next.js 15 (App Router)",

--- a/src/presets/python.ts
+++ b/src/presets/python.ts
@@ -66,7 +66,7 @@ export const pythonPreset: Preset = {
     },
   },
   markdown: {
-    "CLAUDE.md": [
+    "agent-instructions": [
       {
         placeholder: "<!-- SECTION:TECH_STACK -->",
         content: "- **Language**: Python 3.12+ (uv)",

--- a/src/presets/react.ts
+++ b/src/presets/react.ts
@@ -17,7 +17,7 @@ export const reactPreset: Preset = {
     },
   },
   markdown: {
-    "CLAUDE.md": [
+    "agent-instructions": [
       {
         placeholder: "<!-- SECTION:TECH_STACK -->",
         content: "- **Frontend**: React 19 + Vite",

--- a/src/presets/terraform.ts
+++ b/src/presets/terraform.ts
@@ -30,7 +30,7 @@ export const terraformPreset: Preset = {
     },
   },
   markdown: {
-    "CLAUDE.md": [
+    "agent-instructions": [
       {
         placeholder: "<!-- SECTION:TECH_STACK -->",
         content: "- **IaC**: Terraform",

--- a/src/presets/typescript.ts
+++ b/src/presets/typescript.ts
@@ -81,7 +81,7 @@ export const typescriptPreset: Preset = {
     },
   },
   markdown: {
-    "CLAUDE.md": [
+    "agent-instructions": [
       {
         placeholder: "<!-- SECTION:TECH_STACK -->",
         content: '- **Language**: TypeScript (ESM, strict mode, `"type": "module"`)',


### PR DESCRIPTION
## Summary

- 全 14 プリセットの markdown キーを `"CLAUDE.md"` → `"agent-instructions"` に変更
- Generator に `INSTRUCTION_TARGETS` マッピングを追加し、`"agent-instructions"` セクションを CLAUDE.md に配分
- Skills キー（`.claude/skills/*`）と README.md キーは変更なし
- 生成結果は完全に同一（後方互換維持）

マルチエージェント対応（#88）の前提となるリファクタリング。プリセットの markdown 定義をエージェント固有のファイルパスから分離し、将来 AGENTS.md / GEMINI.md 等への配分を可能にする。

## Test plan

- [x] `pnpm run build` — ビルド成功
- [x] `pnpm test` — 437 テスト全通過（生成結果は同一を確認）
- [x] `pnpm run typecheck` — 型チェック通過
- [x] Biome lint — 通過

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)