### PR TITLE
feat(preset): add Trivy security scanning

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -177,12 +177,14 @@ function postProcessPackageJson(pkgContent: string, presets: Preset[]): string {
       key.startsWith("lint:") &&
       key !== "lint:all" &&
       key !== "lint:fix" &&
-      key !== "lint:secrets"
+      key !== "lint:secrets" &&
+      key !== "lint:trivy"
     ) {
       lintParts.push(`pnpm run ${key}`);
     }
   }
   if (scripts["lint:secrets"]) lintParts.push("pnpm run lint:secrets");
+  if (scripts["lint:trivy"]) lintParts.push("pnpm run lint:trivy");
   if (lintParts.length > 0) {
     scripts["lint:all"] = lintParts.join(" && ");
   }

--- a/src/presets/base.ts
+++ b/src/presets/base.ts
@@ -23,6 +23,7 @@ export const basePreset: Preset = {
         "lint:docker": "hadolint --failure-threshold warning .devcontainer/Dockerfile",
         "lint:actions": "actionlint",
         "lint:secrets": "gitleaks detect --no-banner",
+        "lint:trivy": "trivy fs --scanners vuln --exit-code 1 .",
       },
       devDependencies: {
         "@commitlint/cli": "^20.0.0",
@@ -44,6 +45,7 @@ export const basePreset: Preset = {
         "github:reteps/dockerfmt": "0.3",
         hadolint: "2",
         actionlint: "1",
+        trivy: "0.62",
         gitleaks: "8",
         lefthook: "2",
       },
@@ -83,8 +85,26 @@ export const basePreset: Preset = {
     },
   },
   markdown: {
-    "agent-instructions": [],
-    "README.md": [],
+    "agent-instructions": [
+      {
+        placeholder: "<!-- SECTION:TECH_STACK_LINTING -->",
+        content: "  - Trivy (security scanning)",
+      },
+      {
+        placeholder: "<!-- SECTION:LINT_COMMANDS -->",
+        content: "pnpm run lint:trivy        # Trivy vulnerability scan (fs mode)",
+      },
+    ],
+    "README.md": [
+      {
+        placeholder: "<!-- SECTION:ROOT_FILES -->",
+        content: "├── trivy.yaml           # Trivy セキュリティスキャン設定",
+      },
+      {
+        placeholder: "<!-- SECTION:LINT_COMMANDS -->",
+        content: "| `pnpm run lint:trivy` | Trivy 脆弱性スキャン |",
+      },
+    ],
   },
   ciSteps: {
     setupSteps: [
@@ -115,6 +135,7 @@ export const basePreset: Preset = {
       },
       { name: "Lint (GitHub Actions)", run: "actionlint" },
       { name: "Security (Gitleaks)", run: "gitleaks detect --no-banner" },
+      { name: "Security (Trivy)", run: "trivy fs --scanners vuln --exit-code 1 ." },
     ],
   },
 };

--- a/src/presets/bicep.ts
+++ b/src/presets/bicep.ts
@@ -77,6 +77,7 @@ export const bicepPreset: Preset = {
         name: "Lint (Bicep)",
         run: "find infra -name '*.bicep' -print0 | xargs -0 -I{} az bicep build --file {} --stdout > /dev/null",
       },
+      { name: "Security (Trivy IaC)", run: "trivy config --exit-code 1 infra/" },
     ],
   },
 };

--- a/src/presets/cdk.ts
+++ b/src/presets/cdk.ts
@@ -166,7 +166,10 @@ export const cdkPreset: Preset = {
       { name: "Install infra dependencies", run: "cd infra && pnpm install --frozen-lockfile" },
       { name: "CDK synth", run: "cd infra && npx cdk synth" },
     ],
-    lintSteps: [{ name: "Lint (cfn-lint)", run: "cfn-lint" }],
+    lintSteps: [
+      { name: "Lint (cfn-lint)", run: "cfn-lint" },
+      { name: "Security (Trivy IaC)", run: "trivy config --exit-code 1 infra/cdk.out/" },
+    ],
     testSteps: [{ name: "Test (infra CDK)", run: "cd infra && pnpm test" }],
   },
   setupExtra: "cd infra && pnpm install",

--- a/src/presets/cloudformation.ts
+++ b/src/presets/cloudformation.ts
@@ -70,6 +70,9 @@ export const cloudformationPreset: Preset = {
     ],
   },
   ciSteps: {
-    lintSteps: [{ name: "Lint (cfn-lint)", run: "cfn-lint" }],
+    lintSteps: [
+      { name: "Lint (cfn-lint)", run: "cfn-lint" },
+      { name: "Security (Trivy IaC)", run: "trivy config --exit-code 1 infra/" },
+    ],
   },
 };

