### PR TITLE
feat: add GitHub Copilot preset

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -182,6 +182,11 @@ export async function runWizard(defaultName?: string): Promise<WizardAnswers> {
               label: t("wizard.agents.amazon-q.label"),
               hint: t("wizard.agents.amazon-q.hint"),
             },
+            {
+              value: "copilot" as const,
+              label: t("wizard.agents.copilot.label"),
+              hint: t("wizard.agents.copilot.hint"),
+            },
           ],
           required: false,
         }),

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -9,6 +9,7 @@ import { cdkPreset } from "./presets/cdk.js";
 import { claudeCodePreset } from "./presets/claude-code.js";
 import { cloudformationPreset } from "./presets/cloudformation.js";
 import { codexPreset } from "./presets/codex.js";
+import { copilotPreset } from "./presets/copilot.js";
 import { expressPreset } from "./presets/express.js";
 import { fastapiPreset } from "./presets/fastapi.js";
 import { gcpPreset } from "./presets/gcp.js";
@@ -48,6 +49,7 @@ const ALL_PRESETS: Record<string, Preset> = {
   codex: codexPreset,
   gemini: geminiPreset,
   "amazon-q": amazonQPreset,
+  copilot: copilotPreset,
 };
 
 /**
@@ -94,6 +96,7 @@ const PRESET_ORDER = [
   "codex",
   "gemini",
   "amazon-q",
+  "copilot",
 ];
 
 /** Resolve which presets to apply based on wizard answers, including dependency chains. */
@@ -281,6 +284,7 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
       codex: { path: ".codex/config.toml", format: "toml" },
       gemini: { path: ".gemini/settings.json", format: "json" },
       "amazon-q": { path: ".amazonq/mcp.json", format: "json" },
+      copilot: { path: ".copilot/mcp-config.json", format: "json" },
     };
     for (const name of presetNames) {
       const config = AGENT_MCP_FILES[name];
@@ -311,6 +315,7 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
     codex: "AGENTS.md",
     gemini: "GEMINI.md",
     "amazon-q": ".amazonq/rules/project.md",
+    copilot: ".github/copilot-instructions.md",
   };
   const instructionTargets = presetNames
     .filter((name) => name in AGENT_INSTRUCTION_FILES)

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -49,7 +49,8 @@
       "claude-code": { "label": "Claude Code", "hint": "CLAUDE.md, skills, rules" },
       "codex": { "label": "Codex CLI", "hint": "AGENTS.md, MCP" },
       "gemini": { "label": "Gemini CLI", "hint": "GEMINI.md, MCP" },
