### PR TITLE
fix: add explicit node types to tsconfig for CI compatibility

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "lib": ["ES2024"],
+    "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",
     "strict": true,


### PR DESCRIPTION
## Summary

- Add `"types": ["node"]` to tsconfig.json to explicitly resolve `@types/node`
- Fixes CI typecheck failure where `tsc` could not find Node.js type definitions after mise-action update