### PR TITLE
fix: ensure blank line before headings in merged markdown sections

### DIFF
--- a/src/merge.ts
+++ b/src/merge.ts
@@ -93,7 +93,11 @@ export function expandMarkdown(template: string, sections: MarkdownSection[]): s
         }
       }
 
-      const joined = unique.join(separator);
+      let joined = unique.join(separator);
+      // In block context, ensure blank line before Markdown headings (MD022)
+      if (separator === "\n") {
+        joined = joined.replace(/([^\n])\n(#{1,6} )/g, "$1\n\n$2");
+      }
       const replacement = needsLeadingSep ? `${separator}${joined}` : joined;
       result = result.slice(0, idx) + replacement + result.slice(idx + placeholder.length);
       searchFrom = idx + replacement.length;


### PR DESCRIPTION
## Summary

- Fix MD022/MD032 violations in generated `lint-rules/SKILL.md` when multiple presets inject content into the same markdown placeholder
- When content chunks are concatenated, headings could appear immediately after list items without a blank line separator
- Added post-processing in `expandMarkdown()` to ensure blank lines before markdown headings in block context