### PR TITLE
fix(preset): resolve Playwright baseURL by frontend and add CDK typecheck to CI

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -136,6 +136,22 @@ export function resolvePresets(answers: WizardAnswers): string[] {
   return PRESET_ORDER.filter((p) => selected.has(p));
 }
 
+/** Resolve the primary dev server port based on frontend selection. */
+function resolveDevPort(frontend: WizardAnswers["frontend"]): string {
+  switch (frontend) {
+    case "react":
+    case "vue":
+    case "sveltekit":
+      return "5173";
+    case "astro":
+      return "4321";
+    case "nextjs":
+    case "nuxt":
+    case "none":
+      return "3000";
+  }
+}
+
 /** Template variable replacement in file contents. */
 function replaceVariables(content: string, vars: Record<string, string>): string {
   let result = content;
@@ -509,6 +525,7 @@ export function generate(answers: WizardAnswers, options: GenerateOptions = {}):
 
   const vars: Record<string, string> = {
     projectName: answers.projectName,
+    devPort: resolveDevPort(answers.frontend),
     actionsCheckout: ACTIONS.checkout,
     actionsMise: ACTIONS.mise,
     actionsCache: ACTIONS.cache,

--- a/src/presets/cdk.ts
+++ b/src/presets/cdk.ts
@@ -167,6 +167,7 @@ export const cdkPreset: Preset = {
       { name: "CDK synth", run: "cd infra && npx cdk synth" },
     ],
     lintSteps: [
+      { name: "Typecheck (infra tsc)", run: "cd infra && tsc --noEmit" },
       { name: "Lint (cfn-lint)", run: "cfn-lint" },
       { name: "Security (Trivy IaC: CDK)", run: "trivy config --exit-code 1 infra/cdk.out/" },
     ],

--- a/templates/playwright/e2e/playwright.config.ts
+++ b/templates/playwright/e2e/playwright.config.ts
@@ -8,12 +8,12 @@ export default defineConfig({
   workers: process.env.CI ? 1 : undefined,
   reporter: "html",
   use: {
-    baseURL: "http://localhost:3000",
+    baseURL: "http://localhost:{{devPort}}",
     trace: "on-first-retry",
   },
   webServer: {
     command: "cd .. && pnpm run dev",
-    url: "http://localhost:3000",
+    url: "http://localhost:{{devPort}}",
     reuseExistingServer: !process.env.CI,
   },
   projects: [

--- a/tests/presets/cdk.test.ts
+++ b/tests/presets/cdk.test.ts
@@ -59,6 +59,7 @@ describe("generate (cdk)", () => {
     const stepNames = steps.map((s) => s.name);
     expect(stepNames).toContain("Install infra dependencies");
     expect(stepNames).toContain("CDK synth");
+    expect(stepNames).toContain("Typecheck (infra tsc)");
     expect(stepNames).toContain("Lint (cfn-lint)");
     expect(stepNames).toContain("Test (infra CDK)");
     const synthIdx = stepNames.indexOf("CDK synth");

--- a/tests/presets/playwright.test.ts
+++ b/tests/presets/playwright.test.ts
@@ -74,6 +74,12 @@ describe("generate (playwright)", () => {
     expect(pkg).toContain("test-app-e2e");
     expect(pkg).not.toContain("{{projectName}}");
   });
+
+  it("uses default port (3000) in playwright.config.ts when no frontend", () => {
+    const config = result.readText("e2e/playwright.config.ts");
+    expect(config).toContain("localhost:3000");
+    expect(config).not.toContain("{{devPort}}");
+  });
 });
 
 describe("generate (react + playwright)", () => {
@@ -91,5 +97,31 @@ describe("generate (react + playwright)", () => {
     expect(claude).toContain("React");
     expect(claude).toContain("Playwright");
     expect(claude).not.toContain("<!-- SECTION:");
+  });
+
+  it("uses Vite port (5173) in playwright.config.ts for React", () => {
+    const config = result.readText("e2e/playwright.config.ts");
+    expect(config).toContain("localhost:5173");
+    expect(config).not.toContain("localhost:3000");
+  });
+});
+
+describe("generate (nextjs + playwright)", () => {
+  const answers = makeAnswers({ frontend: "nextjs", testing: ["playwright"] });
+  const result = generate(answers);
+
+  it("uses Next.js port (3000) in playwright.config.ts", () => {
+    const config = result.readText("e2e/playwright.config.ts");
+    expect(config).toContain("localhost:3000");
+  });
+});
+
+describe("generate (astro + playwright)", () => {
+  const answers = makeAnswers({ frontend: "astro", testing: ["playwright"] });
+  const result = generate(answers);
+
+  it("uses Astro port (4321) in playwright.config.ts", () => {
+    const config = result.readText("e2e/playwright.config.ts");
+    expect(config).toContain("localhost:4321");
   });
 });


### PR DESCRIPTION
## Summary

- Playwright `baseURL` and `webServer.url` now dynamically resolve per frontend framework using `{{devPort}}` template variable:
  - React / Vue / SvelteKit (Vite): 5173
  - Next.js / Nuxt: 3000
  - Astro: 4321
  - No frontend: 3000
- Add `Typecheck (infra tsc)` CI step to CDK preset (was in package.json and lefthook but missing from CI workflow)