### PR TITLE
feat(preset): install agent CLIs via mise

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -10,9 +10,6 @@ RUN apt-get update \
 # Install as vscode user
 USER vscode
 
-# Install Claude Code
-RUN curl -fsSL https://claude.ai/install.sh | bash
-
 # Install mise
 RUN curl --proto '=https' --tlsv1.2 -fsSL https://mise.run | sh
 

--- a/.mise.toml
+++ b/.mise.toml
@@ -16,3 +16,9 @@ gitleaks = "8"
 
 # Git hooks
 lefthook = "2"
+
+# AI agent CLIs
+"npm:@anthropic-ai/claude-code" = "latest"
+"npm:@openai/codex" = "latest"
+"npm:@github/copilot" = "latest"
+"npm:@google/gemini-cli" = "latest"

--- a/src/presets/claude-code.ts
+++ b/src/presets/claude-code.ts
@@ -8,6 +8,11 @@ export const claudeCodePreset: Preset = {
   mcpConfigPath: { path: ".mcp.json", format: "json" },
   files: { ...readTemplateFiles("claude-code"), "CLAUDE.md": buildClaudeInstruction() },
   merge: {
+    ".mise.toml": {
+      tools: {
+        "npm:@anthropic-ai/claude-code": "latest",
+      },
+    },
     ".gitignore": ".claude/settings.local.json",
     ".devcontainer/devcontainer.json": {
       mounts: [

--- a/src/presets/codex.ts
+++ b/src/presets/codex.ts
@@ -6,6 +6,11 @@ export const codexPreset: Preset = {
   mcpConfigPath: { path: ".codex/config.toml", format: "toml" },
   files: {},
   merge: {
+    ".mise.toml": {
+      tools: {
+        "npm:@openai/codex": "latest",
+      },
+    },
     ".devcontainer/devcontainer.json": {
       remoteEnv: {
         // biome-ignore lint/suspicious/noTemplateCurlyInString: devcontainer variable syntax

--- a/src/presets/copilot.ts
+++ b/src/presets/copilot.ts
@@ -5,7 +5,13 @@ export const copilotPreset: Preset = {
   name: "copilot",
   mcpConfigPath: { path: ".copilot/mcp-config.json", format: "json" },
   files: {},
-  merge: {},
+  merge: {
+    ".mise.toml": {
+      tools: {
+        "npm:@github/copilot": "latest",
+      },
+    },
+  },
   mcpServers: { ...DEFAULT_MCP_SERVERS },
   markdown: {
     "agent-instructions": [],

--- a/src/presets/gemini.ts
+++ b/src/presets/gemini.ts
@@ -8,6 +8,11 @@ export const geminiPreset: Preset = {
     ".gemini/settings.json": `${JSON.stringify({ context: { fileName: "AGENTS.md" } }, null, 2)}\n`,
   },
   merge: {
+    ".mise.toml": {
+      tools: {
+        "npm:@google/gemini-cli": "latest",
+      },
+    },
     ".gitignore": ".gemini/.env",
     ".devcontainer/devcontainer.json": {
       remoteEnv: {

--- a/templates/base/.devcontainer/Dockerfile
+++ b/templates/base/.devcontainer/Dockerfile
@@ -10,9 +10,6 @@ RUN apt-get update \
 # Install as vscode user
 USER vscode
 
-# Install Claude Code
-RUN curl -fsSL https://claude.ai/install.sh | bash
-
 # Install mise
 RUN curl --proto '=https' --tlsv1.2 -fsSL https://mise.run | sh
 


### PR DESCRIPTION
## Summary

- 4つのエージェント CLI（Claude Code, Codex, Copilot, Gemini）を mise の `npm:` パッケージとして管理
- 各エージェントプリセット選択時に `.mise.toml` へ対応する CLI ツールをマージ
- テンプレート Dockerfile からハードコードされた Claude Code インストールを削除（mise に統一）
- 本リポジトリの `.mise.toml` と Dockerfile も同様に更新

### インストール方法

| ツール | mise パッケージ | 条件 |
|---|---|---|
| Claude Code | `npm:@anthropic-ai/claude-code` | claude-code プリセット選択時 |
| Codex CLI | `npm:@openai/codex` | codex プリセット選択時 |
| Copilot CLI | `npm:@github/copilot` | copilot プリセット選択時 |
| Gemini CLI | `npm:@google/gemini-cli` | gemini プリセット選択時 |

### 動作フロー

1. ユーザーが `create-agentic-dev` でプロジェクト生成（エージェント選択）
2. 選択されたエージェントの CLI が `.mise.toml` に追加される
3. devcontainer ビルド時に `mise install` が実行され、CLI がイメージに bake される
4. devcontainer 起動後、全選択エージェントの CLI が即座に利用可能