### PR TITLE
feat(preset): add Playwright E2E testing preset with Testing layer

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -210,6 +210,18 @@ export async function runWizard(defaultName?: string): Promise<WizardAnswers> {
           required: false,
         });
       },
+      testing: () =>
+        p.multiselect({
+          message: `${t("wizard.testing.message")} ${pc.dim(t("wizard.testing.hint"))}`,
+          options: [
+            {
+              value: "playwright" as const,
+              label: t("wizard.testing.playwright.label"),
+              hint: t("wizard.testing.playwright.hint"),
+            },
+          ],
+          required: false,
+        }),
       agents: () =>
         p.multiselect({
           message: `${t("wizard.agents.message")} ${pc.dim(t("wizard.agents.hint"))}`,
@@ -268,6 +280,7 @@ export async function runWizard(defaultName?: string): Promise<WizardAnswers> {
     clouds: (answers.clouds ?? []) as WizardAnswers["clouds"],
     iac: (answers.iac ?? []) as WizardAnswers["iac"],
     languages: (answers.languages ?? []) as WizardAnswers["languages"],
+    testing: (answers.testing ?? []) as WizardAnswers["testing"],
     agents: (answers.agents ?? []) as WizardAnswers["agents"],
   };
 }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -102,6 +102,10 @@ export function resolvePresets(answers: WizardAnswers): string[] {
     selected.add(iac);
   }
 
+  for (const testing of answers.testing) {
+    selected.add(testing);
+  }
+
   for (const agent of answers.agents) {
     selected.add(agent);
   }
@@ -604,6 +608,7 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
   if (answers.frontend !== "none") workspacePackages.push("web");
   if (answers.backend === "hono" || answers.backend === "express") workspacePackages.push("api");
   if (answers.backend === "batch") workspacePackages.push("worker");
+  if (answers.testing.includes("playwright")) workspacePackages.push("e2e");
   if (workspacePackages.length > 0) {
     const yamlLines = ["packages:"];
     for (const pkg of workspacePackages) {
@@ -655,6 +660,7 @@ export function generateApply(answers: ApplyAnswers): GenerateResult {
     clouds: answers.clouds,
     iac: [],
     languages: [],
+    testing: [],
     agents: answers.agents,
   };
 

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -50,6 +50,11 @@
       "terraform": { "label": "Terraform" },
       "bicep": { "label": "Bicep", "hint": "Azure" }
     },
+    "testing": {
+      "message": "Testing tools",
+      "hint": "Add E2E testing setup",
+      "playwright": { "label": "Playwright", "hint": "forces TypeScript" }
+    },
     "agents": {
       "message": "AI Agent tools",
       "hint": "Add agent-specific project config, rules, and MCP servers",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -50,6 +50,11 @@
       "terraform": { "label": "Terraform" },
       "bicep": { "label": "Bicep", "hint": "Azure" }
     },
+    "testing": {
+      "message": "テストツール",
+      "hint": "E2E テスト環境を追加",
+      "playwright": { "label": "Playwright", "hint": "TypeScript が強制されます" }
+    },
     "agents": {
       "message": "AI エージェントツール",
       "hint": "エージェント固有のプロジェクト設定・ルール・MCP サーバーを追加",

--- a/src/presets/index.ts
+++ b/src/presets/index.ts
@@ -20,6 +20,7 @@ import { geminiPreset } from "./gemini.js";
 import { honoPreset } from "./hono.js";
 import { nextjsPreset } from "./nextjs.js";
 import { nuxtPreset } from "./nuxt.js";
+import { playwrightPreset } from "./playwright.js";
 import { pythonPreset } from "./python.js";
 import { reactPreset } from "./react.js";
 import { sveltekitPreset } from "./sveltekit.js";
@@ -52,6 +53,7 @@ const PRESET_ENTRIES: ReadonlyArray<readonly [string, Preset]> = [
   ["cloudformation", cloudformationPreset],
   ["terraform", terraformPreset],
   ["bicep", bicepPreset],
+  ["playwright", playwrightPreset],
   ["claude-code", claudeCodePreset],
   ["codex", codexPreset],
   ["gemini", geminiPreset],

--- a/src/presets/playwright.ts
+++ b/src/presets/playwright.ts
@@ -1,0 +1,82 @@
+import type { Preset } from "../types.js";
+import { readTemplateFiles } from "../utils.js";
+
+export const playwrightPreset: Preset = {
+  name: "playwright",
+  requires: ["typescript"],
+  files: readTemplateFiles("playwright"),
+  merge: {
+    ".gitignore": "# Playwright\nplaywright-report/\nblob-report/\ntest-results/",
+    "package.json": {
+      scripts: {
+        "test:e2e": "cd e2e && pnpm test",
+      },
+    },
+  },
+  markdown: {
+    "agent-instructions": [
+      {
+        placeholder: "<!-- SECTION:TECH_STACK -->",
+        content: "- **E2E Testing**: Playwright",
+      },
+      {
+        placeholder: "<!-- SECTION:PROJECT_STRUCTURE -->",
+        content: "e2e/          -> E2E tests (Playwright)",
+      },
+      {
+        placeholder: "<!-- SECTION:SETUP_COMMANDS -->",
+        content:
+          "cd e2e && pnpm install    # Install E2E test dependencies\nnpx playwright install    # Install browsers",
+      },
+      {
+        placeholder: "<!-- SECTION:TEST_COMMANDS -->",
+        content: "pnpm run test:e2e          # Run E2E tests (Playwright)",
+      },
+      {
+        placeholder: "<!-- SECTION:CODING_CONVENTIONS -->",
+        content: "- Playwright: tests in `e2e/`, use Page Object Model for complex pages",
+      },
+    ],
+    "README.md": [
+      {
+        placeholder: "<!-- SECTION:DIR_STRUCTURE -->",
+        content: "├── e2e/                 # E2E テスト (Playwright)",
+      },
+      {
+        placeholder: "<!-- SECTION:ROOT_FILES -->",
+        content: "├── e2e/package.json     # E2E テスト依存・スクリプト",
+      },
+      {
+        placeholder: "<!-- SECTION:SETUP_STEPS -->",
+        content:
+          "1. `cd e2e && pnpm install`（E2E テスト依存パッケージ）\n1. `npx playwright install`（ブラウザインストール）",
+      },
+      {
+        placeholder: "<!-- SECTION:SETUP_COMMANDS -->",
+        content:
+          "| `cd e2e && pnpm install` | E2E テスト依存パッケージインストール |\n| `npx playwright install` | Playwright ブラウザインストール |",
+      },
+      {
+        placeholder: "<!-- SECTION:TEST_COMMANDS -->",
+        content: "| `pnpm run test:e2e` | E2E テスト（Playwright） |",
+      },
+    ],
+  },
+  mcpServers: {
+    playwright: {
+      command: "npx",
+      args: ["@playwright/mcp@latest"],
+    },
+  },
+  ciSteps: {
+    setupSteps: [
+      { name: "Install E2E dependencies", run: "cd e2e && pnpm install --frozen-lockfile" },
+      {
+        name: "Install Playwright browsers",
+        run: "cd e2e && npx playwright install --with-deps chromium",
+      },
+    ],
+    testSteps: [{ name: "Test (E2E Playwright)", run: "cd e2e && pnpm test" }],
+  },
+  setupExtra: "cd e2e && pnpm install && npx playwright install",
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,7 @@ export interface WizardAnswers {
   clouds: Array<"aws" | "azure" | "gcp">;
   iac: Array<"cdk" | "cloudformation" | "terraform" | "bicep">;
   languages: Array<"typescript" | "python">;
+  testing: Array<"playwright">;
   agents: Array<"claude-code" | "codex" | "gemini" | "amazon-q" | "copilot" | "cline" | "cursor">;
 }
 

--- a/templates/playwright/e2e/example.spec.ts
+++ b/templates/playwright/e2e/example.spec.ts
@@ -1,0 +1,6 @@
+import { expect, test } from "@playwright/test";
+
+test("has title", async ({ page }) => {
+  await page.goto("/");
+  await expect(page).toHaveTitle(/.+/);
+});

--- a/templates/playwright/e2e/package.json
+++ b/templates/playwright/e2e/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "{{projectName}}-e2e",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "test:ui": "playwright test --ui",
+    "test:report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.50.0"
+  }
+}

--- a/templates/playwright/e2e/playwright.config.ts
+++ b/templates/playwright/e2e/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: ".",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: "html",
+  use: {
+    baseURL: "http://localhost:3000",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -7,11 +7,12 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 interface MockAnswers {
   projectName?: string;
-  frontend?: "none" | "react" | "nextjs" | "vue" | "nuxt";
-  backend?: "none" | "fastapi" | "express" | "batch";
+  frontend?: "none" | "react" | "nextjs" | "vue" | "nuxt" | "sveltekit" | "astro";
+  backend?: "none" | "hono" | "fastapi" | "express" | "batch";
   clouds?: Array<"aws" | "azure" | "gcp">;
   iac?: Array<"cdk" | "cloudformation" | "terraform" | "bicep">;
   languages?: Array<"typescript" | "python">;
+  testing?: Array<"playwright">;
   agents?: Array<"claude-code" | "codex" | "gemini" | "amazon-q" | "copilot" | "cline" | "cursor">;
 }
 
@@ -85,7 +86,9 @@ function setupMock(answers: MockAnswers): void {
   if (needsLanguagePrompt) {
     multiselectReturns.push(answers.languages ?? []);
   }
-  // 4. agents
+  // 4. testing
+  multiselectReturns.push(answers.testing ?? []);
+  // 5. agents
   multiselectReturns.push(answers.agents ?? ["claude-code"]);
 
   multiselectMock.mockReset();
@@ -103,8 +106,9 @@ function shouldShowLanguagePrompt(answers: MockAnswers): boolean {
   let hasTypeScript = false;
   let hasPython = false;
 
-  if (["react", "nextjs", "vue", "nuxt"].includes(frontend)) hasTypeScript = true;
-  if (backend === "express" || backend === "batch") hasTypeScript = true;
+  if (["react", "nextjs", "vue", "nuxt", "sveltekit", "astro"].includes(frontend))
+    hasTypeScript = true;
+  if (backend === "hono" || backend === "express" || backend === "batch") hasTypeScript = true;
   if (iac.includes("cdk")) hasTypeScript = true;
   if (backend === "fastapi") hasPython = true;
 
@@ -132,6 +136,7 @@ describe("CLI Wizard E2E", () => {
         clouds: [],
         iac: [],
         languages: [],
+        testing: [],
         agents: ["claude-code"],
       });
     });
@@ -380,6 +385,7 @@ describe("CLI Wizard E2E", () => {
         clouds: ["aws"],
         iac: ["cdk"],
         languages: [],
+        testing: [],
         agents: ["claude-code", "copilot"],
       });
     });
@@ -402,6 +408,7 @@ describe("CLI Wizard E2E", () => {
         clouds: ["aws", "azure", "gcp"],
         iac: ["terraform"],
         languages: ["typescript"],
+        testing: [],
         agents: ["claude-code"],
       });
     });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -11,6 +11,7 @@ export function makeAnswers(overrides: Partial<WizardAnswers> = {}): WizardAnswe
     clouds: [],
     iac: [],
     languages: [],
