### PR TITLE
test: expand test coverage with content validation and edge cases

### DIFF
--- a/tests/content-validation.test.ts
+++ b/tests/content-validation.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Content validation tests — verify generated file contents beyond mere existence.
+ *
+ * Validates:
+ * - tsconfig.json structure (compilerOptions, strict mode, etc.)
+ * - YAML files parse correctly (ci.yaml, lefthook.yaml, etc.)
+ * - TOML files parse correctly (.mise.toml, pyproject.toml, etc.)
+ * - package.json dependencies use valid semver ranges
+ * - CI workflow step ordering (setup → lint → test → build)
+ * - CD workflow structure
+ */
+import { describe, expect, it } from "vitest";
+import { generate } from "../src/generator.js";
+import { makeAnswers } from "./helpers.js";
+
+// --- tsconfig.json structure validation ---
+
+describe("content: tsconfig.json structure", () => {
+  it("typescript preset generates valid tsconfig with strict mode", () => {
+    const result = generate(makeAnswers({ languages: ["typescript"] }));
+    const tsconfig = result.readJson("tsconfig.json") as Record<string, unknown>;
+    const opts = tsconfig.compilerOptions as Record<string, unknown>;
+    expect(opts, "compilerOptions should exist").toBeDefined();
+    expect(opts.strict, "strict should be true").toBe(true);
+    expect(opts.target, "target should be defined").toBeDefined();
+    expect(opts.module, "module should be defined").toBeDefined();
+  });
+
+  it("react preset generates root tsconfig with references or extends", () => {
+    const result = generate(makeAnswers({ frontend: "react" }));
+    const tsconfig = result.readJson("tsconfig.json") as Record<string, unknown>;
+    expect(
+      tsconfig.compilerOptions || tsconfig.references,
+      "should have compilerOptions or references",
+    ).toBeDefined();
+  });
+
+  it("CDK infra has its own tsconfig.json with strict mode", () => {
+    const result = generate(makeAnswers({ clouds: ["aws"], iac: ["cdk"] }));
+    const tsconfig = result.readJson("infra/tsconfig.json") as Record<string, unknown>;
+    const opts = tsconfig.compilerOptions as Record<string, unknown>;
+    expect(opts, "compilerOptions should exist").toBeDefined();
+    expect(opts.strict, "strict should be true").toBe(true);
+  });
+
+  it("express api has its own tsconfig.json", () => {
+    const result = generate(makeAnswers({ backend: "express" }));
+    const tsconfig = result.readJson("api/tsconfig.json") as Record<string, unknown>;
+    const opts = tsconfig.compilerOptions as Record<string, unknown>;
+    expect(opts, "compilerOptions should exist").toBeDefined();
+  });
+});
+
+// --- YAML file syntax validation ---
+
+describe("content: YAML files parse correctly", () => {
+  const combos = [
+    { name: "base only", answers: {} },
+    { name: "typescript", answers: { languages: ["typescript"] as const } },
+    { name: "python", answers: { languages: ["python"] as const } },
+    {
+      name: "react + fastapi",
+      answers: { frontend: "react" as const, backend: "fastapi" as const },
+    },
+    {
+      name: "full stack",
+      answers: {
+        frontend: "react" as const,
+        backend: "express" as const,
+        clouds: ["aws" as const],
+        iac: ["cdk" as const],
+      },
+    },
+  ];
+
+  for (const combo of combos) {
+    describe(combo.name, () => {
+      const result = generate(makeAnswers(combo.answers));
+
+      it("ci.yaml is valid YAML with expected structure", () => {
+        const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+        expect(ci.name, "CI workflow should have a name").toBe("CI");
+        expect(ci.on, "CI workflow should have triggers").toBeDefined();
+        expect(ci.jobs, "CI workflow should have jobs").toBeDefined();
+        const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+        expect(jobs["lint-and-check"], "should have lint-and-check job").toBeDefined();
+        expect(jobs["lint-and-check"]["runs-on"], "should run on ubuntu-latest").toBe(
+          "ubuntu-latest",
+        );
+      });
+
+      it("lefthook.yaml is valid YAML", () => {
+        const lh = result.readYaml("lefthook.yaml") as Record<string, unknown>;
+        expect(lh["commit-msg"], "should have commit-msg hook").toBeDefined();
+        expect(lh["pre-commit"], "should have pre-commit hook").toBeDefined();
+      });
+
+      it("all .yaml files parse without errors", () => {
+        for (const file of result.fileList()) {
+          if (file.endsWith(".yaml") && !file.startsWith("templates/")) {
+            expect(() => result.readYaml(file), `${file} should be valid YAML`).not.toThrow();
+          }
+        }
+      });
+    });
+  }
+});
+
+// --- TOML file syntax validation ---
+
+describe("content: TOML files parse correctly", () => {
+  it(".mise.toml is valid TOML with tools section", () => {
+    const result = generate(makeAnswers({ languages: ["typescript"] }));
+    const toml = result.readToml(".mise.toml") as Record<string, unknown>;
+    expect(toml.tools, ".mise.toml should have tools section").toBeDefined();
+  });
+
+  it("pyproject.toml is valid TOML with project section", () => {
+    const result = generate(makeAnswers({ languages: ["python"] }));
+    const toml = result.readToml("pyproject.toml") as Record<string, unknown>;
+    expect(
+      toml.project || toml.tool,
+      "pyproject.toml should have project or tool section",
+    ).toBeDefined();
+  });
+
+  it("all .toml files parse without errors", () => {
+    const result = generate(
+      makeAnswers({
+        languages: ["typescript", "python"],
+        frontend: "react",
+        backend: "fastapi",
+        clouds: ["aws"],
+        iac: ["cdk"],
+      }),
+    );
+    for (const file of result.fileList()) {
+      if (file.endsWith(".toml")) {
+        expect(() => result.readToml(file), `${file} should be valid TOML`).not.toThrow();
+      }
+    }
+  });
+});
+
+// --- package.json semver validation ---
+
+describe("content: package.json dependency versions", () => {
+  const semverPattern = /^[\^~>=<*]?\d|^workspace:|^latest$/;
+
+  const combos = [
+    { name: "typescript", answers: { languages: ["typescript"] as const } },
+    { name: "react", answers: { frontend: "react" as const } },
+    { name: "express", answers: { backend: "express" as const } },
+    { name: "cdk", answers: { clouds: ["aws" as const], iac: ["cdk" as const] } },
+  ];
+
+  for (const combo of combos) {
+    it(`${combo.name}: all dependency versions are valid semver ranges`, () => {
+      const result = generate(makeAnswers(combo.answers));
+      for (const file of result.fileList()) {
+        if (!file.endsWith("package.json")) continue;
+        const pkg = result.readJson(file) as Record<string, unknown>;
+        for (const depType of ["dependencies", "devDependencies"]) {
+          const deps = pkg[depType] as Record<string, string> | undefined;
+          if (!deps) continue;
+          for (const [name, version] of Object.entries(deps)) {
+            expect(
+              semverPattern.test(version),
+              `${file} ${depType}.${name}: "${version}" should be a valid semver range`,
+            ).toBe(true);
+          }
+        }
+      }
+    });
+  }
+});
+
+// --- CI workflow step ordering ---
+
+describe("content: CI workflow step ordering", () => {
+  it("steps follow setup → lint → test → build order", () => {
+    const result = generate(
+      makeAnswers({
+        languages: ["typescript", "python"],
+        frontend: "react",
+        clouds: ["aws"],
+        iac: ["cdk"],
+      }),
+    );
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name as string);
+
+    // Find indices for each category
+    const checkoutIdx = stepNames.indexOf("Checkout");
+    const miseIdx = stepNames.indexOf("Setup mise");
+    const firstLintIdx = stepNames.findIndex((n) => typeof n === "string" && n.startsWith("Lint"));
+    const firstTestIdx = stepNames.findIndex((n) => typeof n === "string" && n.startsWith("Test"));
+    const firstBuildIdx = stepNames.findIndex(
+      (n) => typeof n === "string" && n.startsWith("Build"),
+    );
+
+    expect(checkoutIdx, "Checkout should be first").toBe(0);
+    expect(miseIdx, "Setup mise should be second").toBe(1);
+    expect(firstLintIdx, "Lint steps should come before Test").toBeLessThan(firstTestIdx);
+    if (firstBuildIdx >= 0) {
+      expect(firstTestIdx, "Test steps should come before Build").toBeLessThan(firstBuildIdx);
+    }
+  });
+
+  it("CDK synth step exists before cfn-lint when both CDK and CloudFormation are used", () => {
+    const result = generate(
+      makeAnswers({
+        clouds: ["aws"],
+        iac: ["cdk", "cloudformation"],
+      }),
+    );
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name as string);
+
+    const synthIdx = stepNames.findIndex((n) => n.includes("CDK"));
+    const cfnLintIdx = stepNames.findIndex((n) => n.includes("cfn-lint"));
+
+    expect(synthIdx, "CDK synth step should exist").toBeGreaterThanOrEqual(0);
+    expect(cfnLintIdx, "cfn-lint step should exist").toBeGreaterThanOrEqual(0);
+  });
+
+  it("always starts with Checkout and Setup mise", () => {
+    const combos = [
+      { languages: ["typescript"] as const },
+      { languages: ["python"] as const },
+      { frontend: "react" as const, backend: "fastapi" as const },
+    ];
+
+    for (const answers of combos) {
+      const result = generate(makeAnswers(answers));
+      const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+      const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+      const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+      expect(steps[0].name, "First step should be Checkout").toBe("Checkout");
+      expect(steps[1].name, "Second step should be Setup mise").toBe("Setup mise");
+    }
+  });
+});
+
+// --- CD workflow content validation ---
+
+describe("content: CD workflow structure", () => {
+  it("cd-cdk.yaml has valid YAML structure with deploy job", () => {
+    const result = generate(makeAnswers({ clouds: ["aws"], iac: ["cdk"] }));
+    const cd = result.readYaml(".github/workflows/cd-cdk.yaml") as Record<string, unknown>;
+    expect(cd.name, "should have a workflow name").toBeDefined();
+    expect(cd.on, "should have triggers").toBeDefined();
+    expect(cd.jobs, "should have jobs").toBeDefined();
+  });
+
+  it("cd-terraform.yaml has valid YAML structure", () => {
+    const result = generate(makeAnswers({ clouds: ["aws"], iac: ["terraform"] }));
+    const cd = result.readYaml(".github/workflows/cd-terraform.yaml") as Record<string, unknown>;
+    expect(cd.name, "should have a workflow name").toBeDefined();
+    expect(cd.on, "should have triggers").toBeDefined();
+    expect(cd.jobs, "should have jobs").toBeDefined();
+  });
+
+  it("cd-cloudformation.yaml has valid YAML structure", () => {
+    const result = generate(
+      makeAnswers({ languages: ["typescript"], clouds: ["aws"], iac: ["cloudformation"] }),
+    );
+    const cd = result.readYaml(".github/workflows/cd-cloudformation.yaml") as Record<
+      string,
+      unknown
+    >;
+    expect(cd.name, "should have a workflow name").toBeDefined();
+    expect(cd.on, "should have triggers").toBeDefined();
+  });
+
+  it("cd-bicep.yaml has valid YAML structure", () => {
+    const result = generate(
+      makeAnswers({ languages: ["typescript"], clouds: ["azure"], iac: ["bicep"] }),
+    );
+    const cd = result.readYaml(".github/workflows/cd-bicep.yaml") as Record<string, unknown>;
+    expect(cd.name, "should have a workflow name").toBeDefined();
+    expect(cd.on, "should have triggers").toBeDefined();
+  });
+});

