### PR TITLE
chore: update test project script with multi-agent defaults

### DIFF
--- a/scripts/gen-test-projects.ts
+++ b/scripts/gen-test-projects.ts
@@ -22,7 +22,7 @@ function defaults(overrides: Partial<WizardAnswers>): WizardAnswers {
     iac: [],
     languages: [],
     testing: [],
-    agents: ["claude-code"],
+    agents: ["claude-code", "codex", "copilot", "gemini"],
     ...overrides,
   };
 }
@@ -298,6 +298,64 @@ const projects: [string, Partial<WizardAnswers>][] = [
       projectName: "aws-only",
       clouds: ["aws"],
       languages: ["typescript"],
+    },
+  ],
+
+  // ── Agent combinations ──
+  [
+    "36-claude-only",
+    {
+      projectName: "claude-only",
+      languages: ["typescript"],
+      agents: ["claude-code"],
+    },
+  ],
+  [
+    "37-codex-only",
+    {
+      projectName: "codex-only",
+      languages: ["typescript"],
+      agents: ["codex"],
+    },
+  ],
+  [
+    "38-copilot-only",
+    {
+      projectName: "copilot-only",
+      languages: ["typescript"],
+      agents: ["copilot"],
+    },
+  ],
+  [
+    "39-gemini-only",
+    {
+      projectName: "gemini-only",
+      languages: ["typescript"],
+      agents: ["gemini"],
+    },
+  ],
+  [
+    "40-claude-codex",
+    {
+      projectName: "claude-codex",
+      languages: ["typescript"],
+      agents: ["claude-code", "codex"],
+    },
+  ],
+  [
+    "41-copilot-gemini",
+    {
+      projectName: "copilot-gemini",
+      languages: ["typescript"],
+      agents: ["copilot", "gemini"],
+    },
+  ],
+  [
+    "42-non-claude-agents",
+    {
+      projectName: "non-claude-agents",
+      languages: ["typescript"],
+      agents: ["codex", "copilot", "gemini", "cline", "amazon-q"],
     },
   ],
 


### PR DESCRIPTION
## Summary

- デフォルトの agents を `["claude-code"]` → `["claude-code", "codex", "copilot", "gemini"]` に変更
- エージェント組み合わせテストケース7件を追加（36〜42）
- 全42プロジェクトの生成を確認済み

### 追加テストケース

| # | ケース | agents |
|---|---|---|
| 36 | claude-only | claude-code |
| 37 | codex-only | codex |
| 38 | copilot-only | copilot |
| 39 | gemini-only | gemini |
| 40 | claude-codex | claude-code, codex |
| 41 | copilot-gemini | copilot, gemini |
| 42 | non-claude-agents | codex, copilot, gemini, cline, amazon-q |

### 検証結果

- Codex only: AGENTS.md ✅, .codex/ ✅, CLAUDE.md なし ✅
- Copilot only: AGENTS.md ✅, .copilot/ ✅, CLAUDE.md なし ✅
- Gemini only: AGENTS.md ✅, .gemini/settings.json (context.fileName) ✅, CLAUDE.md なし ✅
- Non-Claude: 全エージェント設定 ✅, .claude/ なし ✅
- Claude only: CLAUDE.md (@AGENTS.md) ✅, .claude/skills/ (overlay) ✅, .agents/skills/ (shared) ✅