### PR TITLE
test(preset): add cdk-nag integration tests

### DIFF
--- a/tests/presets/cdk.test.ts
+++ b/tests/presets/cdk.test.ts
@@ -82,6 +82,19 @@ describe("generate (cdk)", () => {
     expect(devDeps.vitest).toBe("^4.0.0");
   });
 
+  it("infra/bin/app.ts includes cdk-nag AwsSolutionsChecks", () => {
+    const appTs = result.readText("infra/bin/app.ts");
+    expect(appTs).toContain('import { AwsSolutionsChecks } from "cdk-nag"');
+    expect(appTs).toContain("AwsSolutionsChecks");
+    expect(appTs).toContain("Aspects.of(app).add");
+  });
+
+  it("infra/package.json includes cdk-nag dependency", () => {
+    const infraPkg = result.readJson("infra/package.json") as Record<string, unknown>;
+    const deps = infraPkg.dependencies as Record<string, string>;
+    expect(deps["cdk-nag"]).toBeDefined();
+  });
+
   it("infra/bin/app.ts does not import source-map-support", () => {
     const appTs = result.readText("infra/bin/app.ts");
     expect(appTs).not.toContain("source-map-support");


### PR DESCRIPTION
## Summary

- CDK preset の cdk-nag 統合に対するテストを追加
- `infra/bin/app.ts` に `AwsSolutionsChecks` が含まれることを検証
- `infra/package.json` に `cdk-nag` 依存関係が含まれることを検証

Closes #165