### PR TITLE
feat: add --apply mode for agent setup on existing projects

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,7 +1,7 @@
 import * as p from "@clack/prompts";
 import pc from "picocolors";
 import { t } from "./i18n/index.js";
-import type { WizardAnswers } from "./types.js";
+import type { ApplyAnswers, WizardAnswers } from "./types.js";
 
 /** Build IaC options filtered by selected cloud providers. */
 function buildIacOptions(clouds: Array<"aws" | "azure" | "gcp">): Array<{
@@ -269,5 +269,77 @@ export async function runWizard(defaultName?: string): Promise<WizardAnswers> {
     iac: (answers.iac ?? []) as WizardAnswers["iac"],
     languages: (answers.languages ?? []) as WizardAnswers["languages"],
     agents: (answers.agents ?? []) as WizardAnswers["agents"],
+  };
+}
+
+export async function runApplyWizard(): Promise<ApplyAnswers> {
+  p.intro(pc.bold(t("apply.intro")));
+
+  const answers = await p.group(
+    {
+      clouds: () =>
+        p.multiselect({
+          message: `${t("wizard.clouds.message")} ${pc.dim(t("apply.cloudsHint"))}`,
+          options: [
+            { value: "aws" as const, label: t("wizard.clouds.aws.label") },
+            { value: "azure" as const, label: t("wizard.clouds.azure.label") },
+            { value: "gcp" as const, label: t("wizard.clouds.gcp.label") },
+          ],
+          required: false,
+        }),
+      agents: () =>
+        p.multiselect({
+          message: `${t("wizard.agents.message")} ${pc.dim(t("wizard.agents.hint"))}`,
+          options: [
+            {
+              value: "claude-code" as const,
+              label: t("wizard.agents.claude-code.label"),
+              hint: t("wizard.agents.claude-code.hint"),
+            },
+            {
+              value: "codex" as const,
+              label: t("wizard.agents.codex.label"),
+              hint: t("wizard.agents.codex.hint"),
+            },
+            {
+              value: "gemini" as const,
+              label: t("wizard.agents.gemini.label"),
+              hint: t("wizard.agents.gemini.hint"),
+            },
+            {
+              value: "amazon-q" as const,
+              label: t("wizard.agents.amazon-q.label"),
+              hint: t("wizard.agents.amazon-q.hint"),
+            },
+            {
+              value: "copilot" as const,
+              label: t("wizard.agents.copilot.label"),
+              hint: t("wizard.agents.copilot.hint"),
+            },
+            {
+              value: "cline" as const,
+              label: t("wizard.agents.cline.label"),
+              hint: t("wizard.agents.cline.hint"),
+            },
+            {
+              value: "cursor" as const,
+              label: t("wizard.agents.cursor.label"),
+              hint: t("wizard.agents.cursor.hint"),
+            },
+          ],
+          required: false,
+        }),
+    },
+    {
+      onCancel: () => {
+        p.cancel(t("cancel"));
+        process.exit(0);
+      },
+    },
+  );
+
+  return {
+    clouds: (answers.clouds ?? []) as ApplyAnswers["clouds"],
+    agents: (answers.agents ?? []) as ApplyAnswers["agents"],
   };
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,9 +1,11 @@
+import path from "node:path";
 import { ACTIONS } from "./action-versions.js";
 import { buildCiWorkflow } from "./ci.js";
 import { expandMarkdown, formatMcpJson, formatMcpToml, mergeFile } from "./merge.js";
 import { ALL_PRESETS, PRESET_ORDER } from "./presets/index.js";
 import { expandSetupScript } from "./setup.js";
 import type {
+  ApplyAnswers,
   FileWriter,
   GenerateResult,
   MarkdownSection,
@@ -618,4 +620,53 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
   }
 
   return buildResult(allFiles);
+}
+
+/** File path prefixes/patterns that are agent-related output for --apply mode. */
+const APPLY_FILE_PATTERNS = [
+  "CLAUDE.md",
+  "AGENTS.md",
+  "GEMINI.md",
+  ".claude/",
+  ".amazonq/",
+  ".github/copilot-instructions.md",
+  ".clinerules/",
+  ".cursor/",
+  ".mcp.json",
+];
+
+/** Check if a file path matches agent-related output. */
+function isApplyFile(filePath: string): boolean {
+  return APPLY_FILE_PATTERNS.some(
+    (pattern) => filePath === pattern || filePath.startsWith(pattern),
+  );
+}
+
+/**
+ * Generate agent-related files only (for --apply mode).
+ * Uses the full generator internally, then filters to agent output.
+ */
+export function generateApply(answers: ApplyAnswers): GenerateResult {
+  // Build full WizardAnswers with agent + cloud selections only
+  const fullAnswers: WizardAnswers = {
+    projectName: path.basename(process.cwd()),
+    frontend: "none",
+    backend: "none",
+    clouds: answers.clouds,
+    iac: [],
+    languages: [],
+    agents: answers.agents,
+  };
+
+  const result = generate(fullAnswers);
+
+  // Filter to agent-related files only
+  const filteredFiles = new Map<string, string>();
+  for (const file of result.fileList()) {
+    if (isApplyFile(file)) {
+      filteredFiles.set(file, result.readText(file));
+    }
+  }
+
+  return buildResult(filteredFiles);
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -85,5 +85,12 @@
     "pnpmInstallFailed": "pnpm install failed (skipped)",
     "manualHint": "Run manually: cd {{path}} && pnpm install"
   },
