### PR TITLE
fix: run lint:python (ruff) before lint:mypy in lint:all script

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -199,12 +199,15 @@ function postProcessPackageJson(pkgContent: string, presets: Preset[]): string {
       key.startsWith("lint:") &&
       key !== "lint:all" &&
       key !== "lint:fix" &&
+      key !== "lint:mypy" &&
       key !== "lint:secrets" &&
       key !== "lint:trivy"
     ) {
       lintParts.push(`pnpm run ${key}`);
     }
   }
+  // mypy runs after ruff (lint:python) to avoid format-related false positives
+  if (scripts["lint:mypy"]) lintParts.push("pnpm run lint:mypy");
   if (scripts["lint:secrets"]) lintParts.push("pnpm run lint:secrets");
   if (scripts["lint:trivy"]) lintParts.push("pnpm run lint:trivy");
   if (lintParts.length > 0) {

--- a/tests/pairwise.test.ts
+++ b/tests/pairwise.test.ts
@@ -73,6 +73,15 @@ describe("pairwise: typescript + python", () => {
     expect(scripts["lint:all"]).toContain("pnpm run lint:secrets");
   });
 
+  it("lint:all runs lint:python (ruff) before lint:mypy", () => {
+    const pkg = result.readJson("package.json") as Record<string, unknown>;
+    const scripts = pkg.scripts as Record<string, string>;
+    const lintAll = scripts["lint:all"];
+    const pythonIdx = lintAll.indexOf("lint:python");
+    const mypyIdx = lintAll.indexOf("lint:mypy");
+    expect(pythonIdx, "lint:python should appear before lint:mypy").toBeLessThan(mypyIdx);
+  });
+
   it("merges both language settings into VSCode settings", () => {
     const settings = result.readJson(".vscode/settings.json") as Record<string, unknown>;
     expect(settings["editor.defaultFormatter"]).toBe("biomejs.biome");


### PR DESCRIPTION
## Summary

- Fix `lint:all` script ordering: `lint:python` (Ruff format/lint) now runs before `lint:mypy` (type check)
- Previously `lint:mypy` ran first due to alphabetical sorting, which could cause format-related false positives in mypy
- Add pairwise test to verify lint:python precedes lint:mypy in lint:all