### PR TITLE
docs: update releasing.md to reflect publish job simplification

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -9,7 +9,7 @@
 | ジョブ | 役割 |
 |-------|------|
 | `release-please` | main への push で version bump PR を自動作成（CHANGELOG 生成含む） |
-| `publish` | release-please がリリースを作成した場合のみ lint → test → build → npm publish を実行 |
+| `publish` | release-please がリリースを作成した場合のみ build → npm publish を実行（lint/test は CI で検証済み） |
 
 npm への公開は [Trusted Publishing (OIDC)](https://docs.npmjs.com/trusted-publishers/) を使用する。NPM_TOKEN は不要。
 


### PR DESCRIPTION
## Summary

- Update `docs/releasing.md` to reflect that lint/typecheck/test were removed from the release `publish` job in #152