--- a/src/presets/terraform.ts
+++ b/src/presets/terraform.ts
@@ -74,6 +74,9 @@ export const terraformPreset: Preset = {
     ],
   },
   ciSteps: {
-    lintSteps: [{ name: "Lint (Terraform)", run: "terraform fmt -check -recursive && tflint" }],
+    lintSteps: [
+      { name: "Lint (Terraform)", run: "terraform fmt -check -recursive && tflint" },
+      { name: "Security (Trivy IaC)", run: "trivy config --exit-code 1 ." },
+    ],
   },
 };

--- a/templates/base/trivy.yaml
+++ b/templates/base/trivy.yaml
@@ -1,0 +1,3 @@
+severity:
+  - CRITICAL
+  - HIGH

--- a/tests/__snapshots__/generator.test.ts.snap
+++ b/tests/__snapshots__/generator.test.ts.snap
@@ -55,6 +55,7 @@ exports[`file list snapshots > azure + bicep 1`] = `
   "scripts/setup.sh",
   "src/index.ts",
   "tests/index.test.ts",
+  "trivy.yaml",
   "tsconfig.json",
 ]
 `;
@@ -108,6 +109,7 @@ exports[`file list snapshots > base only 1`] = `
   "scripts/apply-rulesets.sh",
   "scripts/configure-repo.sh",
   "scripts/setup.sh",
+  "trivy.yaml",
 ]
 `;
 
@@ -165,6 +167,7 @@ exports[`file list snapshots > batch 1`] = `
   "scripts/setup.sh",
   "src/index.ts",
   "tests/index.test.ts",
+  "trivy.yaml",
   "tsconfig.json",
   "worker/package.json",
   "worker/src/index.ts",
@@ -234,6 +237,7 @@ exports[`file list snapshots > cdk 1`] = `
   "scripts/setup.sh",
   "src/index.ts",
   "tests/index.test.ts",
+  "trivy.yaml",
   "tsconfig.json",
 ]
 `;
@@ -293,6 +297,7 @@ exports[`file list snapshots > cloudformation (ts) 1`] = `
   "scripts/setup.sh",
   "src/index.ts",
   "tests/index.test.ts",
+  "trivy.yaml",
   "tsconfig.json",
 ]
 `;
@@ -364,6 +369,7 @@ exports[`file list snapshots > express + cdk 1`] = `
   "scripts/setup.sh",
   "src/index.ts",
   "tests/index.test.ts",
+  "trivy.yaml",
   "tsconfig.json",
 ]
 `;
@@ -427,6 +433,7 @@ exports[`file list snapshots > express 1`] = `
   "scripts/setup.sh",
   "src/index.ts",
   "tests/index.test.ts",
+  "trivy.yaml",
   "tsconfig.json",
 ]
 `;
@@ -500,6 +507,7 @@ exports[`file list snapshots > fastapi + cdk 1`] = `
   "tests/__init__.py",
   "tests/index.test.ts",
   "tests/test_placeholder.py",
+  "trivy.yaml",
   "tsconfig.json",
   "uv.lock",
 ]
@@ -563,6 +571,7 @@ exports[`file list snapshots > fastapi 1`] = `
   "scripts/setup.sh",
   "tests/__init__.py",
   "tests/test_placeholder.py",
+  "trivy.yaml",
   "uv.lock",
 ]
 `;
@@ -629,6 +638,7 @@ exports[`file list snapshots > full config 1`] = `
   "scripts/setup.sh",
   "tests/__init__.py",
   "tests/test_placeholder.py",
+  "trivy.yaml",
   "tsconfig.json",
   "uv.lock",
   "web/index.html",
@@ -698,6 +708,7 @@ exports[`file list snapshots > gcp + terraform 1`] = `
   "scripts/setup.sh",
   "src/index.ts",
   "tests/index.test.ts",
+  "trivy.yaml",
   "tsconfig.json",
 ]
 `;
@@ -759,6 +770,7 @@ exports[`file list snapshots > nextjs + express 1`] = `
   "scripts/apply-rulesets.sh",
   "scripts/configure-repo.sh",
   "scripts/setup.sh",
+  "trivy.yaml",
   "tsconfig.json",
   "web/next.config.ts",
   "web/package.json",
