### PR TITLE
feat: add --dry-run preview and post-generation auto-setup

### DIFF
--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -69,5 +69,18 @@
   "nextSteps": {
     "title": "Next steps"
   },
+  "dryRun": {
+    "preview": "Preview: {{count}} files would be generated",
+    "noWrite": "Dry run — no files were written."
+  },
+  "setup": {
+    "gitInit": "Initializing git repository...",
+    "gitInitDone": "Git repository initialized",
+    "gitInitFailed": "git init failed (skipped)",
+    "pnpmInstall": "Installing dependencies (pnpm install)...",
+    "pnpmInstallDone": "Dependencies installed",
+    "pnpmInstallFailed": "pnpm install failed (skipped)",
+    "manualHint": "Run manually: cd {{path}} && pnpm install"
+  },
   "outro": "Done! Happy coding."
 }

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -69,5 +69,18 @@
   "nextSteps": {
     "title": "次のステップ"
   },
+  "dryRun": {
+    "preview": "プレビュー: {{count}} ファイルが生成されます",
+    "noWrite": "ドライラン — ファイルは書き込まれませんでした。"
+  },
+  "setup": {
+    "gitInit": "Git リポジトリを初期化中...",
+    "gitInitDone": "Git リポジトリを初期化しました",
+    "gitInitFailed": "git init に失敗しました（スキップ）",
+    "pnpmInstall": "依存パッケージをインストール中 (pnpm install)...",
+    "pnpmInstallDone": "依存パッケージをインストールしました",
+    "pnpmInstallFailed": "pnpm install に失敗しました（スキップ）",
+    "manualHint": "手動で実行してください: cd {{path}} && pnpm install"
+  },
   "outro": "完了！Happy coding."
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { execFile } from "node:child_process";
 import fs from "node:fs";
 import path from "node:path";
 import { parseArgs } from "node:util";
@@ -7,13 +8,29 @@ import pc from "picocolors";
 import { runWizard } from "./cli.js";
 import { generate, validateAnswers } from "./generator.js";
 import { detectLocale, setLocale, t } from "./i18n/index.js";
+import { buildFileTree } from "./tree.js";
 import { createDiskWriter } from "./utils.js";
