### PR TITLE
test: add shared test helpers and error path / isolation tests

### DIFF
--- a/tests/edge-cases.test.ts
+++ b/tests/edge-cases.test.ts
@@ -9,7 +9,14 @@
  */
 import { describe, expect, it } from "vitest";
 import { generate, resolvePresets } from "../src/generator.js";
-import { makeAnswers } from "./helpers.js";
+import {
+  expectAllJsonValid,
+  expectAllTomlValid,
+  expectAllYamlValid,
+  expectNoLeftoverPlaceholders,
+  expectNoUnreplacedVars,
+  makeAnswers,
+} from "./helpers.js";
 
 // --- No agent selected ---
 
@@ -38,14 +45,8 @@ describe("edge: no agent selected", () => {
   });
 
   it("generates valid JSON/YAML files", () => {
-    for (const file of result.fileList()) {
-      if (file.endsWith(".json")) {
-        expect(() => result.readJson(file), `${file} should be valid JSON`).not.toThrow();
-      }
-      if (file.endsWith(".yaml")) {
-        expect(() => result.readYaml(file), `${file} should be valid YAML`).not.toThrow();
-      }
-    }
+    expectAllJsonValid(result);
+    expectAllYamlValid(result);
   });
 });
 
@@ -105,32 +106,12 @@ describe("edge: all agents selected", () => {
   });
 
   it("all JSON files are valid", () => {
-    for (const file of result.fileList()) {
-      if (file.endsWith(".json")) {
-        expect(() => result.readJson(file), `${file} should be valid JSON`).not.toThrow();
-      }
-    }
+    expectAllJsonValid(result);
   });
 
-  it("no leftover placeholders in any instruction file", () => {
-    const instructionFiles = [
-      "CLAUDE.md",
-      "AGENTS.md",
-      "GEMINI.md",
-      ".amazonq/rules/project.md",
-      ".github/copilot-instructions.md",
-      ".clinerules/project.md",
-      ".cursor/rules/project.mdc",
-    ];
-    for (const file of instructionFiles) {
-      const content = result.readText(file);
-      expect(content, `${file} should not have leftover placeholders`).not.toContain(
-        "<!-- SECTION:",
-      );
-      expect(content, `${file} should not have unreplaced template vars`).not.toContain(
-        "{{projectName}}",
-      );
-    }
+  it("no leftover placeholders or unreplaced vars", () => {
+    expectNoLeftoverPlaceholders(result);
+    expectNoUnreplacedVars(result);
   });
 });
 
@@ -153,49 +134,20 @@ describe("edge: maximum preset combination", () => {
   });
 
   it("all JSON files are valid", () => {
-    for (const file of result.fileList()) {
-      if (file.endsWith(".json")) {
-        expect(() => result.readJson(file), `${file} should be valid JSON`).not.toThrow();
-      }
-    }
+    expectAllJsonValid(result);
   });
 
   it("all YAML files are valid", () => {
-    for (const file of result.fileList()) {
-      if (file.endsWith(".yaml")) {
-        expect(() => result.readYaml(file), `${file} should be valid YAML`).not.toThrow();
-      }
-    }
+    expectAllYamlValid(result);
   });
 
   it("all TOML files are valid", () => {
-    for (const file of result.fileList()) {
-      if (file.endsWith(".toml")) {
-        expect(() => result.readToml(file), `${file} should be valid TOML`).not.toThrow();
-      }
-    }
+    expectAllTomlValid(result);
   });
 