-  "outro": "Done! Happy coding."
+  "outro": "Done! Happy coding.",
+  "apply": {
+    "intro": "create-agentic-dev --apply",
+    "cloudsHint": "Used for MCP server distribution",
+    "noFiles": "No files to generate. Please select at least one agent.",
+    "start": "Generating agent configuration...",
+    "stop": "Generated {{count}} files"
+  }
 }

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -85,5 +85,12 @@
     "pnpmInstallFailed": "pnpm install に失敗しました（スキップ）",
     "manualHint": "手動で実行してください: cd {{path}} && pnpm install"
   },
-  "outro": "完了！Happy coding."
+  "outro": "完了！Happy coding.",
+  "apply": {
+    "intro": "create-agentic-dev --apply",
+    "cloudsHint": "MCP サーバー配布に使用",
+    "noFiles": "生成するファイルがありません。エージェントを1つ以上選択してください。",
+    "start": "エージェント設定を生成中...",
+    "stop": "{{count}} ファイルを生成しました"
+  }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,8 +5,8 @@ import path from "node:path";
 import { parseArgs } from "node:util";
 import * as p from "@clack/prompts";
 import pc from "picocolors";
-import { runWizard } from "./cli.js";
-import { generate, validateAnswers } from "./generator.js";
+import { runApplyWizard, runWizard } from "./cli.js";
+import { generate, generateApply, validateAnswers } from "./generator.js";
 import { detectLocale, setLocale, t } from "./i18n/index.js";
 import { buildFileTree } from "./tree.js";
 import { createDiskWriter } from "./utils.js";
@@ -24,11 +24,46 @@ function run(cmd: string, args: string[], cwd: string): Promise<string> {
   });
 }
 
