### PR TITLE
chore: fix design doc wizard table and pin gcp gcloud version

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -16,8 +16,8 @@
 | # | Question | Type | Options |
 |---|----------|------|---------|
 | 1 | Project name | Text input | — |
-| 2 | Frontend app | Single-select | None / React + Vite / Next.js |
-| 3 | Backend app | Single-select | None / FastAPI / Express |
+| 2 | Frontend app | Single-select | None / React + Vite / Next.js / Vue + Vite / Nuxt |
+| 3 | Backend app | Single-select | None / FastAPI / Express / Batch |
 | 4 | Cloud providers | Multi-select | AWS / Azure / Google Cloud |
 | 5 | Infrastructure as Code | Multi-select | None / CDK / CloudFormation / Terraform / Bicep (filtered by selected cloud providers) |
 | 6 | Language toolchains (complement) | Multi-select | TypeScript / Python (auto-resolved languages are excluded) |

--- a/src/presets/gcp.ts
+++ b/src/presets/gcp.ts
@@ -6,7 +6,7 @@ export const gcpPreset: Preset = {
   merge: {
     ".mise.toml": {
       tools: {
-        gcloud: "latest",
+        gcloud: "2",
       },
     },
     ".devcontainer/devcontainer.json": {

--- a/tests/presets/gcp.test.ts
+++ b/tests/presets/gcp.test.ts
@@ -8,7 +8,7 @@ describe("generate (gcp)", () => {
 
   it("merges gcloud into .mise.toml", () => {
     const toml = result.readToml(".mise.toml") as Record<string, Record<string, string>>;
-    expect(toml.tools.gcloud).toBe("latest");
+    expect(toml.tools.gcloud).toBe("2");
   });
 
   it("merges google-cloud MCP server into .mcp.json", () => {


### PR DESCRIPTION
## Summary

- design.md のウィザード選択テーブルに不足していた Vue + Vite / Nuxt / Batch を追加
- GCP gcloud バージョンを `"latest"` から `"2"` に固定（AWS/Azure と同じメジャーバージョン固定方針に統一）