### PR TITLE
feat: add input validation for requires chains and IaC/cloud combos

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -56,6 +56,43 @@ const ALL_PRESETS: Record<string, Preset> = {
   cursor: cursorPreset,
 };
 
+// Validate that all preset `requires` entries reference known presets (fail-fast at import time)
+for (const [name, preset] of Object.entries(ALL_PRESETS)) {
+  if (!preset.requires) continue;
+  for (const req of preset.requires) {
+    if (!(req in ALL_PRESETS)) {
+      throw new Error(`Preset "${name}" requires unknown preset "${req}"`);
+    }
+  }
+}
+
+/** IaC tools and the cloud providers they require. */
+const IAC_CLOUD_REQUIREMENTS: Record<string, { clouds: string[]; label: string }> = {
+  cdk: { clouds: ["aws"], label: "CDK" },
+  cloudformation: { clouds: ["aws"], label: "CloudFormation" },
+  bicep: { clouds: ["azure"], label: "Bicep" },
+};
+
+/** Validate wizard answers and return warnings for questionable (but allowed) combinations. */
+export function validateAnswers(answers: WizardAnswers): string[] {
+  const warnings: string[] = [];
+
+  for (const iac of answers.iac) {
+    const req = IAC_CLOUD_REQUIREMENTS[iac];
+    if (!req) continue;
+    const hasRequired = req.clouds.some((cloud) =>
+      answers.clouds.includes(cloud as WizardAnswers["clouds"][number]),
+    );
+    if (!hasRequired) {
+      warnings.push(
+        `${req.label} is typically used with ${req.clouds.join("/")} — no matching cloud provider selected`,
+      );
+    }
+  }
+
+  return warnings;
+}
+
 /**
  * Collapse multiple IaC infra placeholder contributions into a single entry.
  * Returns a new array — does not mutate the input.

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { parseArgs } from "node:util";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { runWizard } from "./cli.js";
-import { generate } from "./generator.js";
+import { generate, validateAnswers } from "./generator.js";
 import { detectLocale, setLocale, t } from "./i18n/index.js";
 import { createDiskWriter } from "./utils.js";
 
@@ -28,6 +28,11 @@ async function main(): Promise<void> {
     ? path.resolve(process.cwd(), path.dirname(positionalArg))
     : process.cwd();
   const answers = await runWizard(defaultName);
+
+  const warnings = validateAnswers(answers);
+  for (const warning of warnings) {
+    p.log.warn(pc.yellow(warning));
+  }
 
   const outDir = path.resolve(parentDir, answers.projectName);
   const relPath = path.relative(process.cwd(), outDir) || ".";

--- a/tests/generator.test.ts
+++ b/tests/generator.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { generate, resolvePresets } from "../src/generator.js";
+import { generate, resolvePresets, validateAnswers } from "../src/generator.js";
 import type { WizardAnswers } from "../src/types.js";
 import { makeAnswers } from "./helpers.js";
 
@@ -113,6 +113,48 @@ describe("resolvePresets", () => {
   it("does not force languages for cloud-only selections", () => {
     const result = resolvePresets(makeAnswers({ clouds: ["aws", "azure", "gcp"] }));
     expect(result).toEqual(["base", "aws", "azure", "gcp", "claude-code"]);
+  });
+});
+
+// --- validateAnswers ---
+
+describe("validateAnswers", () => {
+  it("returns no warnings for valid combinations", () => {
+    expect(validateAnswers(makeAnswers({ clouds: ["aws"], iac: ["cdk"] }))).toEqual([]);
+    expect(validateAnswers(makeAnswers({ clouds: ["aws"], iac: ["cloudformation"] }))).toEqual([]);
+    expect(validateAnswers(makeAnswers({ clouds: ["azure"], iac: ["bicep"] }))).toEqual([]);
+    expect(validateAnswers(makeAnswers({ clouds: ["aws"], iac: ["terraform"] }))).toEqual([]);
+    expect(validateAnswers(makeAnswers())).toEqual([]);
+  });
+
+  it("warns when CDK is selected without AWS", () => {
+    const warnings = validateAnswers(makeAnswers({ clouds: ["azure"], iac: ["cdk"] }));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("CDK");
+    expect(warnings[0]).toContain("aws");
+  });
+
+  it("warns when CloudFormation is selected without AWS", () => {
+    const warnings = validateAnswers(makeAnswers({ clouds: ["gcp"], iac: ["cloudformation"] }));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("CloudFormation");
+    expect(warnings[0]).toContain("aws");
+  });
+
+  it("warns when Bicep is selected without Azure", () => {
+    const warnings = validateAnswers(makeAnswers({ clouds: ["aws"], iac: ["bicep"] }));
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("Bicep");
+    expect(warnings[0]).toContain("azure");
+  });
+
+  it("returns multiple warnings for multiple mismatches", () => {
+    const warnings = validateAnswers(makeAnswers({ clouds: [], iac: ["cdk", "bicep"] }));
+    expect(warnings).toHaveLength(2);
+  });
+
+  it("no warning for Terraform (multi-cloud)", () => {
+    expect(validateAnswers(makeAnswers({ clouds: ["gcp"], iac: ["terraform"] }))).toEqual([]);
   });
 });
 


### PR DESCRIPTION
## Summary

Closes #118

- Validate all preset `requires` entries reference known presets at module load time (fail-fast for developers adding new presets)
- Add `validateAnswers()` function that returns warnings for IaC/cloud mismatches: CDK/CloudFormation without AWS, Bicep without Azure
- Display warnings in CLI after wizard completes (before generation)
- MCP server command validation skipped — always `npx`, devcontainer installs via mise

Note: The CLI wizard already prevents invalid IaC/cloud combos via `buildIacOptions()` filtering. The new validation covers programmatic API usage and provides defense-in-depth.

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm test` passes (546 tests, +6 new)
- [x] `pnpm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)