### PR TITLE
test: add CLI wizard E2E tests, coverage visualization, and dependency update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,8 +58,8 @@ jobs:
       - name: Security (Gitleaks)
         run: gitleaks detect --no-banner
 
-      - name: Test
-        run: pnpm test
+      - name: Test with coverage
+        run: pnpm vitest run --coverage
 
       - name: Build
         run: pnpm build

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@commitlint/cli": "^20.0.0",
     "@commitlint/config-conventional": "^20.0.0",
     "@types/node": "^22.0.0",
-    "@vitest/coverage-v8": "4.1.1",
+    "@vitest/coverage-v8": "^4.1.1",
     "tsdown": "^0.12.0",
     "typescript": "^5.8.0",
     "vitest": "^4.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         specifier: ^22.0.0
         version: 22.19.15
       '@vitest/coverage-v8':
-        specifier: 4.1.1
+        specifier: ^4.1.1
         version: 4.1.1(vitest@4.1.1(@types/node@22.19.15)(vite@8.0.1(@types/node@22.19.15)(jiti@2.6.1)(yaml@2.8.2)))
       tsdown:
         specifier: ^0.12.0

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -1,0 +1,456 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- Mock @clack/prompts ---
+// We intercept group() to execute each prompt callback with simulated answers,
+// and stub the individual prompt helpers (text, select, multiselect) to return
+// pre-configured values that the test controls via `mockAnswers`.
+
+interface MockAnswers {
+  projectName?: string;
+  frontend?: "none" | "react" | "nextjs";
+  backend?: "none" | "fastapi" | "express";
+  clouds?: Array<"aws" | "azure" | "gcp">;
+  iac?: Array<"cdk" | "cloudformation" | "terraform" | "bicep">;
+  languages?: Array<"typescript" | "python">;
+  agents?: Array<"claude-code" | "codex" | "gemini" | "amazon-q" | "copilot" | "cline" | "cursor">;
+}
+
+let mockAnswers: MockAnswers = {};
+
+// Track calls to p.log.info for verifying auto-selected language messages
+let logInfoCalls: string[] = [];
+
+vi.mock("@clack/prompts", () => {
+  const intro = vi.fn();
+  const cancel = vi.fn();
+  const log = { info: vi.fn((msg: string) => logInfoCalls.push(msg)) };
+
+  // group() faithfully executes each callback in order, accumulating results,
+  // exactly like the real implementation. The individual prompt mocks below
+  // supply the "user input".
+  const group = vi.fn(
+    async (
+      prompts: Record<string, (opts: { results: Record<string, unknown> }) => unknown>,
+      _opts?: { onCancel?: () => void },
+    ) => {
+      const results: Record<string, unknown> = {};
+      for (const [key, fn] of Object.entries(prompts)) {
+        const value = await fn({ results });
+        // undefined means the question was skipped (conditional)
+        if (value !== undefined) {
+          results[key] = value;
+        }
+      }
+      return results;
+    },
+  );
+
+  const text = vi.fn(async () => mockAnswers.projectName ?? "my-app");
+  const select = vi.fn(async () => "none");
+  const multiselect = vi.fn(async () => []);
+
+  return { intro, cancel, log, group, text, select, multiselect };
+});
+
+// Import after mocking
+import * as p from "@clack/prompts";
+import { runWizard } from "../src/cli.js";
+
+/** Configure mock answers and set up prompt return values. */
+function setupMock(answers: MockAnswers): void {
+  mockAnswers = answers;
+  logInfoCalls = [];
+
+  const textMock = vi.mocked(p.text);
+  textMock.mockResolvedValue(answers.projectName ?? "my-app");
+
+  // select is called twice: frontend then backend
+  const selectMock = vi.mocked(p.select);
+  selectMock
+    .mockResolvedValueOnce(answers.frontend ?? "none")
+    .mockResolvedValueOnce(answers.backend ?? "none");
+
+  // multiselect call order: clouds, (iac if clouds), (languages if needed), agents
+  const multiselectMock = vi.mocked(p.multiselect);
+  const multiselectReturns: unknown[] = [];
+
+  // 1. clouds
+  multiselectReturns.push(answers.clouds ?? []);
+  // 2. iac (only called if clouds.length > 0)
+  if ((answers.clouds ?? []).length > 0) {
+    multiselectReturns.push(answers.iac ?? []);
+  }
+  // 3. languages (only called if not all auto-resolved)
+  const needsLanguagePrompt = shouldShowLanguagePrompt(answers);
+  if (needsLanguagePrompt) {
+    multiselectReturns.push(answers.languages ?? []);
+  }
+  // 4. agents
+  multiselectReturns.push(answers.agents ?? ["claude-code"]);
+
+  multiselectMock.mockReset();
+  for (const val of multiselectReturns) {
+    multiselectMock.mockResolvedValueOnce(val);
+  }
+}
+
+/** Predict whether the languages multiselect will be shown. */
+function shouldShowLanguagePrompt(answers: MockAnswers): boolean {
+  const frontend = answers.frontend ?? "none";
+  const backend = answers.backend ?? "none";
+  const iac = answers.iac ?? [];
+
+  let hasTypeScript = false;
+  let hasPython = false;
+
+  if (frontend === "react" || frontend === "nextjs") hasTypeScript = true;
+  if (backend === "express") hasTypeScript = true;
+  if (iac.includes("cdk")) hasTypeScript = true;
+  if (backend === "fastapi") hasPython = true;
+
+  // If both are auto-resolved, the prompt is skipped
+  return !(hasTypeScript && hasPython);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockAnswers = {};
+  logInfoCalls = [];
+});
+
+describe("CLI Wizard E2E", () => {
+  describe("basic flow", () => {
+    it("returns correct WizardAnswers with minimal selections", async () => {
+      setupMock({ projectName: "test-project", agents: ["claude-code"] });
+
+      const result = await runWizard();
+
+      expect(result).toEqual({
+        projectName: "test-project",
+        frontend: "none",
+        backend: "none",
+        clouds: [],
+        iac: [],
+        languages: [],
+        agents: ["claude-code"],
+      });
+    });
+
+    it("passes defaultName as initialValue to text prompt", async () => {
+      setupMock({ projectName: "provided-name" });
+
+      await runWizard("default-name");
+
+      const textMock = vi.mocked(p.text);
+      expect(textMock).toHaveBeenCalledOnce();
+      const callArg = textMock.mock.calls[0][0];
+      expect(callArg).toHaveProperty("initialValue", "default-name");
+    });
+
+    it("trims whitespace from project name", async () => {
+      setupMock({ projectName: "  spaced-name  " });
+
+      const result = await runWizard();
+
+      expect(result.projectName).toBe("spaced-name");
+    });
+  });
+
+  describe("frontend and backend selections", () => {
+    it("returns selected frontend framework", async () => {
+      setupMock({ frontend: "react", agents: [] });
+
+      const result = await runWizard();
+
+      expect(result.frontend).toBe("react");
+    });
+
+    it("returns selected backend framework", async () => {
+      setupMock({ backend: "express", agents: [] });
+
+      const result = await runWizard();
+
+      expect(result.backend).toBe("express");
+    });
+
+    it("returns both frontend and backend", async () => {
+      setupMock({ frontend: "nextjs", backend: "fastapi", agents: [] });
+
+      const result = await runWizard();
+
+      expect(result.frontend).toBe("nextjs");
+      expect(result.backend).toBe("fastapi");
+    });
+  });
+
+  describe("cloud and IaC conditional flow", () => {
+    it("skips IaC question when no clouds selected", async () => {
+      setupMock({ clouds: [], agents: [] });
+
+      const result = await runWizard();
+
+      expect(result.clouds).toEqual([]);
+      expect(result.iac).toEqual([]);
+    });
+
+    it("shows IaC question when clouds are selected", async () => {
+      setupMock({
+        clouds: ["aws"],
+        iac: ["cdk"],
+        agents: [],
+      });
+
+      const result = await runWizard();
+
+      expect(result.clouds).toEqual(["aws"]);
+      expect(result.iac).toEqual(["cdk"]);
+    });
+
+    it("returns multiple clouds and IaC tools", async () => {
+      setupMock({
+        clouds: ["aws", "azure"],
+        iac: ["terraform"],
+        agents: [],
+      });
+
+      const result = await runWizard();
+
+      expect(result.clouds).toEqual(["aws", "azure"]);
+      expect(result.iac).toEqual(["terraform"]);
+    });
+  });
+
+  describe("dependency chains — language auto-selection", () => {
+    it("React forces TypeScript — logs auto-selected message", async () => {
+      setupMock({ frontend: "react", agents: [] });
+
+      await runWizard();
+
+      expect(logInfoCalls.some((msg) => msg.includes("TypeScript"))).toBe(true);
+    });
+
+    it("Next.js forces TypeScript", async () => {
+      setupMock({ frontend: "nextjs", agents: [] });
+
+      await runWizard();
+
+      expect(logInfoCalls.some((msg) => msg.includes("TypeScript"))).toBe(true);
+    });
+
+    it("Express forces TypeScript", async () => {
+      setupMock({ backend: "express", agents: [] });
+
+      await runWizard();
+
+      expect(logInfoCalls.some((msg) => msg.includes("TypeScript"))).toBe(true);
+    });
+
+    it("FastAPI forces Python", async () => {
+      setupMock({ backend: "fastapi", agents: [] });
+
+      await runWizard();
+
+      expect(logInfoCalls.some((msg) => msg.includes("Python"))).toBe(true);
+    });
+
+    it("React + FastAPI auto-resolves both languages — skips language prompt", async () => {
+      setupMock({ frontend: "react", backend: "fastapi", agents: [] });
+
+      const result = await runWizard();
+
+      // Both languages auto-resolved — languages prompt was skipped (returned undefined)
+      expect(result.languages).toEqual([]);
+
+      // Both auto-selection messages should appear
+      expect(logInfoCalls.some((msg) => msg.includes("TypeScript"))).toBe(true);
+      expect(logInfoCalls.some((msg) => msg.includes("Python"))).toBe(true);
+    });
+
+    it("CDK forces TypeScript", async () => {
+      setupMock({ clouds: ["aws"], iac: ["cdk"], agents: [] });
+
+      await runWizard();
+
+      expect(logInfoCalls.some((msg) => msg.includes("TypeScript"))).toBe(true);
+    });
+  });
+
+  describe("language manual selection", () => {
+    it("allows manual TypeScript selection when no framework forces it", async () => {
+      setupMock({ languages: ["typescript"], agents: [] });
+
+      const result = await runWizard();
+
+      expect(result.languages).toEqual(["typescript"]);
+    });
+
+    it("allows manual Python selection when no framework forces it", async () => {
+      setupMock({ languages: ["python"], agents: [] });
+
+      const result = await runWizard();
+
+      expect(result.languages).toEqual(["python"]);
+    });
+
+    it("allows both languages selected manually", async () => {
+      setupMock({ languages: ["typescript", "python"], agents: [] });
+
+      const result = await runWizard();
+
+      expect(result.languages).toEqual(["typescript", "python"]);
+    });
+  });
+
+  describe("agent selection", () => {
+    it("returns selected agents", async () => {
+      setupMock({ agents: ["claude-code", "copilot", "cursor"] });
+
+      const result = await runWizard();
+
+      expect(result.agents).toEqual(["claude-code", "copilot", "cursor"]);
+    });
+
+    it("allows empty agent selection", async () => {
+      setupMock({ agents: [] });
+
+      const result = await runWizard();
+
+      expect(result.agents).toEqual([]);
+    });
+
+    it("returns all agents when all selected", async () => {
+      const allAgents = [
+        "claude-code",
+        "codex",
+        "gemini",
+        "amazon-q",
+        "copilot",
+        "cline",
+        "cursor",
+      ] as const;
+      setupMock({ agents: [...allAgents] });
+
+      const result = await runWizard();
+
+      expect(result.agents).toEqual([...allAgents]);
+    });
+  });
+
+  describe("full combination flow", () => {
+    it("handles full-stack selection: React + Express + AWS + CDK + all agents", async () => {
+      setupMock({
+        projectName: "full-stack-app",
+        frontend: "react",
+        backend: "express",
+        clouds: ["aws"],
+        iac: ["cdk"],
+        agents: ["claude-code", "copilot"],
+      });
+
+      const result = await runWizard();
+
+      expect(result).toEqual({
+        projectName: "full-stack-app",
+        frontend: "react",
+        backend: "express",
+        clouds: ["aws"],
+        iac: ["cdk"],
+        languages: [],
+        agents: ["claude-code", "copilot"],
+      });
+    });
+
+    it("handles multi-cloud with terraform", async () => {
+      setupMock({
+        projectName: "multi-cloud",
+        clouds: ["aws", "azure", "gcp"],
+        iac: ["terraform"],
+        languages: ["typescript"],
+        agents: ["claude-code"],
+      });
+
+      const result = await runWizard();
+
+      expect(result).toEqual({
+        projectName: "multi-cloud",
+        frontend: "none",
+        backend: "none",
+        clouds: ["aws", "azure", "gcp"],
+        iac: ["terraform"],
+        languages: ["typescript"],
+        agents: ["claude-code"],
+      });
+    });
+  });
+
+  describe("project name validation", () => {
+    it("text prompt has validation function", async () => {
+      setupMock({});
+
+      await runWizard();
+
+      const textMock = vi.mocked(p.text);
+      const callArg = textMock.mock.calls[0][0];
+      expect(callArg).toHaveProperty("validate");
+      expect(typeof callArg.validate).toBe("function");
+    });
+
+    it("validation rejects empty name", async () => {
+      setupMock({});
+
+      await runWizard();
+
+      const validate = vi.mocked(p.text).mock.calls[0][0].validate as (
+        v: string,
+      ) => string | undefined;
+      expect(validate("")).toBeTruthy();
+      expect(validate("   ")).toBeTruthy();
+    });
+
+    it("validation rejects invalid characters", async () => {
+      setupMock({});
+
+      await runWizard();
+
+      const validate = vi.mocked(p.text).mock.calls[0][0].validate as (
+        v: string,
+      ) => string | undefined;
+      expect(validate("invalid name!")).toBeTruthy();
+      expect(validate("@scope/pkg")).toBeTruthy();
+    });
+
+    it("validation accepts valid names", async () => {
+      setupMock({});
+
+      await runWizard();
+
+      const validate = vi.mocked(p.text).mock.calls[0][0].validate as (
+        v: string,
+      ) => string | undefined;
+      expect(validate("my-app")).toBeUndefined();
+      expect(validate("my_app.v2")).toBeUndefined();
+      expect(validate("App123")).toBeUndefined();
+    });
+  });
+
+  describe("wizard → generate integration", () => {
+    it("wizard output is valid input for generate()", async () => {
+      const { generate } = await import("../src/generator.js");
+
+      setupMock({
+        projectName: "integration-test",
+        frontend: "react",
+        backend: "fastapi",
+        clouds: ["aws"],
+        iac: ["cdk"],
+        agents: ["claude-code", "codex"],
+      });
+
+      const answers = await runWizard();
+      const result = generate(answers);
+
+      expect(result.fileList().length).toBeGreaterThan(0);
+      expect(result.hasFile("package.json")).toBe(true);
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,7 +6,13 @@ export default defineConfig({
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],
-      reporter: ["text", "html"],
+      reporter: ["text", "html", "json-summary"],
+      thresholds: {
+        statements: 80,
+        branches: 70,
+        functions: 80,
+        lines: 80,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

Closes #123

- **CLI ウィザード E2E テスト**: `@clack/prompts` をモックし、`runWizard()` の完全フローを検証する 28 テストを追加。依存チェーン（React→TypeScript 強制）の UI 反映、条件分岐（クラウド未選択時の IaC スキップ）、プロジェクト名バリデーション、`generate()` との統合を網羅
- **カバレッジ可視化**: `vitest.config.ts` にしきい値（statements/lines 80%, branches 70%, functions 80%）と `json-summary` レポーターを追加。CI の Test ステップをカバレッジ付き実行に変更
- **依存更新**: `@vitest/coverage-v8` の固定バージョン (`4.1.1`) を範囲指定 (`^4.1.1`) に変更

## Test plan

- [x] 新規 28 E2E テスト全通過
- [x] 既存 568 テスト全通過（合計 596）
- [x] `pnpm run build` 成功
- [x] `pnpm run typecheck` 成功
- [x] lint 全通過（Biome, YAML, actionlint, gitleaks）