--- a/tests/edge-cases.test.ts
+++ b/tests/edge-cases.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Edge case tests — verify behavior for unusual or boundary inputs.
+ *
+ * Validates:
+ * - No-agent selection (no agent presets)
+ * - All agents selected simultaneously
+ * - Maximum preset combination stress test
+ * - Empty/minimal selections
+ */
+import { describe, expect, it } from "vitest";
+import { generate, resolvePresets } from "../src/generator.js";
+import { makeAnswers } from "./helpers.js";
+
+// --- No agent selected ---
+
+describe("edge: no agent selected", () => {
+  const result = generate(makeAnswers({ agents: [] }));
+
+  it("generates base files without any agent-specific files", () => {
+    expect(result.hasFile("package.json")).toBe(true);
+    expect(result.hasFile(".editorconfig")).toBe(true);
+    expect(result.hasFile("CLAUDE.md")).toBe(false);
+    expect(result.hasFile("AGENTS.md")).toBe(false);
+    expect(result.hasFile("GEMINI.md")).toBe(false);
+    expect(result.hasFile(".amazonq/rules/project.md")).toBe(false);
+    expect(result.hasFile(".github/copilot-instructions.md")).toBe(false);
+    expect(result.hasFile(".clinerules/project.md")).toBe(false);
+    expect(result.hasFile(".cursor/rules/project.mdc")).toBe(false);
+  });
+
+  it("does not generate MCP config files", () => {
+    expect(result.hasFile(".mcp.json")).toBe(false);
+    expect(result.hasFile(".codex/config.toml")).toBe(false);
+    expect(result.hasFile(".gemini/settings.json")).toBe(false);
+    expect(result.hasFile(".amazonq/mcp.json")).toBe(false);
+    expect(result.hasFile(".cursor/mcp.json")).toBe(false);
+    expect(result.hasFile(".copilot/mcp-config.json")).toBe(false);
+  });
+
+  it("generates valid JSON/YAML files", () => {
+    for (const file of result.fileList()) {
+      if (file.endsWith(".json")) {
+        expect(() => result.readJson(file), `${file} should be valid JSON`).not.toThrow();
+      }
+      if (file.endsWith(".yaml")) {
+        expect(() => result.readYaml(file), `${file} should be valid YAML`).not.toThrow();
+      }
+    }
+  });
+});
+
+// --- All agents selected simultaneously ---
+
+describe("edge: all agents selected", () => {
+  const result = generate(
+    makeAnswers({
+      agents: ["claude-code", "codex", "gemini", "amazon-q", "copilot", "cline", "cursor"],
+    }),
+  );
+
+  it("generates all agent instruction files", () => {
+    expect(result.hasFile("CLAUDE.md")).toBe(true);
+    expect(result.hasFile("AGENTS.md")).toBe(true);
+    expect(result.hasFile("GEMINI.md")).toBe(true);
+    expect(result.hasFile(".amazonq/rules/project.md")).toBe(true);
+    expect(result.hasFile(".github/copilot-instructions.md")).toBe(true);
+    expect(result.hasFile(".clinerules/project.md")).toBe(true);
+    expect(result.hasFile(".cursor/rules/project.mdc")).toBe(true);
+  });
+
+  it("generates all MCP config files", () => {
+    expect(result.hasFile(".mcp.json")).toBe(true);
+    expect(result.hasFile(".codex/config.toml")).toBe(true);
+    expect(result.hasFile(".gemini/settings.json")).toBe(true);
+    expect(result.hasFile(".amazonq/mcp.json")).toBe(true);
+    expect(result.hasFile(".cursor/mcp.json")).toBe(true);
+    expect(result.hasFile(".copilot/mcp-config.json")).toBe(true);
+  });
+
+  it("all MCP configs have context7 and fetch servers", () => {
+    const mcp = result.readJson(".mcp.json") as Record<string, Record<string, unknown>>;
+    expect(mcp.mcpServers.context7).toBeDefined();
+    expect(mcp.mcpServers.fetch).toBeDefined();
+
+    const codex = result.readText(".codex/config.toml");
+    expect(codex).toContain("[mcp_servers.context7]");
+
+    const gemini = result.readJson(".gemini/settings.json") as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(gemini.mcpServers.context7).toBeDefined();
+
+    const amazonq = result.readJson(".amazonq/mcp.json") as Record<string, Record<string, unknown>>;
+    expect(amazonq.mcpServers.context7).toBeDefined();
+
+    const cursor = result.readJson(".cursor/mcp.json") as Record<string, Record<string, unknown>>;
+    expect(cursor.mcpServers.context7).toBeDefined();
+
+    const copilot = result.readJson(".copilot/mcp-config.json") as Record<
+      string,
+      Record<string, unknown>
+    >;
+    expect(copilot.mcpServers.context7).toBeDefined();
+  });
+
+  it("all JSON files are valid", () => {
+    for (const file of result.fileList()) {
+      if (file.endsWith(".json")) {
+        expect(() => result.readJson(file), `${file} should be valid JSON`).not.toThrow();
+      }
+    }
+  });
+
+  it("no leftover placeholders in any instruction file", () => {
+    const instructionFiles = [
+      "CLAUDE.md",
+      "AGENTS.md",
+      "GEMINI.md",
+      ".amazonq/rules/project.md",
+      ".github/copilot-instructions.md",
+      ".clinerules/project.md",
+      ".cursor/rules/project.mdc",
+    ];
+    for (const file of instructionFiles) {
+      const content = result.readText(file);
+      expect(content, `${file} should not have leftover placeholders`).not.toContain(
+        "<!-- SECTION:",
+      );
+      expect(content, `${file} should not have unreplaced template vars`).not.toContain(
+        "{{projectName}}",
+      );
+    }
+  });
+});
+
+// --- Maximum preset combination (stress test) ---
+
+describe("edge: maximum preset combination", () => {
+  const result = generate(
+    makeAnswers({
+      languages: ["typescript", "python"],
+      frontend: "react",
+      backend: "fastapi",
+      clouds: ["aws", "azure", "gcp"],
+      iac: ["cdk", "cloudformation", "terraform", "bicep"],
+      agents: ["claude-code", "codex", "gemini", "amazon-q", "copilot", "cline", "cursor"],
+    }),
+  );
+
+  it("generates without errors", () => {
+    expect(result.fileList().length).toBeGreaterThan(0);
+  });
+
+  it("all JSON files are valid", () => {
+    for (const file of result.fileList()) {
+      if (file.endsWith(".json")) {
+        expect(() => result.readJson(file), `${file} should be valid JSON`).not.toThrow();
+      }
+    }
+  });
+
+  it("all YAML files are valid", () => {
+    for (const file of result.fileList()) {
+      if (file.endsWith(".yaml")) {
+        expect(() => result.readYaml(file), `${file} should be valid YAML`).not.toThrow();
+      }
+    }
+  });
+
+  it("all TOML files are valid", () => {
+    for (const file of result.fileList()) {
+      if (file.endsWith(".toml")) {
+        expect(() => result.readToml(file), `${file} should be valid TOML`).not.toThrow();
+      }
+    }
+  });
+
+  it("no leftover {{projectName}} in any file", () => {
+    for (const file of result.fileList()) {
+      const content = result.readText(file);
+      if (content.includes("{{projectName}}")) {
+        // pnpm-lock.yaml is copied as-is and may contain template vars (expected)
+        if (file === "pnpm-lock.yaml") continue;
+        expect.fail(`${file} contains unreplaced {{projectName}}`);
+      }
+    }
+  });
+
+  it("no leftover <!-- SECTION: --> placeholders in markdown files", () => {
+    for (const file of result.fileList()) {
+      if (file.endsWith(".md") || file.endsWith(".mdc")) {
+        const content = result.readText(file);
+        expect(content, `${file} should not have leftover section placeholders`).not.toContain(
+          "<!-- SECTION:",
+        );
+      }
+    }
+  });
+
+  it("includes all 4 CD workflows", () => {
+    expect(result.hasFile(".github/workflows/cd-cdk.yaml")).toBe(true);
+    expect(result.hasFile(".github/workflows/cd-cloudformation.yaml")).toBe(true);
+    expect(result.hasFile(".github/workflows/cd-terraform.yaml")).toBe(true);
+    expect(result.hasFile(".github/workflows/cd-bicep.yaml")).toBe(true);
+  });
+
+  it("resolves all expected presets in canonical order", () => {
+    const presets = resolvePresets(
+      makeAnswers({
+        languages: ["typescript", "python"],
+        frontend: "react",
+        backend: "fastapi",
+        clouds: ["aws", "azure", "gcp"],
+        iac: ["cdk", "cloudformation", "terraform", "bicep"],
+        agents: ["claude-code", "codex", "gemini", "amazon-q", "copilot", "cline", "cursor"],
+      }),
+    );
+    expect(presets[0]).toBe("base");
+    // typescript before python (canonical order)
+    expect(presets.indexOf("typescript")).toBeLessThan(presets.indexOf("python"));
+    // languages before frontend
+    expect(presets.indexOf("python")).toBeLessThan(presets.indexOf("react"));
+    // frontend before backend
+    expect(presets.indexOf("react")).toBeLessThan(presets.indexOf("fastapi"));
+    // clouds before iac
+    expect(presets.indexOf("aws")).toBeLessThan(presets.indexOf("cdk"));
+    // iac before agents
+    expect(presets.indexOf("bicep")).toBeLessThan(presets.indexOf("claude-code"));
+  });
+});
+
+// --- Minimal selection (base only) ---
+
+describe("edge: base only (no languages, no frameworks)", () => {
+  const result = generate(makeAnswers({ agents: [] }));
+
+  it("generates only base files plus no language-specific files", () => {
+    expect(result.hasFile("package.json")).toBe(true);
+    expect(result.hasFile(".editorconfig")).toBe(true);
+    expect(result.hasFile("biome.json")).toBe(false);
+    expect(result.hasFile("tsconfig.json")).toBe(false);
+    expect(result.hasFile("pyproject.toml")).toBe(false);
+  });
+
+  it("package.json has no language-specific scripts", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const scripts = pkg.scripts as Record<string, string>;
+    expect(scripts.lint).toBeUndefined();
+    expect(scripts.typecheck).toBeUndefined();
+    expect(scripts["lint:python"]).toBeUndefined();
+  });
+
+  it("CI workflow has only common steps (no language-specific lint/test)", () => {
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name as string);
+    expect(stepNames).not.toContain("Lint (Biome)");
+    expect(stepNames).not.toContain("Lint (Ruff)");
+    expect(stepNames).not.toContain("Typecheck");
+  });
+});
+
+// --- Forced dependency consistency ---
+
+describe("edge: forced dependency chains", () => {
+  it("react forces typescript — resolved presets include typescript", () => {
+    const presets = resolvePresets(makeAnswers({ frontend: "react", agents: [] }));
+    expect(presets).toContain("typescript");
+    expect(presets).toContain("react");
+  });
+
+  it("nextjs forces typescript — resolved presets include typescript", () => {
+    const presets = resolvePresets(makeAnswers({ frontend: "nextjs", agents: [] }));
+    expect(presets).toContain("typescript");
+    expect(presets).toContain("nextjs");
+  });
+
+  it("fastapi forces python — resolved presets include python", () => {
+    const presets = resolvePresets(makeAnswers({ backend: "fastapi", agents: [] }));
+    expect(presets).toContain("python");
+    expect(presets).toContain("fastapi");
+  });
+
+  it("express forces typescript — resolved presets include typescript", () => {
+    const presets = resolvePresets(makeAnswers({ backend: "express", agents: [] }));
+    expect(presets).toContain("typescript");
+    expect(presets).toContain("express");
+  });
+
+  it("cdk forces typescript — resolved presets include typescript", () => {
+    const presets = resolvePresets(makeAnswers({ clouds: ["aws"], iac: ["cdk"], agents: [] }));
+    expect(presets).toContain("typescript");
+    expect(presets).toContain("cdk");
+  });
+
+  it("forced dependencies are not duplicated", () => {
+    const presets = resolvePresets(
+      makeAnswers({ languages: ["typescript"], frontend: "react", agents: [] }),
+    );
+    const tsCount = presets.filter((p) => p === "typescript").length;
+    expect(tsCount, "typescript should appear exactly once").toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #116

- Add `content-validation.test.ts`: tsconfig.json structure validation, YAML/TOML syntax verification across all preset combinations, package.json semver range validation, CI workflow step ordering checks, CD workflow structure validation
- Add `edge-cases.test.ts`: no-agent selection, all-agents-selected, maximum preset stress test, forced dependency chain consistency, base-only minimal generation

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm test` passes (540 tests across 29 files)
- [x] `pnpm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)