### PR TITLE
feat: add Gemini CLI preset

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -172,6 +172,11 @@ export async function runWizard(defaultName?: string): Promise<WizardAnswers> {
               label: t("wizard.agents.codex.label"),
               hint: t("wizard.agents.codex.hint"),
             },
+            {
+              value: "gemini" as const,
+              label: t("wizard.agents.gemini.label"),
+              hint: t("wizard.agents.gemini.hint"),
+            },
           ],
           required: false,
         }),

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -11,6 +11,7 @@ import { codexPreset } from "./presets/codex.js";
 import { expressPreset } from "./presets/express.js";
 import { fastapiPreset } from "./presets/fastapi.js";
 import { gcpPreset } from "./presets/gcp.js";
+import { geminiPreset } from "./presets/gemini.js";
 import { nextjsPreset } from "./presets/nextjs.js";
 import { pythonPreset } from "./presets/python.js";
 import { reactPreset } from "./presets/react.js";
@@ -44,6 +45,7 @@ const ALL_PRESETS: Record<string, Preset> = {
   bicep: bicepPreset,
   "claude-code": claudeCodePreset,
   codex: codexPreset,
+  gemini: geminiPreset,
 };
 
 /**
@@ -88,6 +90,7 @@ const PRESET_ORDER = [
   "bicep",
   "claude-code",
   "codex",
+  "gemini",
 ];
 
 /** Resolve which presets to apply based on wizard answers, including dependency chains. */