@@ -830,6 +842,7 @@ exports[`file list snapshots > nextjs + fastapi 1`] = `
   "scripts/setup.sh",
   "tests/__init__.py",
   "tests/test_placeholder.py",
+  "trivy.yaml",
   "tsconfig.json",
   "uv.lock",
   "web/next.config.ts",
@@ -893,6 +906,7 @@ exports[`file list snapshots > nextjs 1`] = `
   "scripts/apply-rulesets.sh",
   "scripts/configure-repo.sh",
   "scripts/setup.sh",
+  "trivy.yaml",
   "tsconfig.json",
   "web/next.config.ts",
   "web/package.json",
@@ -956,6 +970,7 @@ exports[`file list snapshots > nuxt + batch 1`] = `
   "scripts/apply-rulesets.sh",
   "scripts/configure-repo.sh",
   "scripts/setup.sh",
+  "trivy.yaml",
   "tsconfig.json",
   "web/nuxt.config.ts",
   "web/package.json",
@@ -1022,6 +1037,7 @@ exports[`file list snapshots > nuxt 1`] = `
   "scripts/apply-rulesets.sh",
   "scripts/configure-repo.sh",
   "scripts/setup.sh",
+  "trivy.yaml",
   "tsconfig.json",
   "web/nuxt.config.ts",
   "web/package.json",
@@ -1087,6 +1103,7 @@ exports[`file list snapshots > python + cloudformation 1`] = `
   "scripts/setup.sh",
   "tests/__init__.py",
   "tests/test_placeholder.py",
+  "trivy.yaml",
   "uv.lock",
 ]
 `;
@@ -1146,6 +1163,7 @@ exports[`file list snapshots > python + terraform 1`] = `
   "scripts/setup.sh",
   "tests/__init__.py",
   "tests/test_placeholder.py",
+  "trivy.yaml",
   "uv.lock",
 ]
 `;
@@ -1202,6 +1220,7 @@ exports[`file list snapshots > python 1`] = `
   "scripts/setup.sh",
   "tests/__init__.py",
   "tests/test_placeholder.py",
+  "trivy.yaml",
   "uv.lock",
 ]
 `;
@@ -1258,6 +1277,7 @@ exports[`file list snapshots > react + batch 1`] = `
   "scripts/apply-rulesets.sh",
   "scripts/configure-repo.sh",
   "scripts/setup.sh",
+  "trivy.yaml",
   "tsconfig.json",
   "web/index.html",
   "web/package.json",
@@ -1333,6 +1353,7 @@ exports[`file list snapshots > react + express 1`] = `
   "scripts/apply-rulesets.sh",
   "scripts/configure-repo.sh",
   "scripts/setup.sh",
+  "trivy.yaml",
   "tsconfig.json",
   "web/index.html",
   "web/package.json",
@@ -1406,6 +1427,7 @@ exports[`file list snapshots > react + fastapi 1`] = `
   "scripts/setup.sh",
   "tests/__init__.py",
   "tests/test_placeholder.py",
+  "trivy.yaml",
   "tsconfig.json",
   "uv.lock",
   "web/index.html",
@@ -1471,6 +1493,7 @@ exports[`file list snapshots > react 1`] = `
   "scripts/apply-rulesets.sh",
   "scripts/configure-repo.sh",
   "scripts/setup.sh",
+  "trivy.yaml",
   "tsconfig.json",
   "web/index.html",
   "web/package.json",
@@ -1539,6 +1562,7 @@ exports[`file list snapshots > terraform (ts) 1`] = `
   "scripts/setup.sh",
   "src/index.ts",
   "tests/index.test.ts",
+  "trivy.yaml",
   "tsconfig.json",
 ]
 `;
@@ -1598,6 +1622,7 @@ exports[`file list snapshots > typescript + python 1`] = `
   "tests/__init__.py",
   "tests/index.test.ts",
   "tests/test_placeholder.py",
+  "trivy.yaml",
   "tsconfig.json",
   "uv.lock",
 ]
@@ -1655,6 +1680,7 @@ exports[`file list snapshots > typescript 1`] = `
   "scripts/setup.sh",
   "src/index.ts",
   "tests/index.test.ts",
+  "trivy.yaml",
   "tsconfig.json",
 ]
 `;
@@ -1719,6 +1745,7 @@ exports[`file list snapshots > vue + fastapi 1`] = `
   "scripts/setup.sh",
   "tests/__init__.py",
   "tests/test_placeholder.py",
+  "trivy.yaml",
   "tsconfig.json",
   "uv.lock",
   "web/env.d.ts",
