### PR TITLE
feat(preset): add SvelteKit and Astro frontend presets

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -16,7 +16,7 @@
 | # | Question | Type | Options |
 |---|----------|------|---------|
 | 1 | Project name | Text input | — |
-| 2 | Frontend app | Single-select | None / React + Vite / Next.js / Vue + Vite / Nuxt |
+| 2 | Frontend app | Single-select | None / React + Vite / Next.js / Vue + Vite / Nuxt / SvelteKit / Astro |
 | 3 | Backend app | Single-select | None / Hono / FastAPI / Express / Batch |
 | 4 | Cloud providers | Multi-select | AWS / Azure / Google Cloud |
 | 5 | Infrastructure as Code | Multi-select | None / CDK / CloudFormation / Terraform / Bicep (filtered by selected cloud providers) |
@@ -27,7 +27,7 @@ Language は FW 選択で自動解決された言語を除外して表示する�
 
 ## Presets
 
-25 presets, mapped 1:1 to wizard selections.
+27 presets, mapped 1:1 to wizard selections.
 
 | Preset | Trigger | Requires |
 |--------|---------|----------|
@@ -38,6 +38,8 @@ Language は FW 選択で自動解決された言語を除外して表示する�
 | `nextjs` | Frontend: Next.js | `typescript` (forced) |
 | `vue` | Frontend: Vue 3 + Vite | `typescript` (forced) |
 | `nuxt` | Frontend: Nuxt 3 | `typescript` (forced) |
+| `sveltekit` | Frontend: SvelteKit | `typescript` (forced) |
+| `astro` | Frontend: Astro | `typescript` (forced) |
 | `hono` | Backend: Hono | `typescript` (forced) |
 | `fastapi` | Backend: FastAPI | `python` (forced) |
 | `express` | Backend: Express | `typescript` (forced) |
@@ -62,7 +64,7 @@ Language は FW 選択で自動解決された言語を除外して表示する�
 | レイヤー | カテゴリ | 選択方式 | プリセット |
 |---------|---------|---------|-----------|
 | 0 | Base | 常に適用 | `base` |
-| 1 | Frontend | 単一選択（排他） | `react`, `nextjs`, `vue`, `nuxt` |
+| 1 | Frontend | 単一選択（排他） | `react`, `nextjs`, `vue`, `nuxt`, `sveltekit`, `astro` |
 | 2 | Backend | 単一選択（排他） | `hono`, `fastapi`, `express`, `batch` |
 | 3 | Cloud | 複数選択可 | `aws`, `azure`, `gcp` |
 | 4 | IaC | 複数選択可、Cloud に依存 | `cdk`, `cloudformation`, `terraform`, `bicep` |
@@ -78,7 +80,7 @@ Language は FW 選択で自動解決された言語を除外して表示する�
 
 **新プリセット追加時** は、いずれかのレイヤーに割り当てる。既存レイヤーに該当しない場合は、新レイヤーの追加とウィザードフローの更新を検討する。
 
-Application order: `base → typescript → python → react → nextjs → vue → nuxt → hono → fastapi → express → batch → aws → azure → gcp → cdk → cloudformation → terraform → bicep → claude-code → codex → gemini → amazon-q → copilot → cline → cursor`
+Application order: `base → typescript → python → react → nextjs → vue → nuxt → sveltekit → astro → hono → fastapi → express → batch → aws → azure → gcp → cdk → cloudformation → terraform → bicep → claude-code → codex → gemini → amazon-q → copilot → cline → cursor`
 
 ### Always Included (base)
 
@@ -195,6 +197,26 @@ Agent プリセットは `mcpServers` フィールドで MCP サーバーを定�
 **Next.js** — adds: Next.js + React dependencies, App Router scaffold, configuration in `web/`
 
 ### Backend Selection
+
+**SvelteKit** (forces TypeScript) — adds:
+
+| Element | Files |
+|---------|-------|
+| SvelteKit config | `web/svelte.config.js` |
+| Vite config | `web/vite.config.ts` |
+| App HTML template | `web/src/app.html` |
+| Page component | `web/src/routes/+page.svelte` |
+| Lib index | `web/src/lib/index.ts` |
+| Package (web) | `web/package.json` |
+
+**Astro** (forces TypeScript) — adds:
+
+| Element | Files |
+|---------|-------|
+| Astro config | `web/astro.config.ts` |
+| Index page | `web/src/pages/index.astro` |
+| Layout | `web/src/layouts/Layout.astro` |
+| Package (web) | `web/package.json` |
 
 **FastAPI** (forces Python) — adds:
 