@@ -273,6 +276,7 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
     const AGENT_MCP_FILES: Record<string, { path: string; format: "json" | "toml" }> = {
       "claude-code": { path: ".mcp.json", format: "json" },
       codex: { path: ".codex/config.toml", format: "toml" },
+      gemini: { path: ".gemini/settings.json", format: "json" },
     };
     for (const name of presetNames) {
       const config = AGENT_MCP_FILES[name];
@@ -301,6 +305,7 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
   const AGENT_INSTRUCTION_FILES: Record<string, string> = {
     "claude-code": "CLAUDE.md",
     codex: "AGENTS.md",
+    gemini: "GEMINI.md",
   };
   const instructionTargets = presetNames
     .filter((name) => name in AGENT_INSTRUCTION_FILES)

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -47,7 +47,8 @@
       "message": "AI Agent tools",
       "hint": "Add agent-specific project config, rules, and MCP servers",
       "claude-code": { "label": "Claude Code", "hint": "CLAUDE.md, skills, rules" },
-      "codex": { "label": "Codex CLI", "hint": "AGENTS.md, MCP" }
+      "codex": { "label": "Codex CLI", "hint": "AGENTS.md, MCP" },
+      "gemini": { "label": "Gemini CLI", "hint": "GEMINI.md, MCP" }
     }
   },
   "overwrite": {

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -47,7 +47,8 @@
       "message": "AI エージェントツール",
       "hint": "エージェント固有のプロジェクト設定・ルール・MCP サーバーを追加",
       "claude-code": { "label": "Claude Code", "hint": "CLAUDE.md, スキル, ルール" },
-      "codex": { "label": "Codex CLI", "hint": "AGENTS.md, MCP" }
+      "codex": { "label": "Codex CLI", "hint": "AGENTS.md, MCP" },
+      "gemini": { "label": "Gemini CLI", "hint": "GEMINI.md, MCP" }
     }
   },
   "overwrite": {

--- a/src/presets/gemini.ts
+++ b/src/presets/gemini.ts
@@ -1,0 +1,30 @@
+import type { Preset } from "../types.js";
+import { readTemplateFiles } from "../utils.js";
+
+export const geminiPreset: Preset = {
+  name: "gemini",
+  files: readTemplateFiles("gemini"),
+  merge: {
+    ".gitignore": ".gemini/.env",
+    ".devcontainer/devcontainer.json": {
+      remoteEnv: {
+        // biome-ignore lint/suspicious/noTemplateCurlyInString: devcontainer variable syntax
+        GEMINI_API_KEY: "${localEnv:GEMINI_API_KEY}",
+      },
+    },
+  },
+  mcpServers: {
+    context7: {
+      command: "npx",
+      args: ["-y", "@upstash/context7-mcp@latest"],
+    },
+    fetch: {
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-fetch"],
+    },
+  },
+  markdown: {
+    "agent-instructions": [],
+    "README.md": [],
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface WizardAnswers {
   clouds: Array<"aws" | "azure" | "gcp">;
   iac: Array<"cdk" | "cloudformation" | "terraform" | "bicep">;
   languages: Array<"typescript" | "python">;
-  agents: Array<"claude-code" | "codex">;
+  agents: Array<"claude-code" | "codex" | "gemini">;
 }
 
 // --- Markdown template ---

--- a/templates/gemini/GEMINI.md
+++ b/templates/gemini/GEMINI.md
@@ -1,0 +1,91 @@
+# GEMINI.md
+
+## Project Overview
+
+{{projectName}}: AI-agent-native development project.
+
+## Tech Stack
+
+- **Version management**: mise (`.mise.toml`), gh is managed via devcontainer feature
+- **Tool policy**: Development tools are managed by mise (not in package.json devDependencies)
+- **Linting/Formatting**:
+  - shellcheck + shfmt (Shell)
+  - mdformat + markdownlint-cli2 (Markdown)
+  - yamlfmt + yamllint (YAML)
+  - taplo (TOML)
+  - dockerfmt + hadolint (Dockerfile)
+  - actionlint (GitHub Actions)
+<!-- SECTION:TECH_STACK -->
+- **Security scanning**: Gitleaks (secrets)
+<!-- SECTION:TECH_STACK_LINTING -->
+- **MCP servers**: <!-- SECTION:TECH_STACK_MCP --> — configured in `.gemini/settings.json`
+- **Git hooks**: lefthook (commit-msg: commitlint, pre-commit: linters + gitleaks, pre-push: <!-- SECTION:PRE_PUSH_HOOKS -->)
+
+## Project Structure
+
+```text
+scripts/      -> Shell scripts (setup, etc.)
+docs/         -> Documentation (branch strategy, etc.)
+<!-- SECTION:PROJECT_STRUCTURE -->
+<!-- SECTION:INFRA_STRUCTURE -->
+```
+
+## Key Commands
+
+```bash
+# Setup
+scripts/setup.sh          # Full environment setup
+mise install               # Install all tools
+<!-- SECTION:SETUP_COMMANDS -->
+
+# Lint & Format
+pnpm run lint:md           # Markdown lint (markdownlint-cli2)
+pnpm run lint:yaml         # YAML lint (yamllint)
+pnpm run lint:shell        # Shell lint (shellcheck + shfmt check)
+pnpm run lint:toml         # TOML format check (taplo)
+pnpm run lint:docker       # Dockerfile lint (hadolint)
+pnpm run lint:actions      # GitHub Actions lint (actionlint)
+pnpm run lint:secrets      # Secret detection (Gitleaks)
+<!-- SECTION:LINT_COMMANDS -->
+# Test
+<!-- SECTION:TEST_COMMANDS -->
+```
+
+## Coding Conventions
+
+- Indent: 2 spaces (JSON/YAML)
+- Line endings: LF only
+- All code must pass linters before committing
+- YAML file extension: `.yaml` (not `.yml`, unless required by tools)
+- Shell: must pass shellcheck and shfmt
+- Dockerfile: must pass hadolint
+- GitHub Actions: must pass actionlint
+- Security: must pass Gitleaks secret detection
+<!-- SECTION:CODING_CONVENTIONS -->
+
+## Commit Convention
+
+Conventional Commits required (enforced by commitlint):
+
+```text
+<type>[optional scope]: <description>
+```
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`
+
+Breaking changes: add `!` after type (e.g., `feat!: ...`) or `BREAKING CHANGE:` footer.
+
+## Branching
+
+GitHub Flow: `main` + feature branches. **squash merge only**.
+Branch naming: `<type>/<short-description>` (e.g., `feat/add-auth`, `fix/login-error`).
+See [`docs/branch-strategy.md`](docs/branch-strategy.md) for details.
+
+## Git Workflow
+
+- Lefthook `commit-msg` hook validates Conventional Commits format
+- Lefthook `pre-commit` runs linters (auto-fixes staged)
+- CI validates all linters on PRs
+- Renovate manages dependency updates
+
+<!-- SECTION:CD_SECTION -->

--- a/tests/presets/gemini.test.ts
+++ b/tests/presets/gemini.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { generate } from "../../src/generator.js";
+import { makeAnswers } from "../helpers.js";
+
+describe("generate (gemini)", () => {
+  const result = generate(makeAnswers({ agents: ["gemini"] }));
+
+  it("generates GEMINI.md instruction file", () => {
+    expect(result.hasFile("GEMINI.md")).toBe(true);
+    const gemini = result.readText("GEMINI.md");
+    expect(gemini).toContain("test-app");
+    expect(gemini).not.toContain("{{projectName}}");
+  });
+
+  it("writes MCP servers to .gemini/settings.json", () => {
+    expect(result.hasFile(".gemini/settings.json")).toBe(true);
+    const settings = result.readJson(".gemini/settings.json") as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(settings.mcpServers.context7).toBeDefined();
+    expect(settings.mcpServers.fetch).toBeDefined();
+  });
+
+  it("adds GEMINI_API_KEY to devcontainer remoteEnv", () => {
+    const dc = result.readJson(".devcontainer/devcontainer.json") as Record<string, unknown>;
+    const remoteEnv = dc.remoteEnv as Record<string, string>;
+    expect(remoteEnv.GEMINI_API_KEY).toBeDefined();
+  });
+
+  it("adds .gemini/.env to .gitignore", () => {
+    const gitignore = result.readText(".gitignore");
+    expect(gitignore).toContain(".gemini/.env");
+  });
+
+  it("expands GEMINI.md with agent-instructions sections", () => {
+    const gemini = result.readText("GEMINI.md");
+    expect(gemini).not.toContain("<!-- SECTION:TECH_STACK -->");
+    expect(gemini).not.toContain("<!-- SECTION:PRE_PUSH_HOOKS -->");
+  });
+
+  it("does not generate Claude Code or Codex files", () => {
+    expect(result.hasFile("CLAUDE.md")).toBe(false);
+    expect(result.hasFile("AGENTS.md")).toBe(false);
+    expect(result.hasFile(".mcp.json")).toBe(false);
+    expect(result.hasFile(".codex/config.toml")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Google Gemini CLI 向けプリセット（Agent Layer 6）を追加
- `GEMINI.md` 指示ファイルテンプレート（セクション注入プレースホルダー付き）
- MCP サーバーを `.gemini/settings.json` に JSON 形式で出力
- `GEMINI_API_KEY` を devcontainer の remoteEnv に追加
- `.gemini/.env` を .gitignore に追加

## Test plan

- [x] `pnpm run build` — ビルド成功
- [x] `pnpm test` — 455 テスト全通過（+6 新規テスト）
- [x] `pnpm run typecheck` — 型チェック通過
- [x] Biome lint — 通過

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)