### PR TITLE
fix: add Playwright E2E test step to shared skill and fix MCP package name

### DIFF
--- a/.mcp.json.example
+++ b/.mcp.json.example
@@ -33,7 +33,7 @@
     },
     "playwright": {
       "command": "npx",
-      "args": ["-y", "@anthropic-ai/mcp-server-playwright"]
+      "args": ["-y", "@playwright/mcp@latest"]
     }
   }
 }

--- a/src/presets/playwright.ts
+++ b/src/presets/playwright.ts
@@ -37,6 +37,12 @@ export const playwrightPreset: Preset = {
         content: "- Playwright: tests in `e2e/`, use Page Object Model for complex pages",
       },
     ],
+    ".agents/skills/test/SKILL.md": [
+      {
+        placeholder: "<!-- SECTION:TEST_STEPS -->",
+        content: "1. `cd e2e && pnpm test` で E2E テスト実行（Playwright）",
+      },
+    ],
     "README.md": [
       {
         placeholder: "<!-- SECTION:DIR_STRUCTURE -->",

--- a/templates/base/.mcp.json.example
+++ b/templates/base/.mcp.json.example
@@ -33,7 +33,7 @@
     },
     "playwright": {
       "command": "npx",
-      "args": ["-y", "@anthropic-ai/mcp-server-playwright"]
+      "args": ["-y", "@playwright/mcp@latest"]
     }
   }
 }


### PR DESCRIPTION
## Summary

- Playwright プリセットが `.agents/skills/test/SKILL.md` に `TEST_STEPS` セクションを注入するように修正
- `.mcp.json.example` の Playwright MCP パッケージ名を `@anthropic-ai/mcp-server-playwright`（旧）→ `@playwright/mcp@latest`（公式新パッケージ）に修正

### テストプロジェクト再生成で検証済み

- 35-kitchen-sink: E2E テストステップが `.agents/skills/test/SKILL.md` に展開されることを確認
- `.mcp.json.example` と `.mcp.json` のパッケージ名が一致することを確認