@@ -373,6 +395,8 @@ interface Preset {
 ```text
 React ──────→ TypeScript (forced)
 Next.js ────→ TypeScript (forced)
+SvelteKit ──→ TypeScript (forced)
+Astro ──────→ TypeScript (forced)
 FastAPI ────→ Python (forced)
 Hono ───────→ TypeScript (forced)
 Express ────→ TypeScript (forced)
@@ -405,7 +429,7 @@ GCP ────────→ gcloud CLI
 
 | 要素 | レイヤー | 備考 |
 |-----|---------|------|
-| Remix | 1 (Frontend) | React メタフレームワーク。必要になったら追加 |
+| Remix | 1 (Frontend) | React Router v7 との統合が進んでおり、差別化を確認してから追加 |
 
 ## Adding a New Preset
 
@@ -641,15 +665,17 @@ npm create @ozzylabs/agentic-dev [my-app]
 | 4 | TS + Python | — | — | — | — | Both languages |
 | 5 | (auto) | React | — | — | — | Frontend SPA |
 | 6 | (auto) | Next.js | — | — | — | Frontend SSR |
-| 7 | (auto) | — | FastAPI | — | — | Backend (Python) |
-| 8 | (auto) | — | Hono | — | — | Backend (Hono) |
-| 9 | (auto) | — | Express | — | — | Backend (TS) |
-| 10 | (auto) | — | — | AWS | CDK | IaC (CDK) |
-| 11 | Python | — | — | — | CFn | IaC (CFn) |
-| 12 | — | — | — | — | Terraform | IaC (multi-cloud) |
-| 13 | — | — | — | Azure | Bicep | IaC (Bicep) |
-| 14 | (auto) | React | FastAPI | AWS | CDK | Full config (monorepo) |
-| 15 | (auto) | React | Express | AWS | CDK | Full config (all TS workspace) |
+| 7 | (auto) | SvelteKit | — | — | — | Frontend (SvelteKit) |
+| 8 | (auto) | Astro | — | — | — | Frontend (Astro) |
+| 9 | (auto) | — | FastAPI | — | — | Backend (Python) |
+| 10 | (auto) | — | Hono | — | — | Backend (Hono) |
+| 11 | (auto) | — | Express | — | — | Backend (TS) |
+| 12 | (auto) | — | — | AWS | CDK | IaC (CDK) |
+| 13 | Python | — | — | — | CFn | IaC (CFn) |
+| 14 | — | — | — | — | Terraform | IaC (multi-cloud) |
+| 15 | — | — | — | Azure | Bicep | IaC (Bicep) |
+| 16 | (auto) | React | FastAPI | AWS | CDK | Full config (monorepo) |
+| 17 | (auto) | React | Express | AWS | CDK | Full config (all TS workspace) |
 
 ### Verification per pattern
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,6 +58,8 @@ function resolvedLanguages(
   if (frontend === "nextjs") add("typescript", t("wizard.frontend.nextjs.label"));
   if (frontend === "vue") add("typescript", t("wizard.frontend.vue.label"));
   if (frontend === "nuxt") add("typescript", t("wizard.frontend.nuxt.label"));
+  if (frontend === "sveltekit") add("typescript", t("wizard.frontend.sveltekit.label"));
+  if (frontend === "astro") add("typescript", t("wizard.frontend.astro.label"));
   // Backend frameworks force their language
   if (backend === "fastapi") add("python", t("wizard.backend.fastapi.label"));
   if (backend === "hono") add("typescript", t("wizard.backend.hono.label"));
@@ -109,6 +111,16 @@ export async function runWizard(defaultName?: string): Promise<WizardAnswers> {
               value: "nuxt" as const,
               label: t("wizard.frontend.nuxt.label"),
               hint: t("wizard.frontend.nuxt.hint"),
+            },
+            {
+              value: "sveltekit" as const,
+              label: t("wizard.frontend.sveltekit.label"),
+              hint: t("wizard.frontend.sveltekit.hint"),
+            },
+            {
+              value: "astro" as const,
+              label: t("wizard.frontend.astro.label"),
+              hint: t("wizard.frontend.astro.hint"),
             },
           ],
         }),

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -22,7 +22,9 @@
       "react": { "label": "React + Vite", "hint": "forces TypeScript" },
       "nextjs": { "label": "Next.js", "hint": "forces TypeScript" },
       "vue": { "label": "Vue + Vite", "hint": "forces TypeScript" },
-      "nuxt": { "label": "Nuxt", "hint": "forces TypeScript" }
+      "nuxt": { "label": "Nuxt", "hint": "forces TypeScript" },
+      "sveltekit": { "label": "SvelteKit", "hint": "forces TypeScript" },
+      "astro": { "label": "Astro", "hint": "forces TypeScript" }
     },
     "backend": {
       "message": "Backend app",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -22,7 +22,9 @@
       "react": { "label": "React + Vite", "hint": "TypeScript が強制されます" },
       "nextjs": { "label": "Next.js", "hint": "TypeScript が強制されます" },
       "vue": { "label": "Vue + Vite", "hint": "TypeScript が強制されます" },
-      "nuxt": { "label": "Nuxt", "hint": "TypeScript が強制されます" }
+      "nuxt": { "label": "Nuxt", "hint": "TypeScript が強制されます" },
+      "sveltekit": { "label": "SvelteKit", "hint": "TypeScript が強制されます" },
+      "astro": { "label": "Astro", "hint": "TypeScript が強制されます" }
     },
     "backend": {
       "message": "バックエンドアプリ",

--- a/src/presets/astro.ts
+++ b/src/presets/astro.ts
@@ -1,0 +1,62 @@
+import type { Preset } from "../types.js";
+import { readTemplateFiles } from "../utils.js";
+
+export const astroPreset: Preset = {
+  name: "astro",
+  requires: ["typescript"],
+  files: readTemplateFiles("astro"),
+  merge: {
+    "package.json": {
+      scripts: {
+        dev: "pnpm --filter web dev",
+        build: "pnpm run build:web",
+        "build:web": "pnpm --filter web build",
+        preview: "pnpm --filter web preview",
+      },
+    },
+  },
+  markdown: {
+    "agent-instructions": [
+      {
+        placeholder: "<!-- SECTION:TECH_STACK -->",
+        content: "- **Frontend**: Astro",
+      },
+      {
+        placeholder: "<!-- SECTION:PROJECT_STRUCTURE -->",
+        content: "web/          -> Frontend (Astro)",
+      },
+      {
+        placeholder: "<!-- SECTION:SETUP_COMMANDS -->",
+        content: "pnpm --filter web install # Install frontend dependencies",
+      },
+      {
+        placeholder: "<!-- SECTION:TEST_COMMANDS -->",
+        content: "pnpm --filter web test     # Run frontend tests",
+      },
+      {
+        placeholder: "<!-- SECTION:CODING_CONVENTIONS -->",
+        content:
+          "- Astro: file-based routing in `src/pages/`, layouts in `src/layouts/`, co-located tests in `web/tests/`",
+      },
+    ],
+    "README.md": [
+      {
+        placeholder: "<!-- SECTION:DIR_STRUCTURE -->",
+        content: "├── web/                 # フロントエンド (Astro)",
+      },
+      {
+        placeholder: "<!-- SECTION:ROOT_FILES -->",
+        content: "├── web/package.json     # フロントエンド依存・スクリプト",
+      },
+      {
+        placeholder: "<!-- SECTION:SETUP_COMMANDS -->",
+        content: "| `pnpm --filter web install` | フロントエンド依存パッケージインストール |",
+      },
+      {
+        placeholder: "<!-- SECTION:DEV_COMMANDS -->",
+        content:
+          "| `pnpm run build:web` | フロントエンドビルド |\n| `pnpm run dev` | Astro 開発サーバー起動 |",
+      },
+    ],
+  },
+};

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -1,5 +1,6 @@
 import type { Preset } from "../types.js";
 import { amazonQPreset } from "./amazon-q.js";
+import { astroPreset } from "./astro.js";
 import { awsPreset } from "./aws.js";
 import { azurePreset } from "./azure.js";
 import { basePreset } from "./base.js";
@@ -21,6 +22,7 @@ import { nextjsPreset } from "./nextjs.js";
 import { nuxtPreset } from "./nuxt.js";
 import { pythonPreset } from "./python.js";
 import { reactPreset } from "./react.js";
+import { sveltekitPreset } from "./sveltekit.js";
 import { terraformPreset } from "./terraform.js";
 import { typescriptPreset } from "./typescript.js";
 import { vuePreset } from "./vue.js";
@@ -37,6 +39,8 @@ const PRESET_ENTRIES: ReadonlyArray<readonly [string, Preset]> = [
   ["nextjs", nextjsPreset],
   ["vue", vuePreset],
   ["nuxt", nuxtPreset],
+  ["sveltekit", sveltekitPreset],
+  ["astro", astroPreset],
   ["hono", honoPreset],
   ["fastapi", fastapiPreset],
   ["express", expressPreset],

--- a/src/presets/sveltekit.ts
+++ b/src/presets/sveltekit.ts
@@ -1,0 +1,70 @@
+import type { Preset } from "../types.js";
+import { readTemplateFiles } from "../utils.js";
+
+export const sveltekitPreset: Preset = {
+  name: "sveltekit",
+  requires: ["typescript"],
+  files: readTemplateFiles("sveltekit"),
+  merge: {
+    ".gitignore": "# SvelteKit\n.svelte-kit/",
+    "biome.json": {
+      files: { includes: ["!**/.svelte-kit/"] },
+    },
+    ".vscode/settings.json": {
+      "search.exclude": { "**/.svelte-kit": true },
+      "files.exclude": { "**/.svelte-kit": true },
+    },
+    "package.json": {
+      scripts: {
+        dev: "pnpm --filter web dev",
+        build: "pnpm run build:web",
+        "build:web": "pnpm --filter web build",
+        preview: "pnpm --filter web preview",
+      },
+    },
+  },
+  markdown: {
+    "agent-instructions": [
+      {
+        placeholder: "<!-- SECTION:TECH_STACK -->",
+        content: "- **Frontend**: SvelteKit (Svelte 5)",
+      },
+      {
+        placeholder: "<!-- SECTION:PROJECT_STRUCTURE -->",
+        content: "web/          -> Frontend (SvelteKit)",
+      },
+      {
+        placeholder: "<!-- SECTION:SETUP_COMMANDS -->",
+        content: "pnpm --filter web install # Install frontend dependencies",
+      },
+      {
+        placeholder: "<!-- SECTION:TEST_COMMANDS -->",
+        content: "pnpm --filter web test     # Run frontend tests",
+      },
+      {
+        placeholder: "<!-- SECTION:CODING_CONVENTIONS -->",
+        content:
+          "- SvelteKit: file-based routing in `src/routes/`, shared logic in `src/lib/`, co-located tests in `web/tests/`",
+      },
+    ],
+    "README.md": [
+      {
+        placeholder: "<!-- SECTION:DIR_STRUCTURE -->",
+        content: "├── web/                 # フロントエンド (SvelteKit)",
+      },
+      {
+        placeholder: "<!-- SECTION:ROOT_FILES -->",
+        content: "├── web/package.json     # フロントエンド依存・スクリプト",
+      },
+      {
+        placeholder: "<!-- SECTION:SETUP_COMMANDS -->",
+        content: "| `pnpm --filter web install` | フロントエンド依存パッケージインストール |",
+      },
+      {
+        placeholder: "<!-- SECTION:DEV_COMMANDS -->",
+        content:
+          "| `pnpm run build:web` | フロントエンドビルド |\n| `pnpm run dev` | SvelteKit 開発サーバー起動 |",
+      },
+    ],
+  },
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@
 
 export interface WizardAnswers {
   projectName: string;
-  frontend: "none" | "react" | "nextjs" | "vue" | "nuxt";
+  frontend: "none" | "react" | "nextjs" | "vue" | "nuxt" | "sveltekit" | "astro";
   backend: "none" | "hono" | "fastapi" | "express" | "batch";
   clouds: Array<"aws" | "azure" | "gcp">;
   iac: Array<"cdk" | "cloudformation" | "terraform" | "bicep">;

--- a/templates/astro/tsconfig.json
+++ b/templates/astro/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true
+  },
+  "include": ["web/src", "web/tests"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/templates/astro/web/astro.config.ts
+++ b/templates/astro/web/astro.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "astro/config";
+
+export default defineConfig({
+  srcDir: "./src",
+});

--- a/templates/astro/web/package.json
+++ b/templates/astro/web/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "{{projectName}}-web",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview"
+  },
+  "dependencies": {
+    "astro": "^5.0.0"
+  }
+}

--- a/templates/astro/web/src/index.ts
+++ b/templates/astro/web/src/index.ts
@@ -1,0 +1,1 @@
+export const siteName = "{{projectName}}";

--- a/templates/astro/web/src/layouts/Layout.astro
+++ b/templates/astro/web/src/layouts/Layout.astro
@@ -1,0 +1,19 @@
+---
+interface Props {
+  title: string;
+}
+
+const { title } = Astro.props;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{title}</title>
+  </head>
+  <body>
+    <slot />
+  </body>
+</html>

--- a/templates/astro/web/src/pages/index.astro
+++ b/templates/astro/web/src/pages/index.astro
@@ -1,0 +1,8 @@
+---
+import Layout from "../layouts/Layout.astro";
+---
+
+<Layout title="{{projectName}}">
+  <h1>Welcome to {{projectName}}</h1>
+  <p>Visit <a href="https://docs.astro.build">docs.astro.build</a> to get started.</p>
+</Layout>

--- a/templates/astro/web/tests/index.test.ts
+++ b/templates/astro/web/tests/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { siteName } from "../src/index.js";
+
+describe("siteName", () => {
+  it("is defined", () => {
+    expect(siteName).toBeDefined();
+  });
+});

--- a/templates/sveltekit/tsconfig.json
+++ b/templates/sveltekit/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2024",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true
+  },
+  "include": ["web/src", "web/tests"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/templates/sveltekit/web/package.json
+++ b/templates/sveltekit/web/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "{{projectName}}-web",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@sveltejs/kit": "^2.0.0",
+    "svelte": "^5.0.0"
+  },
+  "devDependencies": {
+    "@sveltejs/adapter-auto": "^6.0.0",
+    "@sveltejs/vite-plugin-svelte": "^5.0.0",
+    "vite": "^6.0.0"
+  }
+}

--- a/templates/sveltekit/web/src/app.html
+++ b/templates/sveltekit/web/src/app.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>{{projectName}}</title>
+    %sveltekit.head%
+  </head>
+  <body>
+    <div>%sveltekit.body%</div>
+  </body>
+</html>

--- a/templates/sveltekit/web/src/index.ts
+++ b/templates/sveltekit/web/src/index.ts
@@ -1,0 +1,1 @@
+export { default as Page } from "./routes/+page.svelte";

--- a/templates/sveltekit/web/src/lib/index.ts
+++ b/templates/sveltekit/web/src/lib/index.ts
@@ -1,0 +1,1 @@
+// place files you want to import through the `$lib` alias in this folder.

--- a/templates/sveltekit/web/src/routes/+page.svelte
+++ b/templates/sveltekit/web/src/routes/+page.svelte
@@ -1,0 +1,2 @@
+<h1>Welcome to {{projectName}}</h1>
+<p>Visit <a href="https://svelte.dev/docs/kit">svelte.dev/docs/kit</a> to get started.</p>

--- a/templates/sveltekit/web/svelte.config.js
+++ b/templates/sveltekit/web/svelte.config.js
@@ -1,0 +1,12 @@
+import adapter from "@sveltejs/adapter-auto";
+import { vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  preprocess: vitePreprocess(),
+  kit: {
+    adapter: adapter(),
+  },
+};
+
+export default config;

--- a/templates/sveltekit/web/tests/index.test.ts
+++ b/templates/sveltekit/web/tests/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from "vitest";
+import { Page } from "../src/index.js";
+
+describe("Page", () => {
+  it("is defined", () => {
+    expect(Page).toBeDefined();
+  });
+});

--- a/templates/sveltekit/web/vite.config.ts
+++ b/templates/sveltekit/web/vite.config.ts
@@ -1,0 +1,6 @@
+import { sveltekit } from "@sveltejs/kit/vite";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [sveltekit()],
+});

--- a/tests/presets/astro.test.ts
+++ b/tests/presets/astro.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+import { generate } from "../../src/generator.js";
+import { makeAnswers } from "../helpers.js";
+
+describe("generate (astro)", () => {
+  const answers = makeAnswers({ frontend: "astro" });
+  const result = generate(answers);
+
+  it("forces TypeScript preset inclusion", () => {
+    expect(result.hasFile("biome.json")).toBe(true);
+    expect(result.hasFile("tsconfig.json")).toBe(true);
+  });
+
+  it("includes Astro owned files in web/", () => {
+    expect(result.hasFile("web/astro.config.ts")).toBe(true);
+    expect(result.hasFile("web/src/pages/index.astro")).toBe(true);
+    expect(result.hasFile("web/src/layouts/Layout.astro")).toBe(true);
+    expect(result.hasFile("web/package.json")).toBe(true);
+  });
+
+  it("removes TypeScript sample files (replaced by web/)", () => {
+    expect(result.hasFile("src/index.ts")).toBe(false);
+    expect(result.hasFile("tests/index.test.ts")).toBe(false);
+  });
+
+  it("has Astro dependencies in web/package.json", () => {
+    const pkg = result.readJson("web/package.json") as Record<string, unknown>;
+    const deps = pkg.dependencies as Record<string, string>;
+    expect(deps.astro).toBeDefined();
+  });
+
+  it("root package.json has orchestration scripts", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const scripts = pkg.scripts as Record<string, string>;
+    expect(scripts.build).toBe("pnpm run build:web");
+    expect(scripts["build:web"]).toBe("pnpm --filter web build");
+    expect(scripts.dev).toBe("pnpm --filter web dev");
+    expect(scripts.preview).toBe("pnpm --filter web preview");
+  });
+
+  it("generates pnpm-workspace.yaml with web", () => {
+    expect(result.hasFile("pnpm-workspace.yaml")).toBe(true);
+    const workspace = result.readText("pnpm-workspace.yaml");
+    expect(workspace).toContain("- web");
+  });
+
+  it("expands CLAUDE.md with Astro sections", () => {
+    const claude = result.readText("CLAUDE.md");
+    expect(claude).toContain("Astro");
+    expect(claude).not.toContain("<!-- SECTION:");
+  });
+
+  it("replaces {{projectName}} in templates", () => {
+    const page = result.readText("web/src/pages/index.astro");
+    expect(page).toContain("test-app");
+    expect(page).not.toContain("{{projectName}}");
+  });
+});

--- a/tests/presets/sveltekit.test.ts
+++ b/tests/presets/sveltekit.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { generate } from "../../src/generator.js";
+import { makeAnswers } from "../helpers.js";
+
+describe("generate (sveltekit)", () => {
+  const answers = makeAnswers({ frontend: "sveltekit" });
+  const result = generate(answers);
+
+  it("forces TypeScript preset inclusion", () => {
+    expect(result.hasFile("biome.json")).toBe(true);
+    expect(result.hasFile("tsconfig.json")).toBe(true);
+  });
+
+  it("includes SvelteKit owned files in web/", () => {
+    expect(result.hasFile("web/svelte.config.js")).toBe(true);
+    expect(result.hasFile("web/vite.config.ts")).toBe(true);
+    expect(result.hasFile("web/src/app.html")).toBe(true);
+    expect(result.hasFile("web/src/routes/+page.svelte")).toBe(true);
+    expect(result.hasFile("web/src/lib/index.ts")).toBe(true);
+    expect(result.hasFile("web/package.json")).toBe(true);
+  });
+
+  it("removes TypeScript sample files (replaced by web/)", () => {
+    expect(result.hasFile("src/index.ts")).toBe(false);
+    expect(result.hasFile("tests/index.test.ts")).toBe(false);
+  });
+
+  it("has SvelteKit dependencies in web/package.json", () => {
+    const pkg = result.readJson("web/package.json") as Record<string, unknown>;
+    const deps = pkg.dependencies as Record<string, string>;
+    expect(deps.svelte).toBeDefined();
+    expect(deps["@sveltejs/kit"]).toBeDefined();
+    const devDeps = pkg.devDependencies as Record<string, string>;
+    expect(devDeps.vite).toBeDefined();
+  });
+
+  it("root package.json has orchestration scripts", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const scripts = pkg.scripts as Record<string, string>;
+    expect(scripts.build).toBe("pnpm run build:web");
+    expect(scripts["build:web"]).toBe("pnpm --filter web build");
+    expect(scripts.dev).toBe("pnpm --filter web dev");
+    expect(scripts.preview).toBe("pnpm --filter web preview");
+  });
+
+  it("adds .svelte-kit/ to .gitignore", () => {
+    const gitignore = result.readText(".gitignore");
+    expect(gitignore).toContain(".svelte-kit/");
+  });
+
+  it("excludes .svelte-kit/ from biome.json", () => {
+    const biome = result.readJson("biome.json") as Record<string, unknown>;
+    const files = biome.files as Record<string, string[]>;
+    expect(files.includes).toContain("!**/.svelte-kit/");
+  });
+
+  it("generates pnpm-workspace.yaml with web", () => {
+    expect(result.hasFile("pnpm-workspace.yaml")).toBe(true);
+    const workspace = result.readText("pnpm-workspace.yaml");
+    expect(workspace).toContain("- web");
+  });
+
+  it("expands CLAUDE.md with SvelteKit sections", () => {
+    const claude = result.readText("CLAUDE.md");
+    expect(claude).toContain("SvelteKit");
+    expect(claude).not.toContain("<!-- SECTION:");
+  });
+
+  it("replaces {{projectName}} in templates", () => {
+    const appHtml = result.readText("web/src/app.html");
+    expect(appHtml).toContain("test-app");
+    expect(appHtml).not.toContain("{{projectName}}");
+  });
+});

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -482,6 +482,66 @@ const patterns: PatternDef[] = [
     },
   },
   {
+    name: "sveltekit",
+    answers: { frontend: "sveltekit" },
+    vscodeSettings: {
+      mustInclude: ["biomejs.biome", "source.fixAll.biome", "**/dist"],
+      mustExclude: ["charliermarsh.ruff", "mypy-type-checker", "cdk.out"],
+    },
+    vscodeExtensions: {
+      mustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
+      mustExclude: [
+        "charliermarsh.ruff",
+        "amazonwebservices.aws-toolkit-vscode",
+        "ms-azuretools.vscode-bicep",
+      ],
+    },
+    devcontainer: {
+      extensionsMustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
+      extensionsMustExclude: [
+        "charliermarsh.ruff",
+        "amazonwebservices.aws-toolkit-vscode",
+        "ms-azuretools.vscode-bicep",
+      ],
+      mountsMustInclude: ["pnpm-store"],
+      mountsMustExclude: [".aws", ".azure", ".config/gcloud", "uv-cache"],
+    },
+    packageJson: {
+      scriptsMustInclude: ["lint", "typecheck", "test", "build", "build:web"],
+      scriptsMustExclude: ["lint:python", "lint:mypy", "lint:cfn", "lint:tf", "lint:bicep"],
+    },
+  },
+  {
+    name: "astro",
+    answers: { frontend: "astro" },
+    vscodeSettings: {
+      mustInclude: ["biomejs.biome", "source.fixAll.biome", "**/dist"],
+      mustExclude: ["charliermarsh.ruff", "mypy-type-checker", "cdk.out"],
+    },
+    vscodeExtensions: {
+      mustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
+      mustExclude: [
+        "charliermarsh.ruff",
+        "amazonwebservices.aws-toolkit-vscode",
+        "ms-azuretools.vscode-bicep",
+      ],
+    },
+    devcontainer: {
+      extensionsMustInclude: [...COMMON_EXTENSIONS, "biomejs.biome"],
+      extensionsMustExclude: [
+        "charliermarsh.ruff",
+        "amazonwebservices.aws-toolkit-vscode",
+        "ms-azuretools.vscode-bicep",
+      ],
+      mountsMustInclude: ["pnpm-store"],
+      mountsMustExclude: [".aws", ".azure", ".config/gcloud", "uv-cache"],
+    },
+    packageJson: {
+      scriptsMustInclude: ["lint", "typecheck", "test", "build", "build:web"],
+      scriptsMustExclude: ["lint:python", "lint:mypy", "lint:cfn", "lint:tf", "lint:bicep"],
+    },
+  },
+  {
     name: "fastapi",
     answers: { backend: "fastapi" },
     vscodeSettings: {


### PR DESCRIPTION
## Summary

- Add SvelteKit frontend preset with Svelte 5 / Vite scaffold in web/
- Add Astro frontend preset with content-first SSG/SSR scaffold in web/
- Both follow existing frontend preset composition pattern (TypeScript forced, pnpm workspace, orchestration scripts)
- Includes template files, preset definitions, i18n, wizard options, and comprehensive tests (unit, smoke)

Closes #180