### PR TITLE
feat: add test project generation script

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -4,6 +4,7 @@
     "includes": [
       "src/**",
       "tests/**",
+      "scripts/**",
       ".vscode/**",
       ".github/**",
       "*.json",

--- a/scripts/gen-test-projects.ts
+++ b/scripts/gen-test-projects.ts
@@ -1,0 +1,270 @@
+/**
+ * Generate test projects under tmp/ for manual inspection.
+ *
+ * Usage:
+ *   npx tsx scripts/gen-test-projects.ts
+ */
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+import { generate } from "../src/generator.js";
+import type { WizardAnswers } from "../src/types.js";
+
+const ROOT = resolve(import.meta.dirname, "..");
+const TMP = resolve(ROOT, "tmp");
+
+function defaults(overrides: Partial<WizardAnswers>): WizardAnswers {
+  return {
+    projectName: "test-project",
+    frontend: "none",
+    backend: "none",
+    clouds: [],
+    iac: [],
+    languages: [],
+    agents: ["claude-code"],
+    ...overrides,
+  };
+}
+
+// ─── Test project definitions ───────────────────────────────────────────────
+// Each entry covers a distinct architectural pattern or feature combination.
+
+const projects: [string, Partial<WizardAnswers>][] = [
+  // ── Minimal baselines ──
+  ["01-base-only", { projectName: "base-only", agents: [] }],
+  ["02-typescript-only", { projectName: "typescript-only", languages: ["typescript"] }],
+  ["03-python-only", { projectName: "python-only", languages: ["python"] }],
+  ["04-dual-language", { projectName: "dual-language", languages: ["typescript", "python"] }],
+
+  // ── Frontend ──
+  [
+    "05-react",
+    {
+      projectName: "react-app",
+      frontend: "react",
+    },
+  ],
+  [
+    "06-nextjs",
+    {
+      projectName: "nextjs-app",
+      frontend: "nextjs",
+    },
+  ],
+  [
+    "07-vue",
+    {
+      projectName: "vue-app",
+      frontend: "vue",
+    },
+  ],
+  [
+    "08-nuxt",
+    {
+      projectName: "nuxt-app",
+      frontend: "nuxt",
+    },
+  ],
+
+  // ── Backend ──
+  [
+    "09-express",
+    {
+      projectName: "express-app",
+      backend: "express",
+    },
+  ],
+  [
+    "10-fastapi",
+    {
+      projectName: "fastapi-app",
+      backend: "fastapi",
+    },
+  ],
+  [
+    "11-batch",
+    {
+      projectName: "batch-app",
+      backend: "batch",
+    },
+  ],
+
+  // ── Frontend + Backend ──
+  [
+    "12-react-express",
+    {
+      projectName: "react-express",
+      frontend: "react",
+      backend: "express",
+    },
+  ],
+  [
+    "13-nextjs-fastapi",
+    {
+      projectName: "nextjs-fastapi",
+      frontend: "nextjs",
+      backend: "fastapi",
+    },
+  ],
+
+  // ── Cloud + IaC ──
+  [
+    "14-aws-cdk",
+    {
+      projectName: "aws-cdk",
+      clouds: ["aws"],
+      iac: ["cdk"],
+      languages: ["typescript"],
+    },
+  ],
+  [
+    "15-aws-terraform",
+    {
+      projectName: "aws-terraform",
+      clouds: ["aws"],
+      iac: ["terraform"],
+      languages: ["typescript"],
+    },
+  ],
+  [
+    "16-azure-bicep",
+    {
+      projectName: "azure-bicep",
+      clouds: ["azure"],
+      iac: ["bicep"],
+      languages: ["typescript"],
+    },
+  ],
+  [
+    "17-gcp-terraform",
+    {
+      projectName: "gcp-terraform",
+      clouds: ["gcp"],
+      iac: ["terraform"],
+      languages: ["typescript"],
+    },
+  ],
+  [
+    "18-multi-cloud-terraform",
+    {
+      projectName: "multi-cloud",
+      clouds: ["aws", "azure", "gcp"],
+      iac: ["terraform"],
+      languages: ["typescript"],
+    },
+  ],
+  [
+    "19-aws-cdk-cloudformation",
+    {
+      projectName: "aws-dual-iac",
+      clouds: ["aws"],
+      iac: ["cdk", "cloudformation"],
+      languages: ["typescript"],
+    },
+  ],
+
+  // ── Full-stack combinations ──
+  [
+    "20-react-express-aws-cdk",
+    {
+      projectName: "fullstack-aws",
+      frontend: "react",
+      backend: "express",
+      clouds: ["aws"],
+      iac: ["cdk"],
+      agents: ["claude-code", "copilot"],
+    },
+  ],
+  [
+    "21-nextjs-fastapi-azure",
+    {
+      projectName: "fullstack-azure",
+      frontend: "nextjs",
+      backend: "fastapi",
+      clouds: ["azure"],
+      iac: ["bicep", "terraform"],
+      agents: ["claude-code", "cursor"],
+    },
+  ],
+
+  // ── Agent variations ──
+  [
+    "22-all-agents",
+    {
+      projectName: "all-agents",
+      languages: ["typescript"],
+      agents: ["claude-code", "codex", "gemini", "amazon-q", "copilot", "cline", "cursor"],
+    },
+  ],
+
+  // ── Cross-layer combinations ──
+  [
+    "24-vue-fastapi",
+    {
+      projectName: "vue-fastapi",
+      frontend: "vue",
+      backend: "fastapi",
+    },
+  ],
+  [
+    "25-nuxt-express",
+    {
+      projectName: "nuxt-express",
+      frontend: "nuxt",
+      backend: "express",
+    },
+  ],
+  [
+    "26-batch-aws-cdk",
+    {
+      projectName: "batch-aws-cdk",
+      backend: "batch",
+      clouds: ["aws"],
+      iac: ["cdk"],
+    },
+  ],
+  [
+    "27-aws-only",
+    {
+      projectName: "aws-only",
+      clouds: ["aws"],
+      languages: ["typescript"],
+    },
+  ],
+
+  // ── Kitchen sink ──
+  [
+    "28-kitchen-sink",
+    {
+      projectName: "kitchen-sink",
+      frontend: "react",
+      backend: "express",
+      clouds: ["aws", "azure", "gcp"],
+      iac: ["cdk", "cloudformation", "terraform", "bicep"],
+      languages: ["python"],
+      agents: ["claude-code", "codex", "gemini", "amazon-q", "copilot", "cline", "cursor"],
+    },
+  ],
+];
+
+// ─── Generate ───────────────────────────────────────────────────────────────
+
+rmSync(TMP, { recursive: true, force: true });
+
+console.log(`Generating ${projects.length} test projects under tmp/\n`);
+
+for (const [dir, overrides] of projects) {
+  const answers = defaults(overrides);
+  const result = generate(answers);
+  const outDir = resolve(TMP, dir);
+
+  for (const [filePath, content] of result.files) {
+    const absPath = resolve(outDir, filePath);
+    mkdirSync(dirname(absPath), { recursive: true });
+    writeFileSync(absPath, content, "utf-8");
+  }
+
+  console.log(`  ✓ ${dir} (${result.files.size} files)`);
+}
+
+console.log(`\nDone! ${projects.length} projects generated in tmp/`);

--- a/scripts/gen-test-projects.ts
+++ b/scripts/gen-test-projects.ts
@@ -199,7 +199,7 @@ const projects: [string, Partial<WizardAnswers>][] = [
 
   // ── Cross-layer combinations ──
   [
-    "24-vue-fastapi",
+    "23-vue-fastapi",
     {
       projectName: "vue-fastapi",
       frontend: "vue",
@@ -207,7 +207,7 @@ const projects: [string, Partial<WizardAnswers>][] = [
     },
   ],
   [
-    "25-nuxt-express",
+    "24-nuxt-express",
     {
       projectName: "nuxt-express",
       frontend: "nuxt",
@@ -215,7 +215,7 @@ const projects: [string, Partial<WizardAnswers>][] = [
     },
   ],
   [
-    "26-batch-aws-cdk",
+    "25-batch-aws-cdk",
     {
       projectName: "batch-aws-cdk",
       backend: "batch",
@@ -224,7 +224,7 @@ const projects: [string, Partial<WizardAnswers>][] = [
     },
   ],
   [
-    "27-aws-only",
+    "26-aws-only",
     {
       projectName: "aws-only",
       clouds: ["aws"],
@@ -234,7 +234,7 @@ const projects: [string, Partial<WizardAnswers>][] = [
 
   // ── Kitchen sink ──
   [
-    "28-kitchen-sink",
+    "27-kitchen-sink",
     {
       projectName: "kitchen-sink",
       frontend: "react",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,5 @@
     "verbatimModuleSyntax": true
   },
   "include": ["src"],
-  "exclude": ["node_modules", "dist", "templates", "tests"]
+  "exclude": ["node_modules", "dist", "templates", "tests", "scripts", "tmp"]
 }


### PR DESCRIPTION
## Summary

- Add `scripts/gen-test-projects.ts` that generates 27 test projects under `tmp/` covering all preset combinations for manual inspection
- Add `scripts/` to biome includes and tsconfig excludes
- Patterns cover: all frontends, backends, clouds, IaC tools, agents, cross-layer combos, and kitchen sink

Usage: `npx tsx scripts/gen-test-projects.ts`