-      "amazon-q": { "label": "Amazon Q Developer", "hint": "project rules, MCP" }
+      "amazon-q": { "label": "Amazon Q Developer", "hint": "project rules, MCP" },
+      "copilot": { "label": "GitHub Copilot", "hint": "copilot-instructions.md, MCP" }
     }
   },
   "overwrite": {

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -49,7 +49,8 @@
       "claude-code": { "label": "Claude Code", "hint": "CLAUDE.md, スキル, ルール" },
       "codex": { "label": "Codex CLI", "hint": "AGENTS.md, MCP" },
       "gemini": { "label": "Gemini CLI", "hint": "GEMINI.md, MCP" },
-      "amazon-q": { "label": "Amazon Q Developer", "hint": "プロジェクトルール, MCP" }
+      "amazon-q": { "label": "Amazon Q Developer", "hint": "プロジェクトルール, MCP" },
+      "copilot": { "label": "GitHub Copilot", "hint": "copilot-instructions.md, MCP" }
     }
   },
   "overwrite": {

--- a/src/presets/copilot.ts
+++ b/src/presets/copilot.ts
@@ -1,0 +1,22 @@
+import type { Preset } from "../types.js";
+import { readTemplateFiles } from "../utils.js";
+
+export const copilotPreset: Preset = {
+  name: "copilot",
+  files: readTemplateFiles("copilot"),
+  merge: {},
+  mcpServers: {
+    context7: {
+      command: "npx",
+      args: ["-y", "@upstash/context7-mcp@latest"],
+    },
+    fetch: {
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-fetch"],
+    },
+  },
+  markdown: {
+    "agent-instructions": [],
+    "README.md": [],
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export interface WizardAnswers {
   clouds: Array<"aws" | "azure" | "gcp">;
   iac: Array<"cdk" | "cloudformation" | "terraform" | "bicep">;
   languages: Array<"typescript" | "python">;
-  agents: Array<"claude-code" | "codex" | "gemini" | "amazon-q">;
+  agents: Array<"claude-code" | "codex" | "gemini" | "amazon-q" | "copilot">;
 }
 
 // --- Markdown template ---

--- a/templates/copilot/.github/copilot-instructions.md
+++ b/templates/copilot/.github/copilot-instructions.md
@@ -1,0 +1,91 @@
+# Copilot Instructions
+
+## Project Overview
+
+{{projectName}}: AI-agent-native development project.
+
+## Tech Stack
+
+- **Version management**: mise (`.mise.toml`), gh is managed via devcontainer feature
+- **Tool policy**: Development tools are managed by mise (not in package.json devDependencies)
+- **Linting/Formatting**:
+  - shellcheck + shfmt (Shell)
+  - mdformat + markdownlint-cli2 (Markdown)
+  - yamlfmt + yamllint (YAML)
+  - taplo (TOML)
+  - dockerfmt + hadolint (Dockerfile)
+  - actionlint (GitHub Actions)
+<!-- SECTION:TECH_STACK -->
+- **Security scanning**: Gitleaks (secrets)
+<!-- SECTION:TECH_STACK_LINTING -->
+- **MCP servers**: <!-- SECTION:TECH_STACK_MCP --> — configured in `.copilot/mcp-config.json`
+- **Git hooks**: lefthook (commit-msg: commitlint, pre-commit: linters + gitleaks, pre-push: <!-- SECTION:PRE_PUSH_HOOKS -->)
+
+## Project Structure
+
+```text
+scripts/      -> Shell scripts (setup, etc.)
+docs/         -> Documentation (branch strategy, etc.)
+<!-- SECTION:PROJECT_STRUCTURE -->
+<!-- SECTION:INFRA_STRUCTURE -->
+```
+
+## Key Commands
+
+```bash
+# Setup
+scripts/setup.sh          # Full environment setup
+mise install               # Install all tools
+<!-- SECTION:SETUP_COMMANDS -->
+
+# Lint & Format
+pnpm run lint:md           # Markdown lint (markdownlint-cli2)
+pnpm run lint:yaml         # YAML lint (yamllint)
+pnpm run lint:shell        # Shell lint (shellcheck + shfmt check)
+pnpm run lint:toml         # TOML format check (taplo)
+pnpm run lint:docker       # Dockerfile lint (hadolint)
+pnpm run lint:actions      # GitHub Actions lint (actionlint)
+pnpm run lint:secrets      # Secret detection (Gitleaks)
+<!-- SECTION:LINT_COMMANDS -->
+# Test
+<!-- SECTION:TEST_COMMANDS -->
+```
+
+## Coding Conventions
+
+- Indent: 2 spaces (JSON/YAML)
+- Line endings: LF only
+- All code must pass linters before committing
+- YAML file extension: `.yaml` (not `.yml`, unless required by tools)
+- Shell: must pass shellcheck and shfmt
+- Dockerfile: must pass hadolint
+- GitHub Actions: must pass actionlint
+- Security: must pass Gitleaks secret detection
+<!-- SECTION:CODING_CONVENTIONS -->
+
+## Commit Convention
+
+Conventional Commits required (enforced by commitlint):
+
+```text
+<type>[optional scope]: <description>
+```
+
+Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`
+
+Breaking changes: add `!` after type (e.g., `feat!: ...`) or `BREAKING CHANGE:` footer.
+
+## Branching
+
+GitHub Flow: `main` + feature branches. **squash merge only**.
+Branch naming: `<type>/<short-description>` (e.g., `feat/add-auth`, `fix/login-error`).
+See [`docs/branch-strategy.md`](docs/branch-strategy.md) for details.
+
+## Git Workflow
+
+- Lefthook `commit-msg` hook validates Conventional Commits format
+- Lefthook `pre-commit` runs linters (auto-fixes staged)
+- CI validates all linters on PRs
+- Renovate manages dependency updates
+
+<!-- SECTION:CD_SECTION -->

--- a/tests/presets/copilot.test.ts
+++ b/tests/presets/copilot.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { generate } from "../../src/generator.js";
+import { makeAnswers } from "../helpers.js";
+
+describe("generate (copilot)", () => {
+  const result = generate(makeAnswers({ agents: ["copilot"] }));
+
+  it("generates .github/copilot-instructions.md", () => {
+    expect(result.hasFile(".github/copilot-instructions.md")).toBe(true);
+    const instructions = result.readText(".github/copilot-instructions.md");
+    expect(instructions).toContain("test-app");
+    expect(instructions).not.toContain("{{projectName}}");
+  });
+
+  it("writes MCP servers to .copilot/mcp-config.json", () => {
+    expect(result.hasFile(".copilot/mcp-config.json")).toBe(true);
+    const mcp = result.readJson(".copilot/mcp-config.json") as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(mcp.mcpServers.context7).toBeDefined();
+    expect(mcp.mcpServers.fetch).toBeDefined();
+  });
+
+  it("expands instruction file with agent-instructions sections", () => {
+    const instructions = result.readText(".github/copilot-instructions.md");
+    expect(instructions).not.toContain("<!-- SECTION:TECH_STACK -->");
+    expect(instructions).not.toContain("<!-- SECTION:PRE_PUSH_HOOKS -->");
+  });
+
+  it("does not generate other agent files", () => {
+    expect(result.hasFile("CLAUDE.md")).toBe(false);
+    expect(result.hasFile("AGENTS.md")).toBe(false);
+    expect(result.hasFile("GEMINI.md")).toBe(false);
+    expect(result.hasFile(".mcp.json")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- GitHub Copilot 向けプリセット（Agent Layer 6）を追加
- `.github/copilot-instructions.md` 指示ファイル（セクション注入プレースホルダー付き）
- MCP サーバーを `.copilot/mcp-config.json` に JSON 形式で出力
- 認証は GitHub OAuth（追加設定不要）

## Test plan

- [x] `pnpm run build` — ビルド成功
- [x] `pnpm test` — 464 テスト全通過（+4 新規テスト）
- [x] `pnpm run typecheck` — 型チェック通過
- [x] Biome lint — 通過

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)