### PR TITLE
feat(renovate): migrate to shared org preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,22 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", "helpers:pinGitHubActionDigests"],
-  "minimumReleaseAge": "3 days",
-  "automergeType": "pr",
-  "packageRules": [
-    {
-      "matchUpdateTypes": ["patch", "minor"],
-      "automerge": true
-    },
-    {
-      "matchUpdateTypes": ["major"],
-      "automerge": false,
-      "dependencyDashboardApproval": true
-    },
-    {
-      "matchDepTypes": ["devDependencies"],
-      "groupName": "devDependencies (non-major)",
-      "matchUpdateTypes": ["patch", "minor"]
-    }
-  ]
+  "extends": ["github>ozzy-labs/.github", "helpers:pinGitHubActionDigests"]
 }


### PR DESCRIPTION
## Summary

- Renovate 設定を org 共有プリセット (`github>ozzy-labs/.github`) への参照に移行
- `helpers:pinGitHubActionDigests` はリポ固有の拡張として維持

Closes ozzy-labs/dev-config#34