### PR TITLE
fix: update all GitHub Actions to latest commit hashes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,15 +17,15 @@ jobs:
   lint-and-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: jdx/mise-action@5083fe46f0db0d17c4a46080674d3981cf8e538e # v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
           install: true
           cache: true
 
       - name: pnpm cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.local/share/pnpm/store
           key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,14 +12,14 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: jdx/mise-action@5083fe46f0db0d17c4a46080674d3981cf8e538e # v2
+      - uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac # v2
         with:
           install: true
           cache: true
 
-      - uses: actions/setup-node@49933ea5288caeca8642195f882660b323136e2a # v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           registry-url: "https://registry.npmjs.org"
 
@@ -27,7 +27,7 @@ jobs:
         run: npm install -g npm@latest
 
       - name: pnpm cache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.local/share/pnpm/store
           key: pnpm-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/docs/preset-authoring.md
+++ b/docs/preset-authoring.md
@@ -310,7 +310,7 @@ ciSteps: {
   setupSteps: [
     {
       name: "uv cache",
-      uses: "actions/cache@5a3ec84eff668545956fd18022155c47e93e2684",
+      uses: "actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830",
       with: {
         path: "~/.cache/uv",
         key: "uv-${{ runner.os }}-${{ hashFiles('uv.lock') }}",

--- a/src/ci.ts
+++ b/src/ci.ts
@@ -39,11 +39,11 @@ export function buildCiWorkflow({ contributions, hasTest, hasBuild }: CiWorkflow
   const commonSetup: CiStep[] = [
     {
       name: "Checkout",
-      uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683",
+      uses: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
     },
     {
       name: "Setup mise",
-      uses: "jdx/mise-action@5083fe46f0db0d17c4a46080674d3981cf8e538e",
+      uses: "jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac",
       with: { install: "true", cache: "true" },
     },
   ];

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -364,10 +364,10 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup mise
-        uses: jdx/mise-action@5083fe46f0db0d17c4a46080674d3981cf8e538e
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac
         with:
           install: "true"
           cache: "true"

--- a/src/presets/base.ts
+++ b/src/presets/base.ts
@@ -89,7 +89,7 @@ export const basePreset: Preset = {
     setupSteps: [
       {
         name: "pnpm cache",
-        uses: "actions/cache@5a3ec84eff668545956fd18022155c47e93e2684",
+        uses: "actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830",
         with: {
           path: "~/.local/share/pnpm/store",
           // biome-ignore lint/suspicious/noTemplateCurlyInString: GitHub Actions expression

--- a/src/presets/python.ts
+++ b/src/presets/python.ts
@@ -165,7 +165,7 @@ export const pythonPreset: Preset = {
     setupSteps: [
       {
         name: "uv cache",
-        uses: "actions/cache@5a3ec84eff668545956fd18022155c47e93e2684",
+        uses: "actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830",
         with: {
           path: "~/.cache/uv",
           // biome-ignore lint/suspicious/noTemplateCurlyInString: GitHub Actions expression

--- a/templates/bicep/.github/workflows/cd-bicep.yaml
+++ b/templates/bicep/.github/workflows/cd-bicep.yaml
@@ -20,10 +20,10 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup mise
-        uses: jdx/mise-action@5083fe46f0db0d17c4a46080674d3981cf8e538e
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac
         with:
           install: "true"
           cache: "true"

--- a/templates/cdk/.github/workflows/cd-cdk.yaml
+++ b/templates/cdk/.github/workflows/cd-cdk.yaml
@@ -20,10 +20,10 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup mise
-        uses: jdx/mise-action@5083fe46f0db0d17c4a46080674d3981cf8e538e
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac
         with:
           install: "true"
           cache: "true"

--- a/templates/cloudformation/.github/workflows/cd-cloudformation.yaml
+++ b/templates/cloudformation/.github/workflows/cd-cloudformation.yaml
@@ -20,10 +20,10 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup mise
-        uses: jdx/mise-action@5083fe46f0db0d17c4a46080674d3981cf8e538e
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac
         with:
           install: "true"
           cache: "true"


### PR DESCRIPTION
## Summary

- Update `actions/checkout` v4 commit hash (fixes CI failure)
- Update `jdx/mise-action` v2 commit hash (fixes CI failure)
- Update `actions/cache` v4 commit hash
- Update `actions/setup-node` v4 commit hash

Applied to: CI/Release workflows, CI builder, Terraform CD generator, preset templates (base, python), CD workflow templates (cdk, cloudformation, bicep), and preset-authoring docs.