### PR TITLE
feat: add Codex CLI preset

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -167,6 +167,11 @@ export async function runWizard(defaultName?: string): Promise<WizardAnswers> {
               label: t("wizard.agents.claude-code.label"),
               hint: t("wizard.agents.claude-code.hint"),
             },
+            {
+              value: "codex" as const,
+              label: t("wizard.agents.codex.label"),
+              hint: t("wizard.agents.codex.hint"),
+            },
           ],
           required: false,
         }),

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,5 +1,5 @@
 import { buildCiWorkflow } from "./ci.js";
-import { expandMarkdown, formatMcpJson, mergeFile } from "./merge.js";
+import { expandMarkdown, formatMcpJson, formatMcpToml, mergeFile } from "./merge.js";
 import { awsPreset } from "./presets/aws.js";
 import { azurePreset } from "./presets/azure.js";
 import { basePreset } from "./presets/base.js";
@@ -7,6 +7,7 @@ import { bicepPreset } from "./presets/bicep.js";
 import { cdkPreset } from "./presets/cdk.js";
 import { claudeCodePreset } from "./presets/claude-code.js";
 import { cloudformationPreset } from "./presets/cloudformation.js";
+import { codexPreset } from "./presets/codex.js";
 import { expressPreset } from "./presets/express.js";
 import { fastapiPreset } from "./presets/fastapi.js";
 import { gcpPreset } from "./presets/gcp.js";
@@ -42,6 +43,7 @@ const ALL_PRESETS: Record<string, Preset> = {
   terraform: terraformPreset,
   bicep: bicepPreset,
   "claude-code": claudeCodePreset,
+  codex: codexPreset,
 };
 
 /**
@@ -85,6 +87,7 @@ const PRESET_ORDER = [
   "terraform",
   "bicep",
   "claude-code",
+  "codex",
 ];
 
 /** Resolve which presets to apply based on wizard answers, including dependency chains. */
@@ -259,7 +262,7 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
     allFiles.set("package.json", `${JSON.stringify(pkg, null, 2)}\n`);
   }
 
-  // 2.7. Collect MCP servers from all presets and write .mcp.json
+  // 2.7. Collect MCP servers from all presets and distribute to agent config files
   const allMcpServers: Record<string, McpServerConfig> = {};
   for (const preset of presets) {
     if (preset.mcpServers) {
@@ -267,7 +270,19 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
     }
   }
   if (Object.keys(allMcpServers).length > 0) {
-    allFiles.set(".mcp.json", formatMcpJson(allMcpServers));
+    const AGENT_MCP_FILES: Record<string, { path: string; format: "json" | "toml" }> = {
+      "claude-code": { path: ".mcp.json", format: "json" },
+      codex: { path: ".codex/config.toml", format: "toml" },
+    };
+    for (const name of presetNames) {
+      const config = AGENT_MCP_FILES[name];
+      if (config) {
+        allFiles.set(
+          config.path,
+          config.format === "toml" ? formatMcpToml(allMcpServers) : formatMcpJson(allMcpServers),
+        );
+      }
+    }
   }
 
   // 3. Expand Markdown templates