@@ -1783,6 +1810,7 @@ exports[`file list snapshots > vue 1`] = `
   "scripts/apply-rulesets.sh",
   "scripts/configure-repo.sh",
   "scripts/setup.sh",
+  "trivy.yaml",
   "tsconfig.json",
   "web/env.d.ts",
   "web/index.html",

--- a/tests/presets/base.test.ts
+++ b/tests/presets/base.test.ts
@@ -47,6 +47,30 @@ describe("generate (base only)", () => {
     expect(commands.markdownlint).toBeDefined();
   });
 
+  it("includes trivy.yaml config file", () => {
+    expect(result.hasFile("trivy.yaml")).toBe(true);
+  });
+
+  it("merges trivy tool into .mise.toml", () => {
+    const toml = result.readToml(".mise.toml") as Record<string, Record<string, string>>;
+    expect(toml.tools.trivy).toBe("0.62");
+  });
+
+  it("merges lint:trivy script into package.json", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const scripts = pkg.scripts as Record<string, string>;
+    expect(scripts["lint:trivy"]).toContain("trivy fs");
+  });
+
+  it("includes lint:trivy at end of lint:all", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const scripts = pkg.scripts as Record<string, string>;
+    expect(scripts["lint:all"]).toContain("lint:trivy");
+    expect(scripts["lint:all"].indexOf("lint:secrets")).toBeLessThan(
+      scripts["lint:all"].indexOf("lint:trivy"),
+    );
+  });
+
   it("generates CI workflow", () => {
     expect(result.hasFile(".github/workflows/ci.yaml")).toBe(true);
     const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
@@ -57,6 +81,7 @@ describe("generate (base only)", () => {
     expect(stepNames).toContain("Install dependencies");
     expect(stepNames).toContain("Lint (Markdown)");
     expect(stepNames).toContain("Security (Gitleaks)");
+    expect(stepNames).toContain("Security (Trivy)");
   });
 
   it("generates setup.sh", () => {

--- a/tests/presets/bicep.test.ts
+++ b/tests/presets/bicep.test.ts
@@ -37,6 +37,14 @@ describe("generate (bicep)", () => {
     expect(stepNames).toContain("Lint (Bicep)");
   });
 
+  it("adds Trivy IaC CI step", () => {
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name);
+    expect(stepNames).toContain("Security (Trivy IaC)");
+  });
+
   it("expands CLAUDE.md with Bicep sections", () => {
     const claude = result.readText("CLAUDE.md");
     expect(claude).toContain("Bicep");

--- a/tests/presets/cdk.test.ts
+++ b/tests/presets/cdk.test.ts
@@ -44,6 +44,14 @@ describe("generate (cdk)", () => {
     expect(mcp.mcpServers.context7).toBeDefined();
   });
 
+  it("adds Trivy IaC CI step", () => {
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name);
+    expect(stepNames).toContain("Security (Trivy IaC)");
+  });
+
   it("adds CDK CI steps with correct order (synth before cfn-lint)", () => {
     const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
     const jobs = ci.jobs as Record<string, Record<string, unknown>>;

--- a/tests/presets/cloudformation.test.ts
+++ b/tests/presets/cloudformation.test.ts
@@ -35,6 +35,14 @@ describe("generate (cloudformation)", () => {
     expect(stepNames).toContain("Lint (cfn-lint)");
   });
 
+  it("adds Trivy IaC CI step", () => {
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name);
+    expect(stepNames).toContain("Security (Trivy IaC)");
+  });
+
   it("merges ~/.aws mount into devcontainer", () => {
     const dc = result.readJson(".devcontainer/devcontainer.json") as Record<string, unknown>;
     const mounts = dc.mounts as string[];

--- a/tests/presets/terraform.test.ts
+++ b/tests/presets/terraform.test.ts
@@ -31,6 +31,14 @@ describe("generate (terraform)", () => {
     expect(stepNames).toContain("Lint (Terraform)");
   });
 
+  it("adds Trivy IaC CI step", () => {
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name);
+    expect(stepNames).toContain("Security (Trivy IaC)");
+  });
+
   it("merges ~/.aws mount into devcontainer", () => {
     const dc = result.readJson(".devcontainer/devcontainer.json") as Record<string, unknown>;
     const mounts = dc.mounts as string[];


### PR DESCRIPTION
## Summary

- base preset に Trivy の依存関係スキャン（fs モード）を追加
- IaC preset（CDK, CloudFormation, Terraform, Bicep）に Trivy IaC スキャン CI ステップを追加
- `trivy.yaml` 設定ファイルテンプレートを追加
- `.mise.toml` に trivy ツールを追加
- `lint:trivy` スクリプトを `lint:all` の末尾に配置
- CI ワークフローに Security (Trivy) / Security (Trivy IaC) ステップを追加
- テスト追加・スナップショット更新

Closes #166