### PR TITLE
feat: add Amazon Q Developer preset

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -177,6 +177,11 @@ export async function runWizard(defaultName?: string): Promise<WizardAnswers> {
               label: t("wizard.agents.gemini.label"),
               hint: t("wizard.agents.gemini.hint"),
             },
+            {
+              value: "amazon-q" as const,
+              label: t("wizard.agents.amazon-q.label"),
+              hint: t("wizard.agents.amazon-q.hint"),
+            },
           ],
           required: false,
         }),

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,5 +1,6 @@
 import { buildCiWorkflow } from "./ci.js";
 import { expandMarkdown, formatMcpJson, formatMcpToml, mergeFile } from "./merge.js";
+import { amazonQPreset } from "./presets/amazon-q.js";
 import { awsPreset } from "./presets/aws.js";
 import { azurePreset } from "./presets/azure.js";
 import { basePreset } from "./presets/base.js";
@@ -46,6 +47,7 @@ const ALL_PRESETS: Record<string, Preset> = {
   "claude-code": claudeCodePreset,
   codex: codexPreset,
   gemini: geminiPreset,
+  "amazon-q": amazonQPreset,
 };
 
 /**
@@ -91,6 +93,7 @@ const PRESET_ORDER = [
   "claude-code",
   "codex",
   "gemini",
+  "amazon-q",
 ];
 
 /** Resolve which presets to apply based on wizard answers, including dependency chains. */
@@ -277,6 +280,7 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
       "claude-code": { path: ".mcp.json", format: "json" },
       codex: { path: ".codex/config.toml", format: "toml" },
       gemini: { path: ".gemini/settings.json", format: "json" },
+      "amazon-q": { path: ".amazonq/mcp.json", format: "json" },
     };
     for (const name of presetNames) {
       const config = AGENT_MCP_FILES[name];
@@ -306,6 +310,7 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
     "claude-code": "CLAUDE.md",
     codex: "AGENTS.md",
     gemini: "GEMINI.md",
+    "amazon-q": ".amazonq/rules/project.md",
   };
   const instructionTargets = presetNames
     .filter((name) => name in AGENT_INSTRUCTION_FILES)

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -48,7 +48,8 @@
       "hint": "Add agent-specific project config, rules, and MCP servers",
       "claude-code": { "label": "Claude Code", "hint": "CLAUDE.md, skills, rules" },
       "codex": { "label": "Codex CLI", "hint": "AGENTS.md, MCP" },
