### PR TITLE
chore: add @ozzylabs npm scope and package metadata

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -15,7 +15,7 @@ body:
       label: Steps to Reproduce
       description: Steps to reproduce the behavior.
       value: |
-        1. Run `npm create agentic-dev my-app`
+        1. Run `npm create @ozzylabs/agentic-dev my-app`
         2. Select ...
         3. See error
     validations:
@@ -38,7 +38,7 @@ body:
     id: version
     attributes:
       label: Version
-      description: "Output of `npx create-agentic-dev --version` or package.json version."
+      description: "Output of `npx @ozzylabs/create-agentic-dev --version` or package.json version."
       placeholder: "0.1.0"
     validations:
       required: false

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Companion to [agentic-dev-template](https://github.com/ozzy-3/agentic-dev-templa
 ## Quick Start
 
 ```bash
-npm create agentic-dev my-app
+npm create @ozzylabs/agentic-dev my-app
 cd my-app
 bash scripts/setup.sh
 ```

--- a/docs/design.md
+++ b/docs/design.md
@@ -4,7 +4,7 @@
 
 `create-agentic-dev` is a CLI tool that scaffolds AI-agent-native development projects with interactive presets.
 
-- **Distribution**: npm package (`npm create agentic-dev`)
+- **Distribution**: npm package (`npm create @ozzylabs/agentic-dev`)
 - **Prompt library**: @clack/prompts
 - **Architecture**: Preset Composition (composable presets merged into final project)
 - **Relationship**: Companion to [agentic-dev-template](https://github.com/ozzy-3/agentic-dev-template)
@@ -571,7 +571,7 @@ No arg parser needed — only `process.argv[2]` for project name.
 ### Execution flow
 
 ```text
-npm create agentic-dev [my-app]
+npm create @ozzylabs/agentic-dev [my-app]
   │
   ├─ src/index.ts          # Get project name from process.argv
   ├─ src/cli.ts            # Run wizard with @clack/prompts
@@ -688,7 +688,7 @@ npm create agentic-dev [my-app]
 |------|-------|
 | Package name | `create-agentic-dev` |
 | Registry | npm public |
-| Usage | `npm create agentic-dev` / `npx create-agentic-dev` |
+| Usage | `npm create @ozzylabs/agentic-dev` / `npx @ozzylabs/create-agentic-dev` |
 | Release trigger | GitHub Release (tag `v*`) → auto publish |
 | Provenance | Enabled (`--provenance`) for supply chain security |
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "create-agentic-dev",
+  "name": "@ozzylabs/create-agentic-dev",
   "version": "0.1.0",
   "description": "Scaffold an AI-agent-native development environment with interactive presets",
   "type": "module",
@@ -36,6 +36,9 @@
     "provenance": true
   },
   "license": "MIT",
+  "author": "ozzy-labs",
+  "homepage": "https://github.com/ozzy-3/create-agentic-dev#readme",
+  "bugs": "https://github.com/ozzy-3/create-agentic-dev/issues",
   "repository": {
     "type": "git",
     "url": "https://github.com/ozzy-3/create-agentic-dev.git"


### PR DESCRIPTION
## Summary

- Change package name to `@ozzylabs/create-agentic-dev` (scoped under npm org)
- Add `author`, `homepage`, `bugs` fields to package.json
- Update install commands across README.md, docs/design.md, bug report template