+
+/** Run a shell command and return stdout. Rejects on non-zero exit. */
+function run(cmd: string, args: string[], cwd: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(cmd, args, { cwd }, (error, stdout, stderr) => {
+      if (error) {
+        reject(new Error(`${cmd} ${args.join(" ")} failed: ${stderr || error.message}`));
+      } else {
+        resolve(stdout);
+      }
+    });
+  });
+}
 
 async function main(): Promise<void> {
   const { values, positionals } = parseArgs({
     args: process.argv.slice(2),
     options: {
       lang: { type: "string" },
+      "dry-run": { type: "boolean", default: false },
+      "no-install": { type: "boolean", default: false },
     },
     allowPositionals: true,
     strict: false,
@@ -21,6 +38,9 @@ async function main(): Promise<void> {
 
   const langFlag = typeof values.lang === "string" ? values.lang : undefined;
   setLocale(detectLocale(langFlag));
+
+  const dryRun = values["dry-run"] === true;
+  const noInstall = values["no-install"] === true;
 
   const positionalArg = positionals[0];
   const defaultName = positionalArg ? path.basename(positionalArg) : undefined;
@@ -37,6 +57,19 @@ async function main(): Promise<void> {
   const outDir = path.resolve(parentDir, answers.projectName);
   const relPath = path.relative(process.cwd(), outDir) || ".";
 
+  // --- Dry-run mode: preview only, no disk writes ---
+  if (dryRun) {
+    const result = generate(answers);
+    const fileList = result.fileList();
+    const tree = buildFileTree(fileList);
+    p.log.info(
+      `${t("dryRun.preview", { count: fileList.length })}\n\n${pc.dim(tree)}\n\n${pc.yellow(t("dryRun.noWrite"))}`,
+    );
+    p.outro(pc.green(t("outro")));
+    return;
+  }
+
+  // --- Normal mode: write to disk ---
   if (fs.existsSync(outDir) && fs.readdirSync(outDir).length > 0) {
     const overwrite = await p.confirm({
       message: t("overwrite.message", { path: relPath }),
@@ -55,7 +88,31 @@ async function main(): Promise<void> {
 
   s.stop(t("spinner.stop", { count: result.fileList().length }));
 
-  p.log.step(`${t("nextSteps.title")}:\n  cd ${relPath}\n  bash scripts/setup.sh`);
+  // --- Post-generation setup ---
+  if (noInstall) {
+    p.log.step(`${t("nextSteps.title")}:\n  cd ${relPath}\n  bash scripts/setup.sh`);
+  } else {
+    const setupSpinner = p.spinner();
+
+    // git init
+    setupSpinner.start(t("setup.gitInit"));
+    try {
+      await run("git", ["init"], outDir);
+      setupSpinner.stop(t("setup.gitInitDone"));
+    } catch {
+      setupSpinner.stop(pc.yellow(t("setup.gitInitFailed")));
+    }
+
+    // pnpm install
+    setupSpinner.start(t("setup.pnpmInstall"));
+    try {
+      await run("pnpm", ["install"], outDir);
+      setupSpinner.stop(t("setup.pnpmInstallDone"));
+    } catch {
+      setupSpinner.stop(pc.yellow(t("setup.pnpmInstallFailed")));
+      p.log.warn(t("setup.manualHint", { path: relPath }));
+    }
+  }
 
   p.outro(pc.green(t("outro")));
 }

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -1,0 +1,48 @@
+/**
+ * Build a tree-formatted string from a sorted list of file paths.
+ *
+ * Example output:
+ *   ├── package.json
+ *   ├── src/
+ *   │   └── index.ts
+ *   └── tests/
+ *       └── index.test.ts
+ */
+export function buildFileTree(paths: string[]): string {
+  interface TreeNode {
+    children: Map<string, TreeNode>;
+  }
+
+  const root: TreeNode = { children: new Map() };
+
+  for (const p of paths) {
+    const parts = p.split("/");
+    let current = root;
+    for (const part of parts) {
+      if (!current.children.has(part)) {
+        current.children.set(part, { children: new Map() });
+      }
+      // biome-ignore lint/style/noNonNullAssertion: just set above
+      current = current.children.get(part)!;
+    }
+  }
+
+  const lines: string[] = [];
+
+  function render(node: TreeNode, prefix: string): void {
+    const entries = [...node.children.entries()];
+    for (let i = 0; i < entries.length; i++) {
+      const [name, child] = entries[i];
+      const last = i === entries.length - 1;
+      const connector = last ? "└── " : "├── ";
+      const isDir = child.children.size > 0;
+      lines.push(`${prefix}${connector}${name}${isDir ? "/" : ""}`);
+      if (isDir) {
+        render(child, prefix + (last ? "    " : "│   "));
+      }
+    }
+  }
+
+  render(root, "");
+  return lines.join("\n");
+}

--- a/tests/tree.test.ts
+++ b/tests/tree.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { buildFileTree } from "../src/tree.js";
+
+describe("buildFileTree", () => {
+  it("renders a flat list of files", () => {
+    const tree = buildFileTree(["a.txt", "b.txt"]);
+    expect(tree).toBe("├── a.txt\n└── b.txt");
+  });
+
+  it("renders nested directories", () => {
+    const tree = buildFileTree(["src/index.ts", "src/utils.ts", "package.json"]);
+    expect(tree).toContain("src/");
+    expect(tree).toContain("index.ts");
+    expect(tree).toContain("utils.ts");
+    expect(tree).toContain("package.json");
+  });
+
+  it("renders deeply nested paths", () => {
+    const tree = buildFileTree([".claude/rules/git-workflow.md", ".claude/skills/lint/SKILL.md"]);
+    expect(tree).toContain(".claude/");
+    expect(tree).toContain("rules/");
+    expect(tree).toContain("skills/");
+    expect(tree).toContain("git-workflow.md");
+    expect(tree).toContain("SKILL.md");
+  });
+
+  it("handles single file", () => {
+    const tree = buildFileTree(["README.md"]);
+    expect(tree).toBe("└── README.md");
+  });
+
+  it("handles empty list", () => {
+    const tree = buildFileTree([]);
+    expect(tree).toBe("");
+  });
+
+  it("uses tree connectors correctly", () => {
+    const tree = buildFileTree(["a.txt", "b.txt", "c.txt"]);
+    const lines = tree.split("\n");
+    expect(lines[0]).toMatch(/^├── a\.txt$/);
+    expect(lines[1]).toMatch(/^├── b\.txt$/);
+    expect(lines[2]).toMatch(/^└── c\.txt$/);
+  });
+
+  it("marks directories with trailing /", () => {
+    const tree = buildFileTree(["src/index.ts"]);
+    expect(tree).toContain("src/");
+  });
+
+  it("renders a realistic project structure", () => {
+    const files = [
+      ".gitignore",
+      "package.json",
+      "src/index.ts",
+      "src/utils.ts",
+      "tests/index.test.ts",
+      "web/package.json",
+      "web/src/App.tsx",
+    ];
+    const tree = buildFileTree(files);
+    expect(tree).toContain("src/");
+    expect(tree).toContain("tests/");
+    expect(tree).toContain("web/");
+    // All files should be present
+    for (const f of files) {
+      const name = f.split("/").pop() ?? "";
+      expect(tree).toContain(name);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #128

- Add `--dry-run` flag: generates in memory and displays a tree preview of all files that would be created, without writing anything to disk
- Add post-generation auto-setup: automatically runs `git init` + `pnpm install` after file generation (skip with `--no-install`)
- Add `buildFileTree()` utility for tree-formatted file path rendering
- Add i18n strings (en/ja) for all new messages

## Changes

### `--dry-run` flag
- `src/index.ts` — when `--dry-run` is set, call `generate()` without a writer, display file tree via `buildFileTree()`, then exit
- `src/tree.ts` — new utility that builds a tree-formatted string from file paths (with `├──`, `└──`, `│` connectors)

### Post-generation auto-setup
- `src/index.ts` — after writing files, run `git init` + `pnpm install` in the output directory. Each step has error handling (warns and continues on failure)
- `--no-install` flag skips auto-setup and shows manual instructions instead (previous behavior)

### i18n
- `src/i18n/{en,ja}.json` — new `dryRun.*` and `setup.*` message keys

### Tests
- `tests/tree.test.ts` — 8 tests for `buildFileTree()` (flat, nested, deep, single, empty, connectors, directories, realistic)

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm run typecheck` passes  
- [x] `pnpm test` — 699 tests pass (35 files)
- [x] All lint hooks pass