### PR TITLE
fix: add safety guards and improve error handling

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -132,9 +132,14 @@ export function resolvePresets(answers: WizardAnswers): string[] {
     selected.add(agent);
   }
 
-  // Resolve `requires` chains
+  // Resolve `requires` chains (with guard against circular dependencies)
+  const MAX_RESOLVE_ITERATIONS = 100;
   let changed = true;
+  let iterations = 0;
   while (changed) {
+    if (++iterations > MAX_RESOLVE_ITERATIONS) {
+      throw new Error("Circular dependency detected in preset requires chains");
+    }
     changed = false;
     for (const name of [...selected]) {
       const preset = ALL_PRESETS[name];
@@ -213,7 +218,14 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
   // 2.5. Post-merge cleanup & lint:all generation for package.json
   const pkgContent = allFiles.get("package.json");
   if (pkgContent) {
-    const pkg = JSON.parse(pkgContent) as Record<string, Record<string, string>>;
+    let pkg: Record<string, Record<string, string>>;
+    try {
+      pkg = JSON.parse(pkgContent) as Record<string, Record<string, string>>;
+    } catch (e) {
+      throw new Error(
+        `Failed to parse merged package.json: ${e instanceof Error ? e.message : String(e)}`,
+      );
+    }
     const scripts = pkg.scripts ?? {};
 
     // Remove devDependencies not referenced by any script (e.g. tsdown when React overrides build)

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -60,26 +60,32 @@ export function expandMarkdown(template: string, sections: MarkdownSection[]): s
     const allLines = contents.flatMap((c) => c.split("\n"));
     const unique = [...new Set(allLines)].filter((l) => l !== "");
 
-    // Detect inline placeholder (preceded by non-whitespace on same line) → join with ", "
-    const idx = result.indexOf(placeholder);
-    let separator = "\n";
-    let needsLeadingSep = false;
-    if (idx > 0) {
-      const lineStart = result.lastIndexOf("\n", idx - 1) + 1;
-      const prefix = result.slice(lineStart, idx);
-      if (prefix.trim().length > 0) {
-        separator = ", ";
-        // If the char before the placeholder is not a natural separator, prepend one
-        const charBefore = result[idx - 1];
-        if (unique.length > 0 && !/[\s,:]/.test(charBefore)) {
-          needsLeadingSep = true;
+    // Replace each occurrence individually, detecting context per-occurrence
+    let searchFrom = 0;
+    while (true) {
+      const idx = result.indexOf(placeholder, searchFrom);
+      if (idx === -1) break;
+
+      // Detect inline placeholder (preceded by non-whitespace on same line) → join with ", "
+      let separator = "\n";
+      let needsLeadingSep = false;
+      if (idx > 0) {
+        const lineStart = result.lastIndexOf("\n", idx - 1) + 1;
+        const prefix = result.slice(lineStart, idx);
+        if (prefix.trim().length > 0) {
+          separator = ", ";
+          const charBefore = result[idx - 1];
+          if (unique.length > 0 && !/[\s,:]/.test(charBefore)) {
+            needsLeadingSep = true;
+          }
         }
       }
-    }
 
-    const joined = unique.join(separator);
-    const replacement = needsLeadingSep ? `${separator}${joined}` : joined;
-    result = result.replaceAll(placeholder, replacement);
+      const joined = unique.join(separator);
+      const replacement = needsLeadingSep ? `${separator}${joined}` : joined;
+      result = result.slice(0, idx) + replacement + result.slice(idx + placeholder.length);
+      searchFrom = idx + replacement.length;
+    }
   }
   return result;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -60,17 +60,29 @@ export function buildResult(files: Map<string, string>): GenerateResult {
     readJson: (p: string) => {
       const c = files.get(p);
       if (c === undefined) throw new Error(`File not found: ${p}`);
-      return JSON.parse(c) as unknown;
+      try {
+        return JSON.parse(c) as unknown;
+      } catch (e) {
+        throw new Error(`Invalid JSON in ${p}: ${e instanceof Error ? e.message : String(e)}`);
+      }
     },
     readYaml: (p: string) => {
       const c = files.get(p);
       if (c === undefined) throw new Error(`File not found: ${p}`);
-      return parseYaml(c) as unknown;
+      try {
+        return parseYaml(c) as unknown;
+      } catch (e) {
+        throw new Error(`Invalid YAML in ${p}: ${e instanceof Error ? e.message : String(e)}`);
+      }
     },
     readToml: (p: string) => {
       const c = files.get(p);
       if (c === undefined) throw new Error(`File not found: ${p}`);
-      return parseToml(c) as unknown;
+      try {
+        return parseToml(c) as unknown;
+      } catch (e) {
+        throw new Error(`Invalid TOML in ${p}: ${e instanceof Error ? e.message : String(e)}`);
+      }
     },
   };
 }

--- a/tests/merge.test.ts
+++ b/tests/merge.test.ts
@@ -154,6 +154,18 @@ describe("expandMarkdown", () => {
     ]);
     expect(result).toBe("<!-- SECTION:UNKNOWN -->");
   });
+
+  it("handles same placeholder in both inline and block contexts", () => {
+    const template = "Tools: <!-- SECTION:TOOLS -->\n\n## Details\n<!-- SECTION:TOOLS -->\nEnd";
+    const result = expandMarkdown(template, [
+      { placeholder: "<!-- SECTION:TOOLS -->", content: "Node.js" },
+      { placeholder: "<!-- SECTION:TOOLS -->", content: "pnpm" },
+    ]);
+    // First occurrence is inline → comma-separated
+    expect(result).toContain("Tools: Node.js, pnpm");
+    // Second occurrence is block → newline-separated
+    expect(result).toContain("## Details\nNode.js\npnpm\nEnd");
+  });
 });
 
 describe("mergeFile", () => {

--- a/tests/utils.test.ts
+++ b/tests/utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { buildResult } from "../src/utils.js";
+
+describe("buildResult parse error messages", () => {
+  it("readJson throws with file path on invalid JSON", () => {
+    const files = new Map([["config.json", "not valid json"]]);
+    const result = buildResult(files);
+    expect(() => result.readJson("config.json")).toThrow(/Invalid JSON in config\.json/);
+  });
+
+  it("readYaml throws with file path on invalid YAML", () => {
+    const files = new Map([["config.yaml", ":\n  :\n    - :\n  :\n:"]]);
+    const result = buildResult(files);
+    expect(() => result.readYaml("config.yaml")).toThrow(/Invalid YAML in config\.yaml/);
+  });
+
+  it("readToml throws with file path on invalid TOML", () => {
+    const files = new Map([["config.toml", "[invalid\nkey = "]]);
+    const result = buildResult(files);
+    expect(() => result.readToml("config.toml")).toThrow(/Invalid TOML in config\.toml/);
+  });
+
+  it("readJson still throws file-not-found for missing files", () => {
+    const result = buildResult(new Map());
+    expect(() => result.readJson("missing.json")).toThrow("File not found: missing.json");
+  });
+});


### PR DESCRIPTION
## Summary

- `resolvePresets()` に最大反復回数ガードを追加し、循環依存による無限ループを防止
- `expandMarkdown()` でプレースホルダー出現ごとにコンテキスト判定するよう修正（セパレータ不整合の解消）
- `readJson/readYaml/readToml` のパースエラーに適切なエラーメッセージを追加
- `generator.ts` の `package.json` パースに try-catch を追加

## Test plan

- [x] `pnpm run build` — ビルド成功
- [x] `pnpm test` — 464件全通過
- [x] `pnpm run typecheck` — 型チェック通過
- [x] Biome lint 通過
- [x] Gitleaks 通過