-  it("no leftover {{projectName}} in any file", () => {
-    for (const file of result.fileList()) {
-      const content = result.readText(file);
-      if (content.includes("{{projectName}}")) {
-        // pnpm-lock.yaml is copied as-is and may contain template vars (expected)
-        if (file === "pnpm-lock.yaml") continue;
-        expect.fail(`${file} contains unreplaced {{projectName}}`);
-      }
-    }
-  });
-
-  it("no leftover <!-- SECTION: --> placeholders in markdown files", () => {
-    for (const file of result.fileList()) {
-      if (file.endsWith(".md") || file.endsWith(".mdc")) {
-        const content = result.readText(file);
-        expect(content, `${file} should not have leftover section placeholders`).not.toContain(
-          "<!-- SECTION:",
-        );
-      }
-    }
+  it("no leftover vars or placeholders", () => {
+    expectNoUnreplacedVars(result);
+    expectNoLeftoverPlaceholders(result);
   });
 
   it("includes all 4 CD workflows", () => {

--- a/tests/error-paths.test.ts
+++ b/tests/error-paths.test.ts
@@ -1,11 +1,12 @@
 /**
- * Error path tests — verify error handling for invalid inputs and edge conditions.
+ * Error path and isolation tests.
  *
  * Validates:
  * - buildResult file-not-found errors (readText, readYaml, readToml)
- * - Generator behavior with unusual but valid inputs
  * - Conditional devDeps removal logic
  * - Owned file isolation (preset files don't leak)
+ * - Frontend sample file override behavior
+ * - Devcontainer port forwarding
  */
 import { describe, expect, it } from "vitest";
 import { generate } from "../src/generator.js";
@@ -44,18 +45,13 @@ describe("error: buildResult file access", () => {
 
 // --- Conditional devDeps removal ---
 
-describe("error: conditional devDeps removal", () => {
+describe("behavior: conditional devDeps removal", () => {
   it("removes tsdown when React overrides build script", () => {
     const result = generate(makeAnswers({ frontend: "react" }));
     const pkg = result.readJson("package.json") as Record<string, unknown>;
-    const devDeps = pkg.devDependencies as Record<string, string> | undefined;
+    const devDeps = (pkg.devDependencies ?? {}) as Record<string, string>;
     // React overrides build to "pnpm run build:web", removing tsdown usage
-    // tsdown is a conditional dep — should be removed if not referenced
-    if (devDeps && "tsdown" in devDeps) {
-      const scripts = pkg.scripts as Record<string, string>;
-      const allScripts = Object.values(scripts).join(" ");
-      expect(allScripts).toContain("tsdown");
-    }
+    expect(devDeps.tsdown).toBeUndefined();
   });
 
   it("keeps vitest when tests exist", () => {
@@ -63,15 +59,14 @@ describe("error: conditional devDeps removal", () => {
     const pkg = result.readJson("package.json") as Record<string, unknown>;
     const devDeps = (pkg.devDependencies ?? {}) as Record<string, string>;
     const scripts = (pkg.scripts ?? {}) as Record<string, string>;
-    if ("vitest" in devDeps) {
-      expect(scripts.test).toBeDefined();
-    }
+    expect(devDeps.vitest).toBeDefined();
+    expect(scripts.test).toBeDefined();
   });
 });
 
 // --- Owned file isolation ---
 
-describe("error: owned file isolation", () => {
+describe("isolation: owned file isolation", () => {
   it("React files only exist when React is selected", () => {
     const withReact = generate(makeAnswers({ frontend: "react" }));
     const withoutReact = generate(makeAnswers({ languages: ["typescript"] }));
@@ -147,7 +142,7 @@ describe("error: owned file isolation", () => {
 
 // --- Frontend removes language sample files ---
 
-describe("error: frontend overrides language sample files", () => {
+describe("behavior: frontend overrides language sample files", () => {
   it("React removes src/index.ts and tests/index.test.ts", () => {
     const result = generate(makeAnswers({ frontend: "react" }));
     expect(result.hasFile("src/index.ts")).toBe(false);
@@ -169,7 +164,7 @@ describe("error: frontend overrides language sample files", () => {
 
 // --- Port forwarding ---
 
-describe("error: devcontainer port forwarding", () => {
+describe("behavior: devcontainer port forwarding", () => {
   it("no forwardPorts without backend", () => {
     const result = generate(makeAnswers({ languages: ["typescript"] }));
     const dc = result.readJson(".devcontainer/devcontainer.json") as Record<string, unknown>;
@@ -190,7 +185,7 @@ describe("error: devcontainer port forwarding", () => {
     expect(ports).toContain(8000);
   });
 
-  it("Express + FastAPI forwards both ports", () => {
+  it("React + Express forwards port 3000", () => {
     const result = generate(makeAnswers({ frontend: "react", backend: "express" }));
     const dc = result.readJson(".devcontainer/devcontainer.json") as Record<string, unknown>;
     const ports = dc.forwardPorts as number[];

--- a/tests/error-paths.test.ts
+++ b/tests/error-paths.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Error path tests — verify error handling for invalid inputs and edge conditions.
+ *
+ * Validates:
+ * - buildResult file-not-found errors (readText, readYaml, readToml)
+ * - Generator behavior with unusual but valid inputs
+ * - Conditional devDeps removal logic
+ * - Owned file isolation (preset files don't leak)
+ */
+import { describe, expect, it } from "vitest";
+import { generate } from "../src/generator.js";
+import { buildResult } from "../src/utils.js";
+import { makeAnswers } from "./helpers.js";
+
+// --- buildResult error paths ---
+
+describe("error: buildResult file access", () => {
+  const result = buildResult(new Map([["a.txt", "hello"]]));
+
+  it("readText throws for missing file", () => {
+    expect(() => result.readText("missing.txt")).toThrow("File not found: missing.txt");
+  });
+
+  it("readYaml throws for missing file", () => {
+    expect(() => result.readYaml("missing.yaml")).toThrow("File not found: missing.yaml");
+  });
+
+  it("readToml throws for missing file", () => {
+    expect(() => result.readToml("missing.toml")).toThrow("File not found: missing.toml");
+  });
+
+  it("readJson throws for missing file", () => {
+    expect(() => result.readJson("missing.json")).toThrow("File not found: missing.json");
+  });
+
+  it("hasFile returns false for missing file", () => {
+    expect(result.hasFile("missing.txt")).toBe(false);
+  });
+
+  it("hasFile returns true for existing file", () => {
+    expect(result.hasFile("a.txt")).toBe(true);
+  });
+});
+
+// --- Conditional devDeps removal ---
+
+describe("error: conditional devDeps removal", () => {
+  it("removes tsdown when React overrides build script", () => {
+    const result = generate(makeAnswers({ frontend: "react" }));
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const devDeps = pkg.devDependencies as Record<string, string> | undefined;
+    // React overrides build to "pnpm run build:web", removing tsdown usage
+    // tsdown is a conditional dep — should be removed if not referenced
+    if (devDeps && "tsdown" in devDeps) {
+      const scripts = pkg.scripts as Record<string, string>;
+      const allScripts = Object.values(scripts).join(" ");
+      expect(allScripts).toContain("tsdown");
+    }
+  });
+
+  it("keeps vitest when tests exist", () => {
+    const result = generate(makeAnswers({ languages: ["typescript"] }));
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const devDeps = (pkg.devDependencies ?? {}) as Record<string, string>;
+    const scripts = (pkg.scripts ?? {}) as Record<string, string>;
+    if ("vitest" in devDeps) {
+      expect(scripts.test).toBeDefined();
+    }
+  });
+});
+
+// --- Owned file isolation ---
+
+describe("error: owned file isolation", () => {
+  it("React files only exist when React is selected", () => {
+    const withReact = generate(makeAnswers({ frontend: "react" }));
+    const withoutReact = generate(makeAnswers({ languages: ["typescript"] }));
+
+    expect(withReact.hasFile("web/vite.config.ts")).toBe(true);
+    expect(withReact.hasFile("web/src/App.tsx")).toBe(true);
+
+    expect(withoutReact.hasFile("web/vite.config.ts")).toBe(false);
+    expect(withoutReact.hasFile("web/src/App.tsx")).toBe(false);
+  });
+
+  it("Express files only exist when Express is selected", () => {
+    const withExpress = generate(makeAnswers({ backend: "express" }));
+    const withoutExpress = generate(makeAnswers({ languages: ["typescript"] }));
+
+    expect(withExpress.hasFile("api/src/app.ts")).toBe(true);
+    expect(withoutExpress.hasFile("api/src/app.ts")).toBe(false);
+  });
+
+  it("FastAPI files only exist when FastAPI is selected", () => {
+    const withFastapi = generate(makeAnswers({ backend: "fastapi" }));
+    const withoutFastapi = generate(makeAnswers({ languages: ["python"] }));
+
+    expect(withFastapi.hasFile("api/src/main.py")).toBe(true);
+    expect(withoutFastapi.hasFile("api/src/main.py")).toBe(false);
+  });
+
+  it("CDK files only exist when CDK is selected", () => {
+    const withCdk = generate(makeAnswers({ clouds: ["aws"], iac: ["cdk"] }));
+    const withoutCdk = generate(makeAnswers({ clouds: ["aws"] }));
+
+    expect(withCdk.hasFile("infra/bin/app.ts")).toBe(true);
+    expect(withoutCdk.hasFile("infra/bin/app.ts")).toBe(false);
+  });
+
+  it("Claude Code files only exist when claude-code agent is selected", () => {
+    const withClaude = generate(makeAnswers({ agents: ["claude-code"] }));
+    const withoutClaude = generate(makeAnswers({ agents: ["codex"] }));
+
+    expect(withClaude.hasFile("CLAUDE.md")).toBe(true);
+    expect(withClaude.hasFile(".claude/settings.json")).toBe(true);
+
+    expect(withoutClaude.hasFile("CLAUDE.md")).toBe(false);
+    expect(withoutClaude.hasFile(".claude/settings.json")).toBe(false);
+  });
+
+  it("Codex files only exist when codex agent is selected", () => {
+    const withCodex = generate(makeAnswers({ agents: ["codex"] }));
+    const withoutCodex = generate(makeAnswers({ agents: ["claude-code"] }));
+
+    expect(withCodex.hasFile("AGENTS.md")).toBe(true);
+    expect(withoutCodex.hasFile("AGENTS.md")).toBe(false);
+  });
+
+  it("Python files only exist when Python is selected", () => {
+    const withPython = generate(makeAnswers({ languages: ["python"] }));
+    const withoutPython = generate(makeAnswers({ languages: ["typescript"] }));
+
+    expect(withPython.hasFile("pyproject.toml")).toBe(true);
+    expect(withoutPython.hasFile("pyproject.toml")).toBe(false);
+  });
+
+  it("TypeScript files only exist when TypeScript is selected", () => {
+    const withTs = generate(makeAnswers({ languages: ["typescript"] }));
+    const withoutTs = generate(makeAnswers({ languages: ["python"] }));
+
+    expect(withTs.hasFile("tsconfig.json")).toBe(true);
+    expect(withTs.hasFile("biome.json")).toBe(true);
+    expect(withoutTs.hasFile("tsconfig.json")).toBe(false);
+    expect(withoutTs.hasFile("biome.json")).toBe(false);
+  });
+});
+
+// --- Frontend removes language sample files ---
+
+describe("error: frontend overrides language sample files", () => {
+  it("React removes src/index.ts and tests/index.test.ts", () => {
+    const result = generate(makeAnswers({ frontend: "react" }));
+    expect(result.hasFile("src/index.ts")).toBe(false);
+    expect(result.hasFile("tests/index.test.ts")).toBe(false);
+  });
+
+  it("Next.js removes src/index.ts and tests/index.test.ts", () => {
+    const result = generate(makeAnswers({ frontend: "nextjs" }));
+    expect(result.hasFile("src/index.ts")).toBe(false);
+    expect(result.hasFile("tests/index.test.ts")).toBe(false);
+  });
+
+  it("TypeScript without frontend keeps src/index.ts", () => {
+    const result = generate(makeAnswers({ languages: ["typescript"] }));
+    expect(result.hasFile("src/index.ts")).toBe(true);
+    expect(result.hasFile("tests/index.test.ts")).toBe(true);
+  });
+});
+
+// --- Port forwarding ---
+
+describe("error: devcontainer port forwarding", () => {
+  it("no forwardPorts without backend", () => {
+    const result = generate(makeAnswers({ languages: ["typescript"] }));
+    const dc = result.readJson(".devcontainer/devcontainer.json") as Record<string, unknown>;
+    expect(dc.forwardPorts).toBeUndefined();
+  });
+
+  it("Express forwards port 3000", () => {
+    const result = generate(makeAnswers({ backend: "express" }));
+    const dc = result.readJson(".devcontainer/devcontainer.json") as Record<string, unknown>;
+    const ports = dc.forwardPorts as number[];
+    expect(ports).toContain(3000);
+  });
+
+  it("FastAPI forwards port 8000", () => {
+    const result = generate(makeAnswers({ backend: "fastapi" }));
+    const dc = result.readJson(".devcontainer/devcontainer.json") as Record<string, unknown>;
+    const ports = dc.forwardPorts as number[];
+    expect(ports).toContain(8000);
+  });
+
+  it("Express + FastAPI forwards both ports", () => {
+    const result = generate(makeAnswers({ frontend: "react", backend: "express" }));
+    const dc = result.readJson(".devcontainer/devcontainer.json") as Record<string, unknown>;
+    const ports = dc.forwardPorts as number[];
+    expect(ports).toContain(3000);
+  });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -1,6 +1,6 @@
 import { expect } from "vitest";
 import type { generate } from "../src/generator.js";
-import type { WizardAnswers } from "../src/types.js";
+import type { GenerateResult, WizardAnswers } from "../src/types.js";
 
 /** Create WizardAnswers with sensible defaults. */
 export function makeAnswers(overrides: Partial<WizardAnswers> = {}): WizardAnswers {
@@ -24,4 +24,52 @@ export function readValidJson(
   const text = result.readText(path);
   expect(() => JSON.parse(text), `${path} should be valid JSON`).not.toThrow();
   return JSON.parse(text) as Record<string, unknown>;
+}
+
+/** Assert that all JSON files in the result are parseable. */
+export function expectAllJsonValid(result: GenerateResult): void {
+  for (const file of result.fileList()) {
+    if (file.endsWith(".json")) {
+      expect(() => result.readJson(file), `${file} should be valid JSON`).not.toThrow();
+    }
+  }
+}
+
+/** Assert that all YAML files in the result are parseable. */
+export function expectAllYamlValid(result: GenerateResult): void {
+  for (const file of result.fileList()) {
+    if (file.endsWith(".yaml")) {
+      expect(() => result.readYaml(file), `${file} should be valid YAML`).not.toThrow();
+    }
+  }
+}
+
+/** Assert that all TOML files in the result are parseable. */
+export function expectAllTomlValid(result: GenerateResult): void {
+  for (const file of result.fileList()) {
+    if (file.endsWith(".toml")) {
+      expect(() => result.readToml(file), `${file} should be valid TOML`).not.toThrow();
+    }
+  }
+}
+
+/** Assert that no markdown/mdc files contain leftover section placeholders. */
+export function expectNoLeftoverPlaceholders(result: GenerateResult): void {
+  for (const file of result.fileList()) {
+    if (file.endsWith(".md") || file.endsWith(".mdc")) {
+      const content = result.readText(file);
+      expect(content, `${file} should not have leftover placeholders`).not.toContain(
+        "<!-- SECTION:",
+      );
+    }
+  }
+}
+
+/** Assert that no files contain unreplaced {{projectName}} (except pnpm-lock.yaml). */
+export function expectNoUnreplacedVars(result: GenerateResult): void {
+  for (const file of result.fileList()) {
+    if (file === "pnpm-lock.yaml") continue;
+    const content = result.readText(file);
+    expect(content, `${file} should not contain {{projectName}}`).not.toContain("{{projectName}}");
+  }
 }


### PR DESCRIPTION
## Summary

- Extract 5 shared assertion helpers to `tests/helpers.ts`: `expectAllJsonValid`, `expectAllYamlValid`, `expectAllTomlValid`, `expectNoLeftoverPlaceholders`, `expectNoUnreplacedVars`
- Refactor `edge-cases.test.ts` to use shared helpers (reduce inline duplication)
- Add `error-paths.test.ts` with 22 new tests:
  - `buildResult` error handling (file-not-found for all read methods)
  - Conditional devDeps removal logic validation
  - Owned file isolation (React, Express, FastAPI, CDK, Claude Code, Codex, Python, TypeScript)
  - Frontend sample file override behavior
  - Devcontainer port forwarding (none, Express 3000, FastAPI 8000)

Test count: 546 → 568 (+22)

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm test` passes (568 tests, 30 files)
- [x] `pnpm run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)