+async function runApplyMode(dryRun: boolean): Promise<void> {
+  const outDir = process.cwd();
+  const answers = await runApplyWizard();
+
+  const result = generateApply(answers);
+  const fileList = result.fileList();
+
+  if (fileList.length === 0) {
+    p.log.warn(t("apply.noFiles"));
+    p.outro(pc.green(t("outro")));
+    return;
+  }
+
+  if (dryRun) {
+    const tree = buildFileTree(fileList);
+    p.log.info(
+      `${t("dryRun.preview", { count: fileList.length })}\n\n${pc.dim(tree)}\n\n${pc.yellow(t("dryRun.noWrite"))}`,
+    );
+    p.outro(pc.green(t("outro")));
+    return;
+  }
+
+  const s = p.spinner();
+  s.start(t("apply.start"));
+
+  const writer = createDiskWriter(outDir);
+  for (const file of fileList) {
+    writer.write(file, result.readText(file));
+  }
+
+  s.stop(t("apply.stop", { count: fileList.length }));
+  p.outro(pc.green(t("outro")));
+}
+
 async function main(): Promise<void> {
   const { values, positionals } = parseArgs({
     args: process.argv.slice(2),
     options: {
       lang: { type: "string" },
+      apply: { type: "boolean", default: false },
       "dry-run": { type: "boolean", default: false },
       "no-install": { type: "boolean", default: false },
     },
@@ -39,8 +74,15 @@ async function main(): Promise<void> {
   const langFlag = typeof values.lang === "string" ? values.lang : undefined;
   setLocale(detectLocale(langFlag));
 
+  const applyMode = values.apply === true;
   const dryRun = values["dry-run"] === true;
   const noInstall = values["no-install"] === true;
+
+  // --- Apply mode: add agent config to existing project ---
+  if (applyMode) {
+    await runApplyMode(dryRun);
+    return;
+  }
 
   const positionalArg = positionals[0];
   const defaultName = positionalArg ? path.basename(positionalArg) : undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,12 @@ export interface WizardAnswers {
   agents: Array<"claude-code" | "codex" | "gemini" | "amazon-q" | "copilot" | "cline" | "cursor">;
 }
 
+/** Answers for --apply mode (agent-only wizard). */
+export interface ApplyAnswers {
+  clouds: WizardAnswers["clouds"];
+  agents: WizardAnswers["agents"];
+}
+
 // --- Markdown template ---
 
 export interface MarkdownSection {

--- a/tests/apply.test.ts
+++ b/tests/apply.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import { generateApply } from "../src/generator.js";
+import type { ApplyAnswers } from "../src/types.js";
+
+function makeApplyAnswers(overrides: Partial<ApplyAnswers> = {}): ApplyAnswers {
+  return {
+    clouds: [],
+    agents: ["claude-code"],
+    ...overrides,
+  };
+}
+
+describe("generateApply", () => {
+  it("generates Claude Code agent files only", () => {
+    const result = generateApply(makeApplyAnswers({ agents: ["claude-code"] }));
+    const files = result.fileList();
+
+    // Should include Claude Code agent files
+    expect(files.some((f) => f === "CLAUDE.md")).toBe(true);
+    expect(files.some((f) => f.startsWith(".claude/"))).toBe(true);
+    expect(files.some((f) => f === ".mcp.json")).toBe(true);
+
+    // Should NOT include non-agent files
+    expect(files.some((f) => f === "package.json")).toBe(false);
+    expect(files.some((f) => f === ".gitignore")).toBe(false);
+    expect(files.some((f) => f === "biome.json")).toBe(false);
+    expect(files.some((f) => f === "lefthook.yaml")).toBe(false);
+    expect(files.some((f) => f.startsWith(".devcontainer/"))).toBe(false);
+    expect(files.some((f) => f.startsWith(".github/workflows/"))).toBe(false);
+    expect(files.some((f) => f === ".vscode/settings.json")).toBe(false);
+  });
+
+  it("generates multiple agent files when multiple agents selected", () => {
+    const result = generateApply(
+      makeApplyAnswers({ agents: ["claude-code", "codex", "gemini", "cursor"] }),
+    );
+    const files = result.fileList();
+
+    expect(files.some((f) => f === "CLAUDE.md")).toBe(true);
+    expect(files.some((f) => f === "AGENTS.md")).toBe(true);
+    expect(files.some((f) => f === "GEMINI.md")).toBe(true);
+    expect(files.some((f) => f.startsWith(".cursor/"))).toBe(true);
+    expect(files.some((f) => f === ".mcp.json")).toBe(true);
+  });
+
+  it("includes cloud MCP servers when clouds are selected", () => {
+    const result = generateApply(makeApplyAnswers({ clouds: ["aws"], agents: ["claude-code"] }));
+    const mcp = result.readJson(".mcp.json") as Record<string, Record<string, unknown>>;
+    expect(mcp.mcpServers["aws-iac"]).toBeDefined();
+    expect(mcp.mcpServers.context7).toBeDefined();
+    expect(mcp.mcpServers.fetch).toBeDefined();
+  });
+
+  it("includes multiple cloud MCP servers", () => {
+    const result = generateApply(
+      makeApplyAnswers({ clouds: ["aws", "azure", "gcp"], agents: ["claude-code"] }),
+    );
+    const mcp = result.readJson(".mcp.json") as Record<string, Record<string, unknown>>;
+    expect(mcp.mcpServers["aws-iac"]).toBeDefined();
+    expect(mcp.mcpServers.azure).toBeDefined();
+    expect(mcp.mcpServers["google-cloud"]).toBeDefined();
+  });
+
+  it("generates no files when no agents selected", () => {
+    const result = generateApply(makeApplyAnswers({ agents: [] }));
+    const files = result.fileList();
+
+    // Only base .mcp.json would exist (from base preset), but no agent instruction files
+    expect(files.some((f) => f === "CLAUDE.md")).toBe(false);
+    expect(files.some((f) => f === "AGENTS.md")).toBe(false);
+  });
+
+  it("does not contain leftover section placeholders", () => {
+    const result = generateApply(
+      makeApplyAnswers({ clouds: ["aws"], agents: ["claude-code", "codex", "gemini"] }),
+    );
+    for (const file of result.fileList()) {
+      if (file.endsWith(".md") || file.endsWith(".mdc")) {
+        const content = result.readText(file);
+        expect(content, `${file} should not have leftover placeholders`).not.toContain(
+          "<!-- SECTION:",
+        );
+      }
+    }
+  });
+
+  it("Amazon Q and Copilot instruction files are included", () => {
+    const result = generateApply(makeApplyAnswers({ agents: ["amazon-q", "copilot"] }));
+    const files = result.fileList();
+    expect(files.some((f) => f.startsWith(".amazonq/"))).toBe(true);
+    expect(files.some((f) => f === ".github/copilot-instructions.md")).toBe(true);
+  });
+
+  it("Cline instruction files are included", () => {
+    const result = generateApply(makeApplyAnswers({ agents: ["cline"] }));
+    const files = result.fileList();
+    expect(files.some((f) => f.startsWith(".clinerules/"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `--apply` flag to apply AI agent configurations to existing projects
- Simplified wizard (Cloud providers + AI agents only)
- Generates only agent-related files: instruction files, MCP configs, Claude Code skills/rules
- Cloud MCP servers (AWS IaC, Azure, Google Cloud) distributed to agent configs
- Supports `--dry-run` for preview
- Does not modify package.json, lint configs, CI, or other project-specific files

Closes #176