+    testing: [],
     agents: ["claude-code"],
     ...overrides,
   };

--- a/tests/presets/playwright.test.ts
+++ b/tests/presets/playwright.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import { generate } from "../../src/generator.js";
+import { makeAnswers } from "../helpers.js";
+
+describe("generate (playwright)", () => {
+  const answers = makeAnswers({ testing: ["playwright"] });
+  const result = generate(answers);
+
+  it("forces TypeScript preset inclusion", () => {
+    expect(result.hasFile("biome.json")).toBe(true);
+    expect(result.hasFile("tsconfig.json")).toBe(true);
+  });
+
+  it("includes Playwright owned files in e2e/", () => {
+    expect(result.hasFile("e2e/playwright.config.ts")).toBe(true);
+    expect(result.hasFile("e2e/example.spec.ts")).toBe(true);
+    expect(result.hasFile("e2e/package.json")).toBe(true);
+  });
+
+  it("has Playwright dependencies in e2e/package.json", () => {
+    const pkg = result.readJson("e2e/package.json") as Record<string, unknown>;
+    const devDeps = pkg.devDependencies as Record<string, string>;
+    expect(devDeps["@playwright/test"]).toBeDefined();
+  });
+
+  it("merges test:e2e script into package.json", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const scripts = pkg.scripts as Record<string, string>;
+    expect(scripts["test:e2e"]).toContain("pnpm test");
+  });
+
+  it("adds Playwright-related entries to .gitignore", () => {
+    const gitignore = result.readText(".gitignore");
+    expect(gitignore).toContain("playwright-report/");
+    expect(gitignore).toContain("test-results/");
+  });
+
+  it("adds Playwright CI steps", () => {
+    const ci = result.readYaml(".github/workflows/ci.yaml") as Record<string, unknown>;
+    const jobs = ci.jobs as Record<string, Record<string, unknown>>;
+    const steps = jobs["lint-and-check"].steps as Array<Record<string, unknown>>;
+    const stepNames = steps.map((s) => s.name);
+    expect(stepNames).toContain("Install E2E dependencies");
+    expect(stepNames).toContain("Install Playwright browsers");
+    expect(stepNames).toContain("Test (E2E Playwright)");
+  });
+
+  it("adds E2E install to setup.sh", () => {
+    const setup = result.readText("scripts/setup.sh");
+    expect(setup).toContain("cd e2e && pnpm install");
+    expect(setup).toContain("npx playwright install");
+  });
+
+  it("generates pnpm-workspace.yaml with e2e", () => {
+    expect(result.hasFile("pnpm-workspace.yaml")).toBe(true);
+    const workspace = result.readText("pnpm-workspace.yaml");
+    expect(workspace).toContain("- e2e");
+  });
+
+  it("distributes Playwright MCP server to agent configs", () => {
+    const mcp = result.readJson(".mcp.json") as Record<string, Record<string, unknown>>;
+    expect(mcp.mcpServers.playwright).toBeDefined();
+  });
+
+  it("expands CLAUDE.md with Playwright sections", () => {
+    const claude = result.readText("CLAUDE.md");
+    expect(claude).toContain("Playwright");
+    expect(claude).toContain("e2e/");
+    expect(claude).not.toContain("<!-- SECTION:");
+  });
+
+  it("replaces {{projectName}} in e2e/package.json", () => {
+    const pkg = result.readText("e2e/package.json");
+    expect(pkg).toContain("test-app-e2e");
+    expect(pkg).not.toContain("{{projectName}}");
+  });
+});
+
+describe("generate (react + playwright)", () => {
+  const answers = makeAnswers({ frontend: "react", testing: ["playwright"] });
+  const result = generate(answers);
+
+  it("workspace includes both web and e2e", () => {
+    const workspace = result.readText("pnpm-workspace.yaml");
+    expect(workspace).toContain("- web");
+    expect(workspace).toContain("- e2e");
+  });
+
+  it("CLAUDE.md contains both React and Playwright sections", () => {
+    const claude = result.readText("CLAUDE.md");
+    expect(claude).toContain("React");
+    expect(claude).toContain("Playwright");
+    expect(claude).not.toContain("<!-- SECTION:");
+  });
+});


### PR DESCRIPTION
## Summary

- Add new Testing layer (Layer 6) between Language and Agent layers
- Add Playwright E2E testing preset with template files (config, example spec)
- Playwright MCP server (`@playwright/mcp`) distributed to agent configs
- E2E tests in `e2e/` directory as pnpm workspace package
- CI steps for browser install and E2E test execution
- Wizard updated with Testing question

Closes #175