### PR TITLE
docs: update README presets and fix ozzy-3 URLs to ozzy-labs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-`create-agentic-dev`: CLI tool that scaffolds AI-agent-native development projects with interactive presets. Companion to [agentic-dev-template](https://github.com/ozzy-3/agentic-dev-template).
+`create-agentic-dev`: CLI tool that scaffolds AI-agent-native development projects with interactive presets. Companion to [agentic-dev-template](https://github.com/ozzy-labs/agentic-dev-template).
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Scaffold an AI-agent-native development environment with interactive presets.
 
-Companion to [agentic-dev-template](https://github.com/ozzy-3/agentic-dev-template).
+Companion to [agentic-dev-template](https://github.com/ozzy-labs/agentic-dev-template).
 
 ## Quick Start
 
@@ -17,28 +17,28 @@ bash scripts/setup.sh
 The interactive wizard asks 7 questions in an app-first flow:
 
 1. **Project name**
-2. **Frontend** — None / React + Vite / Next.js
-3. **Backend** — None / FastAPI / Express
+2. **Frontend** — None / React + Vite / Next.js / Vue / Nuxt
+3. **Backend** — None / FastAPI / Express / Batch
 4. **Cloud providers** — AWS / Azure / Google Cloud (multi-select)
 5. **Infrastructure as Code** — CDK / CloudFormation / Terraform / Bicep (filtered by cloud)
 6. **Language toolchains** — TypeScript / Python (excluding auto-resolved)
-7. **AI Agent tools** — Claude Code / Codex CLI / Gemini CLI / Amazon Q / Copilot (multi-select)
+7. **AI Agent tools** — Claude Code / Codex CLI / Gemini CLI / Amazon Q / Copilot / Cline / Cursor (multi-select)
 
 ## Presets
 
-20 composable presets across 7 layers. Each provides owned files + merge contributions
+24 composable presets across 7 layers. Each provides owned files + merge contributions
 to shared files (package.json, .mise.toml, lefthook.yaml, VSCode, devcontainer,
 README.md, CI workflow).
 
 | Layer | Presets |
 |-------|--------|
 | Base | Always included (git hooks, linters, devcontainer) |
-| Frontend | React + Vite, Next.js |
-| Backend | FastAPI, Express |
+| Frontend | React + Vite, Next.js, Vue, Nuxt |
+| Backend | FastAPI, Express, Batch |
 | Cloud | AWS, Azure, Google Cloud |
 | IaC | CDK, CloudFormation, Terraform, Bicep |
 | Language | TypeScript, Python |
-| Agent | Claude Code, Codex CLI, Gemini CLI, Amazon Q, Copilot |
+| Agent | Claude Code, Codex CLI, Gemini CLI, Amazon Q, Copilot, Cline, Cursor |
 
 See [docs/design.md](docs/design.md) for the full preset details and dependency chains.
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -7,7 +7,7 @@
 - **Distribution**: npm package (`npm create @ozzylabs/agentic-dev`)
 - **Prompt library**: @clack/prompts
 - **Architecture**: Preset Composition (composable presets merged into final project)
-- **Relationship**: Companion to [agentic-dev-template](https://github.com/ozzy-3/agentic-dev-template)
+- **Relationship**: Companion to [agentic-dev-template](https://github.com/ozzy-labs/agentic-dev-template)
 
 ## Wizard Selections
 

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
   },
   "license": "MIT",
   "author": "ozzy-labs",
-  "homepage": "https://github.com/ozzy-3/create-agentic-dev#readme",
-  "bugs": "https://github.com/ozzy-3/create-agentic-dev/issues",
+  "homepage": "https://github.com/ozzy-labs/create-agentic-dev#readme",
+  "bugs": "https://github.com/ozzy-labs/create-agentic-dev/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ozzy-3/create-agentic-dev.git"
+    "url": "https://github.com/ozzy-labs/create-agentic-dev.git"
   },
   "keywords": [
     "create",


### PR DESCRIPTION
## Summary

- Update README.md preset listing to include Vue, Nuxt, Batch, Cline, Cursor (20 → 24 presets)
- Fix `package.json` repository/homepage/bugs URLs from `ozzy-3` to `ozzy-labs`
- Fix `agentic-dev-template` links in README.md, CLAUDE.md, docs/design.md from `ozzy-3` to `ozzy-labs`