@@ -285,6 +300,7 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
   // Each agent preset's top-level .md owned file is an instruction target.
   const AGENT_INSTRUCTION_FILES: Record<string, string> = {
     "claude-code": "CLAUDE.md",
+    codex: "AGENTS.md",
   };
   const instructionTargets = presetNames
     .filter((name) => name in AGENT_INSTRUCTION_FILES)

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -46,7 +46,8 @@
     "agents": {
       "message": "AI Agent tools",
       "hint": "Add agent-specific project config, rules, and MCP servers",
-      "claude-code": { "label": "Claude Code", "hint": "CLAUDE.md, skills, rules" }
+      "claude-code": { "label": "Claude Code", "hint": "CLAUDE.md, skills, rules" },
+      "codex": { "label": "Codex CLI", "hint": "AGENTS.md, MCP" }
     }
   },
   "overwrite": {

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -46,7 +46,8 @@
     "agents": {
       "message": "AI エージェントツール",
       "hint": "エージェント固有のプロジェクト設定・ルール・MCP サーバーを追加",
-      "claude-code": { "label": "Claude Code", "hint": "CLAUDE.md, スキル, ルール" }
+      "claude-code": { "label": "Claude Code", "hint": "CLAUDE.md, スキル, ルール" },
+      "codex": { "label": "Codex CLI", "hint": "AGENTS.md, MCP" }
     }
   },
   "overwrite": {

--- a/src/presets/codex.ts
+++ b/src/presets/codex.ts
@@ -1,0 +1,29 @@
+import type { Preset } from "../types.js";
+import { readTemplateFiles } from "../utils.js";
+
+export const codexPreset: Preset = {
+  name: "codex",
+  files: readTemplateFiles("codex"),
+  merge: {
+    ".devcontainer/devcontainer.json": {
+      remoteEnv: {
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: devcontainer variable syntax
+        OPENAI_API_KEY: "${localEnv:OPENAI_API_KEY}",
+      },
+    },
+  },
+  mcpServers: {
+    context7: {
+      command: "npx",
+      args: ["-y", "@upstash/context7-mcp@latest"],
+    },
+    fetch: {
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-fetch"],
+    },
+  },
+  markdown: {
+    "agent-instructions": [],
+    "README.md": [],
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface WizardAnswers {
   clouds: Array<"aws" | "azure" | "gcp">;
   iac: Array<"cdk" | "cloudformation" | "terraform" | "bicep">;
   languages: Array<"typescript" | "python">;
-  agents: Array<"claude-code">;
+  agents: Array<"claude-code" | "codex">;
 }
 
 // --- Markdown template ---

--- a/templates/codex/AGENTS.md
+++ b/templates/codex/AGENTS.md
@@ -1,0 +1,91 @@
+# AGENTS.md
+
+## Project Overview
+
+{{projectName}}: AI-agent-native development project.
+
+## Tech Stack
+
+- **Version management**: mise (`.mise.toml`), gh is managed via devcontainer feature
+- **Tool policy**: Development tools are managed by mise (not in package.json devDependencies)
+- **Linting/Formatting**:
+  - shellcheck + shfmt (Shell)
+  - mdformat + markdownlint-cli2 (Markdown)
+  - yamlfmt + yamllint (YAML)
+  - taplo (TOML)
+  - dockerfmt + hadolint (Dockerfile)
+  - actionlint (GitHub Actions)
+<!-- SECTION:TECH_STACK -->
+- **Security scanning**: Gitleaks (secrets)
+<!-- SECTION:TECH_STACK_LINTING -->
+- **MCP servers**: <!-- SECTION:TECH_STACK_MCP --> — configured via Codex MCP settings
+- **Git hooks**: lefthook (commit-msg: commitlint, pre-commit: linters + gitleaks, pre-push: <!-- SECTION:PRE_PUSH_HOOKS -->)
+
+## Project Structure
+
+```text
+scripts/      -> Shell scripts (setup, etc.)
+docs/         -> Documentation (branch strategy, etc.)
+<!-- SECTION:PROJECT_STRUCTURE -->
+<!-- SECTION:INFRA_STRUCTURE -->
+```
+
+## Key Commands
+
+```bash
+# Setup
+scripts/setup.sh          # Full environment setup
+mise install               # Install all tools
+<!-- SECTION:SETUP_COMMANDS -->
+
+# Lint & Format
+pnpm run lint:md           # Markdown lint (markdownlint-cli2)
+pnpm run lint:yaml         # YAML lint (yamllint)
+pnpm run lint:shell        # Shell lint (shellcheck + shfmt check)
+pnpm run lint:toml         # TOML format check (taplo)
+pnpm run lint:docker       # Dockerfile lint (hadolint)
+pnpm run lint:actions      # GitHub Actions lint (actionlint)
+pnpm run lint:secrets      # Secret detection (Gitleaks)
+<!-- SECTION:LINT_COMMANDS -->
+# Test
+<!-- SECTION:TEST_COMMANDS -->
+```
+
+## Coding Conventions
+
+- Indent: 2 spaces (JSON/YAML)
+- Line endings: LF only
+- All code must pass linters before committing
+- YAML file extension: `.yaml` (not `.yml`, unless required by tools)
+- Shell: must pass shellcheck and shfmt
+- Dockerfile: must pass hadolint
+- GitHub Actions: must pass actionlint
+- Security: must pass Gitleaks secret detection
+<!-- SECTION:CODING_CONVENTIONS -->
+
+## Commit Convention
+
+Conventional Commits required (enforced by commitlint):
+
+```text
+<type>[optional scope]: <description>
+```
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`
+
+Breaking changes: add `!` after type (e.g., `feat!: ...`) or `BREAKING CHANGE:` footer.
+
+## Branching
+
+GitHub Flow: `main` + feature branches. **squash merge only**.
+Branch naming: `<type>/<short-description>` (e.g., `feat/add-auth`, `fix/login-error`).
+See [`docs/branch-strategy.md`](docs/branch-strategy.md) for details.
+
+## Git Workflow
+
+- Lefthook `commit-msg` hook validates Conventional Commits format
+- Lefthook `pre-commit` runs linters (auto-fixes staged)
+- CI validates all linters on PRs
+- Renovate manages dependency updates
+
+<!-- SECTION:CD_SECTION -->

--- a/tests/presets/codex.test.ts
+++ b/tests/presets/codex.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+import { generate } from "../../src/generator.js";
+import { makeAnswers } from "../helpers.js";
+
+describe("generate (codex)", () => {
+  const result = generate(makeAnswers({ agents: ["codex"] }));
+
+  it("generates AGENTS.md instruction file", () => {
+    expect(result.hasFile("AGENTS.md")).toBe(true);
+    const agents = result.readText("AGENTS.md");
+    expect(agents).toContain("test-app");
+    expect(agents).not.toContain("{{projectName}}");
+  });
+
+  it("writes MCP servers to .codex/config.toml", () => {
+    expect(result.hasFile(".codex/config.toml")).toBe(true);
+    const toml = result.readText(".codex/config.toml");
+    expect(toml).toContain("[mcp_servers.context7]");
+    expect(toml).toContain("[mcp_servers.fetch]");
+  });
+
+  it("adds OPENAI_API_KEY to devcontainer remoteEnv", () => {
+    const dc = result.readJson(".devcontainer/devcontainer.json") as Record<string, unknown>;
+    const remoteEnv = dc.remoteEnv as Record<string, string>;
+    expect(remoteEnv.OPENAI_API_KEY).toBeDefined();
+  });
+
+  it("expands AGENTS.md with agent-instructions sections", () => {
+    const agents = result.readText("AGENTS.md");
+    // No leftover placeholders
+    expect(agents).not.toContain("<!-- SECTION:TECH_STACK -->");
+    expect(agents).not.toContain("<!-- SECTION:PRE_PUSH_HOOKS -->");
+  });
+
+  it("does not generate Claude Code files", () => {
+    expect(result.hasFile("CLAUDE.md")).toBe(false);
+    expect(result.hasFile(".claude/settings.json")).toBe(false);
+    expect(result.hasFile(".mcp.json")).toBe(false);
+  });
+
+  it("includes cloud MCP servers when cloud is selected", () => {
+    const withAws = generate(makeAnswers({ agents: ["codex"], clouds: ["aws"] }));
+    const toml = withAws.readText(".codex/config.toml");
+    expect(toml).toContain("[mcp_servers.context7]");
+    expect(toml).toContain("[mcp_servers.aws-iac]");
+  });
+});


### PR DESCRIPTION
## Summary

- OpenAI Codex CLI 向けプリセット（Agent Layer 6）を追加
- `AGENTS.md` 指示ファイルテンプレート（セクション注入プレースホルダー付き）
- MCP サーバーを `.codex/config.toml` に TOML 形式で出力
- `OPENAI_API_KEY` を devcontainer の remoteEnv に追加
- MCP 出力ロジックを汎化: Agent プリセットごとの設定ファイルに配分
  - claude-code → `.mcp.json` (JSON)
  - codex → `.codex/config.toml` (TOML)

## Test plan

- [x] `pnpm run build` — ビルド成功
- [x] `pnpm test` — 449 テスト全通過（+6 新規テスト）
- [x] `pnpm run typecheck` — 型チェック通過
- [x] Biome lint — 通過
- [x] Codex 選択時に AGENTS.md と .codex/config.toml が生成されることを確認
- [x] Cloud MCP サーバーが TOML 形式で正しく出力されることを確認
- [x] Claude Code のみ選択時に既存動作が維持されることを確認

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)