### PR TITLE
fix(preset): use unique Trivy IaC CI step names to avoid dedup conflict

### DIFF
--- a/src/presets/bicep.ts
+++ b/src/presets/bicep.ts
@@ -77,7 +77,7 @@ export const bicepPreset: Preset = {
         name: "Lint (Bicep)",
         run: "find infra -name '*.bicep' -print0 | xargs -0 -I{} az bicep build --file {} --stdout > /dev/null",
       },
-      { name: "Security (Trivy IaC)", run: "trivy config --exit-code 1 infra/" },
+      { name: "Security (Trivy IaC: Bicep)", run: "trivy config --exit-code 1 infra/" },
     ],
   },
 };

--- a/src/presets/cdk.ts
+++ b/src/presets/cdk.ts
@@ -168,7 +168,7 @@ export const cdkPreset: Preset = {
     ],
     lintSteps: [
       { name: "Lint (cfn-lint)", run: "cfn-lint" },
-      { name: "Security (Trivy IaC)", run: "trivy config --exit-code 1 infra/cdk.out/" },
+      { name: "Security (Trivy IaC: CDK)", run: "trivy config --exit-code 1 infra/cdk.out/" },
     ],
     testSteps: [{ name: "Test (infra CDK)", run: "cd infra && pnpm test" }],
   },

--- a/src/presets/cloudformation.ts
+++ b/src/presets/cloudformation.ts
@@ -72,7 +72,7 @@ export const cloudformationPreset: Preset = {
   ciSteps: {
     lintSteps: [
       { name: "Lint (cfn-lint)", run: "cfn-lint" },
-      { name: "Security (Trivy IaC)", run: "trivy config --exit-code 1 infra/" },
+      { name: "Security (Trivy IaC: CloudFormation)", run: "trivy config --exit-code 1 infra/" },
     ],
   },
 };

--- a/src/presets/terraform.ts
+++ b/src/presets/terraform.ts
@@ -76,7 +76,7 @@ export const terraformPreset: Preset = {
   ciSteps: {
     lintSteps: [
       { name: "Lint (Terraform)", run: "terraform fmt -check -recursive && tflint" },
-      { name: "Security (Trivy IaC)", run: "trivy config --exit-code 1 ." },
+      { name: "Security (Trivy IaC: Terraform)", run: "trivy config --exit-code 1 ." },
     ],
   },
 };

--- a/tests/presets/bicep.test.ts
+++ b/tests/presets/bicep.test.ts
@@ -42,7 +42,7 @@ describe("generate (bicep)", () => {
     const jobs = ci.jobs as Record<string, Record<string, unknown>>;
     const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
     const stepNames = steps.map((s) => s.name);
-    expect(stepNames).toContain("Security (Trivy IaC)");
+    expect(stepNames).toContain("Security (Trivy IaC: Bicep)");
   });
 
   it("expands CLAUDE.md with Bicep sections", () => {

--- a/tests/presets/cdk.test.ts
+++ b/tests/presets/cdk.test.ts
@@ -49,7 +49,7 @@ describe("generate (cdk)", () => {
     const jobs = ci.jobs as Record<string, Record<string, unknown>>;
     const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
     const stepNames = steps.map((s) => s.name);
-    expect(stepNames).toContain("Security (Trivy IaC)");
+    expect(stepNames).toContain("Security (Trivy IaC: CDK)");
   });
 
   it("adds CDK CI steps with correct order (synth before cfn-lint)", () => {

--- a/tests/presets/cloudformation.test.ts
+++ b/tests/presets/cloudformation.test.ts
@@ -40,7 +40,7 @@ describe("generate (cloudformation)", () => {
     const jobs = ci.jobs as Record<string, Record<string, unknown>>;
     const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
     const stepNames = steps.map((s) => s.name);
-    expect(stepNames).toContain("Security (Trivy IaC)");
+    expect(stepNames).toContain("Security (Trivy IaC: CloudFormation)");
   });
 
   it("merges ~/.aws mount into devcontainer", () => {

--- a/tests/presets/terraform.test.ts
+++ b/tests/presets/terraform.test.ts
@@ -36,7 +36,7 @@ describe("generate (terraform)", () => {
     const jobs = ci.jobs as Record<string, Record<string, unknown>>;
     const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
     const stepNames = steps.map((s) => s.name);
-    expect(stepNames).toContain("Security (Trivy IaC)");
+    expect(stepNames).toContain("Security (Trivy IaC: Terraform)");
   });
 
   it("merges ~/.aws mount into devcontainer", () => {


### PR DESCRIPTION
## Summary

- Trivy IaC CI ステップ名を IaC プリセットごとにユニーク化
- 複数 IaC 同時選択時に CI builder の dedup（last-wins）で一部スキャンが消失する問題を修正
- 例: Terraform + Bicep 選択時に Terraform のルート `.tf` ファイルがスキャンされない問題

変更: `"Security (Trivy IaC)"` → `"Security (Trivy IaC: CDK|CloudFormation|Terraform|Bicep)"`