-      "gemini": { "label": "Gemini CLI", "hint": "GEMINI.md, MCP" }
+      "gemini": { "label": "Gemini CLI", "hint": "GEMINI.md, MCP" },
+      "amazon-q": { "label": "Amazon Q Developer", "hint": "project rules, MCP" }
     }
   },
   "overwrite": {

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -48,7 +48,8 @@
       "hint": "エージェント固有のプロジェクト設定・ルール・MCP サーバーを追加",
       "claude-code": { "label": "Claude Code", "hint": "CLAUDE.md, スキル, ルール" },
       "codex": { "label": "Codex CLI", "hint": "AGENTS.md, MCP" },
-      "gemini": { "label": "Gemini CLI", "hint": "GEMINI.md, MCP" }
+      "gemini": { "label": "Gemini CLI", "hint": "GEMINI.md, MCP" },
+      "amazon-q": { "label": "Amazon Q Developer", "hint": "プロジェクトルール, MCP" }
     }
   },
   "overwrite": {

--- a/src/presets/amazon-q.ts
+++ b/src/presets/amazon-q.ts
@@ -1,0 +1,22 @@
+import type { Preset } from "../types.js";
+import { readTemplateFiles } from "../utils.js";
+
+export const amazonQPreset: Preset = {
+  name: "amazon-q",
+  files: readTemplateFiles("amazon-q"),
+  merge: {},
+  mcpServers: {
+    context7: {
+      command: "npx",
+      args: ["-y", "@upstash/context7-mcp@latest"],
+    },
+    fetch: {
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-fetch"],
+    },
+  },
+  markdown: {
+    "agent-instructions": [],
+    "README.md": [],
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface WizardAnswers {
   clouds: Array<"aws" | "azure" | "gcp">;
   iac: Array<"cdk" | "cloudformation" | "terraform" | "bicep">;
   languages: Array<"typescript" | "python">;
-  agents: Array<"claude-code" | "codex" | "gemini">;
+  agents: Array<"claude-code" | "codex" | "gemini" | "amazon-q">;
 }
 
 // --- Markdown template ---

--- a/templates/amazon-q/.amazonq/rules/project.md
+++ b/templates/amazon-q/.amazonq/rules/project.md
@@ -1,0 +1,91 @@
+# Project Rules
+
+## Project Overview
+
+{{projectName}}: AI-agent-native development project.
+
+## Tech Stack
+
+- **Version management**: mise (`.mise.toml`), gh is managed via devcontainer feature
+- **Tool policy**: Development tools are managed by mise (not in package.json devDependencies)
+- **Linting/Formatting**:
+  - shellcheck + shfmt (Shell)
+  - mdformat + markdownlint-cli2 (Markdown)
+  - yamlfmt + yamllint (YAML)
+  - taplo (TOML)
+  - dockerfmt + hadolint (Dockerfile)
+  - actionlint (GitHub Actions)
+<!-- SECTION:TECH_STACK -->
+- **Security scanning**: Gitleaks (secrets)
+<!-- SECTION:TECH_STACK_LINTING -->
+- **MCP servers**: <!-- SECTION:TECH_STACK_MCP --> — configured in `.amazonq/mcp.json`
+- **Git hooks**: lefthook (commit-msg: commitlint, pre-commit: linters + gitleaks, pre-push: <!-- SECTION:PRE_PUSH_HOOKS -->)
+
+## Project Structure
+
+```text
+scripts/      -> Shell scripts (setup, etc.)
+docs/         -> Documentation (branch strategy, etc.)
+<!-- SECTION:PROJECT_STRUCTURE -->
+<!-- SECTION:INFRA_STRUCTURE -->
+```
+
+## Key Commands
+
+```bash
+# Setup
+scripts/setup.sh          # Full environment setup
+mise install               # Install all tools
+<!-- SECTION:SETUP_COMMANDS -->
+
+# Lint & Format
+pnpm run lint:md           # Markdown lint (markdownlint-cli2)
+pnpm run lint:yaml         # YAML lint (yamllint)
+pnpm run lint:shell        # Shell lint (shellcheck + shfmt check)
+pnpm run lint:toml         # TOML format check (taplo)
+pnpm run lint:docker       # Dockerfile lint (hadolint)
+pnpm run lint:actions      # GitHub Actions lint (actionlint)
+pnpm run lint:secrets      # Secret detection (Gitleaks)
+<!-- SECTION:LINT_COMMANDS -->
+# Test
+<!-- SECTION:TEST_COMMANDS -->
+```
+
+## Coding Conventions
+
+- Indent: 2 spaces (JSON/YAML)
+- Line endings: LF only
+- All code must pass linters before committing
+- YAML file extension: `.yaml` (not `.yml`, unless required by tools)
+- Shell: must pass shellcheck and shfmt
+- Dockerfile: must pass hadolint
+- GitHub Actions: must pass actionlint
+- Security: must pass Gitleaks secret detection
+<!-- SECTION:CODING_CONVENTIONS -->
+
+## Commit Convention
+
+Conventional Commits required (enforced by commitlint):
+
+```text
+<type>[optional scope]: <description>
+```
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`
+
+Breaking changes: add `!` after type (e.g., `feat!: ...`) or `BREAKING CHANGE:` footer.
+
+## Branching
+
+GitHub Flow: `main` + feature branches. **squash merge only**.
+Branch naming: `<type>/<short-description>` (e.g., `feat/add-auth`, `fix/login-error`).
+See [`docs/branch-strategy.md`](docs/branch-strategy.md) for details.
+
+## Git Workflow
+
+- Lefthook `commit-msg` hook validates Conventional Commits format
+- Lefthook `pre-commit` runs linters (auto-fixes staged)
+- CI validates all linters on PRs
+- Renovate manages dependency updates
+
+<!-- SECTION:CD_SECTION -->

--- a/tests/presets/amazon-q.test.ts
+++ b/tests/presets/amazon-q.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { generate } from "../../src/generator.js";
+import { makeAnswers } from "../helpers.js";
+
+describe("generate (amazon-q)", () => {
+  const result = generate(makeAnswers({ agents: ["amazon-q"] }));
+
+  it("generates .amazonq/rules/project.md instruction file", () => {
+    expect(result.hasFile(".amazonq/rules/project.md")).toBe(true);
+    const rules = result.readText(".amazonq/rules/project.md");
+    expect(rules).toContain("test-app");
+    expect(rules).not.toContain("{{projectName}}");
+  });
+
+  it("writes MCP servers to .amazonq/mcp.json", () => {
+    expect(result.hasFile(".amazonq/mcp.json")).toBe(true);
+    const mcp = result.readJson(".amazonq/mcp.json") as Record<string, Record<string, unknown>>;
+    expect(mcp.mcpServers.context7).toBeDefined();
+    expect(mcp.mcpServers.fetch).toBeDefined();
+  });
+
+  it("expands instruction file with agent-instructions sections", () => {
+    const rules = result.readText(".amazonq/rules/project.md");
+    expect(rules).not.toContain("<!-- SECTION:TECH_STACK -->");
+    expect(rules).not.toContain("<!-- SECTION:PRE_PUSH_HOOKS -->");
+  });
+
+  it("does not generate other agent files", () => {
+    expect(result.hasFile("CLAUDE.md")).toBe(false);
+    expect(result.hasFile("AGENTS.md")).toBe(false);
+    expect(result.hasFile("GEMINI.md")).toBe(false);
+    expect(result.hasFile(".mcp.json")).toBe(false);
+  });
+
+  it("includes cloud MCP servers when cloud is selected", () => {
+    const withAws = generate(makeAnswers({ agents: ["amazon-q"], clouds: ["aws"] }));
+    const mcp = withAws.readJson(".amazonq/mcp.json") as Record<string, Record<string, unknown>>;
+    expect(mcp.mcpServers["aws-iac"]).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Amazon Q Developer 向けプリセット（Agent Layer 6）を追加
- `.amazonq/rules/project.md` 指示ファイル（セクション注入プレースホルダー付き）
- MCP サーバーを `.amazonq/mcp.json` に JSON 形式で出力
- AWS 認証は aws プリセット側で処理済み（追加 devcontainer 設定なし）

## Test plan

- [x] `pnpm run build` — ビルド成功
- [x] `pnpm test` — 460 テスト全通過（+5 新規テスト）
- [x] `pnpm run typecheck` — 型チェック通過
- [x] Biome lint — 通過

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)