### PR TITLE
feat: show forced dependency hints in CLI wizard

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -41,20 +41,26 @@ function buildIacOptions(clouds: Array<"aws" | "azure" | "gcp">): Array<{
   return options;
 }
 
-/** Determine which languages are already forced by frontend/backend selections. */
+/** Determine which languages are already forced by frontend/backend/IaC selections, with reasons. */
 function resolvedLanguages(
   frontend: WizardAnswers["frontend"],
   backend: WizardAnswers["backend"],
   iac: WizardAnswers["iac"],
-): Set<"typescript" | "python"> {
-  const resolved = new Set<"typescript" | "python">();
+): Map<"typescript" | "python", string[]> {
+  const resolved = new Map<"typescript" | "python", string[]>();
+  const add = (lang: "typescript" | "python", source: string) => {
+    const sources = resolved.get(lang) ?? [];
+    sources.push(source);
+    resolved.set(lang, sources);
+  };
   // Frontend frameworks force TypeScript
-  if (frontend === "react" || frontend === "nextjs") resolved.add("typescript");
+  if (frontend === "react") add("typescript", t("wizard.frontend.react.label"));
+  if (frontend === "nextjs") add("typescript", t("wizard.frontend.nextjs.label"));
   // Backend frameworks force their language
-  if (backend === "fastapi") resolved.add("python");
-  if (backend === "express") resolved.add("typescript");
+  if (backend === "fastapi") add("python", t("wizard.backend.fastapi.label"));
+  if (backend === "express") add("typescript", t("wizard.backend.express.label"));
   // CDK forces TypeScript
-  if (iac.includes("cdk")) resolved.add("typescript");
+  if (iac.includes("cdk")) add("typescript", t("wizard.iac.cdk.label"));
   return resolved;
 }
 
@@ -137,6 +143,16 @@ export async function runWizard(defaultName?: string): Promise<WizardAnswers> {
         const backend = (results.backend ?? "none") as WizardAnswers["backend"];
         const iac = (results.iac ?? []) as WizardAnswers["iac"];
         const resolved = resolvedLanguages(frontend, backend, iac);
+
+        // Show hints for auto-selected languages
+        for (const [lang, sources] of resolved) {
+          p.log.info(
+            t("wizard.languages.autoSelected", {
+              lang: t(`wizard.languages.${lang}.label`),
+              sources: sources.join(", "),
+            }),
+          );
+        }
 
         // All languages already resolved by FW/IaC selections — skip
         if (resolved.has("typescript") && resolved.has("python")) return undefined;

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -12,7 +12,8 @@
       "message": "Language toolchains",
       "hint": "Each selection adds linters, formatters, and test setup",
       "typescript": { "label": "TypeScript" },
-      "python": { "label": "Python" }
+      "python": { "label": "Python" },
+      "autoSelected": "{{lang}} was auto-selected (required by {{sources}})"
     },
     "frontend": {
       "message": "Frontend app",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -12,7 +12,8 @@
       "message": "言語ツールチェイン",
       "hint": "選択ごとにリンター・フォーマッター・テスト環境を追加",
       "typescript": { "label": "TypeScript" },
-      "python": { "label": "Python" }
+      "python": { "label": "Python" },
+      "autoSelected": "{{lang}} は自動選択されました（{{sources}} に必要）"
     },
     "frontend": {
       "message": "フロントエンドアプリ",


### PR DESCRIPTION
## Summary

- CLI ウィザードの Language ステップで、フレームワーク/IaC 選択により自動選択された言語のヒントメッセージを表示
- 例: `ℹ TypeScript was auto-selected (required by React + Vite, CDK)`
- `resolvedLanguages()` を `Set` から `Map<lang, sources[]>` に拡張し、強制元の情報を保持
- i18n 対応（en/ja）

Closes #108