### PR TITLE
feat!: rename package to @ozzylabs/create-agentic-app

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,5 +1,5 @@
 name: Bug Report
-description: Report a bug in create-agentic-dev
+description: Report a bug in create-agentic-app
 labels: ["bug"]
 body:
   - type: textarea
@@ -15,7 +15,7 @@ body:
       label: Steps to Reproduce
       description: Steps to reproduce the behavior.
       value: |
-        1. Run `npm create @ozzylabs/agentic-dev my-app`
+        1. Run `npm create @ozzylabs/agentic-app my-app`
         2. Select ...
         3. See error
     validations:
@@ -38,7 +38,7 @@ body:
     id: version
     attributes:
       label: Version
-      description: "Output of `npx @ozzylabs/create-agentic-dev --version` or package.json version."
+      description: "Output of `npx @ozzylabs/create-agentic-app --version` or package.json version."
       placeholder: "0.1.0"
     validations:
       required: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-`create-agentic-dev`: CLI tool that scaffolds AI-agent-native development projects with interactive presets. Companion to [agentic-dev-template](https://github.com/ozzy-labs/agentic-dev-template).
+`create-agentic-app`: CLI tool that scaffolds AI-agent-native development projects with interactive presets. Companion to [agentic-dev-template](https://github.com/ozzy-labs/agentic-dev-template).
 
 ## Tech Stack
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-`create-agentic-dev`: CLI tool that scaffolds AI-agent-native development projects with interactive presets. Companion to [agentic-dev-template](https://github.com/ozzy-labs/agentic-dev-template).
+`create-agentic-app`: CLI tool that scaffolds AI-agent-native development projects with interactive presets. Companion to [agentic-dev-template](https://github.com/ozzy-labs/agentic-dev-template).
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# create-agentic-dev
+# create-agentic-app
 
 Scaffold an AI-agent-native development environment with interactive presets.
 
@@ -7,7 +7,7 @@ Companion to [agentic-dev-template](https://github.com/ozzy-labs/agentic-dev-tem
 ## Quick Start
 
 ```bash
-npm create @ozzylabs/agentic-dev my-app
+npm create @ozzylabs/agentic-app my-app
 cd my-app
 bash scripts/setup.sh
 ```

--- a/docs/design.md
+++ b/docs/design.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-`create-agentic-dev` is a CLI tool that scaffolds AI-agent-native development projects with interactive presets.
+`create-agentic-app` is a CLI tool that scaffolds AI-agent-native development projects with interactive presets.
 
-- **Distribution**: npm package (`npm create @ozzylabs/agentic-dev`)
+- **Distribution**: npm package (`npm create @ozzylabs/agentic-app`)
 - **Prompt library**: @clack/prompts
 - **Architecture**: Preset Composition (composable presets merged into final project)
 - **Relationship**: Companion to [agentic-dev-template](https://github.com/ozzy-labs/agentic-dev-template)
@@ -465,7 +465,7 @@ GCP ────────→ gcloud CLI
 ### Directory layout
 
 ```text
-create-agentic-dev/
+create-agentic-app/
 ├── src/
 │   ├── index.ts              # Entry point (CLI startup)
 │   ├── cli.ts                # Wizard (@clack/prompts)
@@ -602,12 +602,12 @@ No arg parser needed — only `process.argv[2]` for project name.
 
 ```json
 {
-  "name": "@ozzylabs/create-agentic-dev",
+  "name": "@ozzylabs/create-agentic-app",
   "version": "0.1.0",
   "description": "Scaffold an AI-agent-native development environment with interactive presets",
   "type": "module",
   "bin": {
-    "create-agentic-dev": "./dist/index.mjs"
+    "create-agentic-app": "./dist/index.mjs"
   },
   "files": [
     "dist",
@@ -747,9 +747,9 @@ npm create @ozzylabs/agentic-dev [my-app]
 
 | Item | Value |
 |------|-------|
-| Package name | `@ozzylabs/create-agentic-dev` |
+| Package name | `@ozzylabs/create-agentic-app` |
 | Registry | npm public |
-| Usage | `npm create @ozzylabs/agentic-dev` / `npx @ozzylabs/create-agentic-dev` |
+| Usage | `npm create @ozzylabs/agentic-app` / `npx @ozzylabs/create-agentic-app` |
 | Release trigger | GitHub Release (tag `v*`) → auto publish |
 | Provenance | Enabled (`--provenance`) for supply chain security |
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -9,8 +9,8 @@
 ## Development Setup
 
 ```bash
-git clone https://github.com/ozzy-labs/create-agentic-dev.git
-cd create-agentic-dev
+git clone https://github.com/ozzy-labs/create-agentic-app.git
+cd create-agentic-app
 mise install
 pnpm install
 ```
@@ -77,7 +77,7 @@ After making changes to the CLI or templates, verify the generated output by ins
 
    ```bash
    cd /tmp
-   create-agentic-dev my-test-app
+   create-agentic-app my-test-app
    ```
 
 4. Verify the generated project:
@@ -88,7 +88,7 @@ After making changes to the CLI or templates, verify the generated output by ins
 5. Clean up when done:
 
    ```bash
-   pnpm unlink --global create-agentic-dev
+   pnpm unlink --global create-agentic-app
    rm -rf /tmp/my-test-app
    ```
 

--- a/docs/preset-authoring.md
+++ b/docs/preset-authoring.md
@@ -1,6 +1,6 @@
 # Preset Authoring Guide
 
-This guide explains how to create and modify presets for `create-agentic-dev`.
+This guide explains how to create and modify presets for `create-agentic-app`.
 
 ## Overview
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -57,11 +57,11 @@ npm publish --access public --provenance false --//registry.npmjs.org/:_authToke
 
 npmjs.com でパッケージの Trusted Publishing を設定する手順（初回のみ）:
 
-1. <https://www.npmjs.com/package/@ozzylabs/create-agentic-dev/access> にアクセス
+1. <https://www.npmjs.com/package/@ozzylabs/create-agentic-app/access> にアクセス
 2. **Trusted Publisher** セクションで **GitHub Actions** を選択
 3. 以下を入力:
    - **Repository owner**: `ozzy-labs`
-   - **Repository name**: `create-agentic-dev`
+   - **Repository name**: `create-agentic-app`
    - **Workflow filename**: `release.yaml`
    - **Environment name**: （空欄）
 4. 保存する

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "@ozzylabs/create-agentic-dev",
+  "name": "@ozzylabs/create-agentic-app",
   "version": "0.1.2",
   "description": "Scaffold an AI-agent-native development environment with interactive presets",
   "type": "module",
   "bin": {
-    "create-agentic-dev": "./dist/index.mjs"
+    "create-agentic-app": "./dist/index.mjs"
   },
   "files": [
     "dist",
@@ -37,11 +37,11 @@
   },
   "license": "MIT",
   "author": "ozzy-labs",
-  "homepage": "https://github.com/ozzy-labs/create-agentic-dev#readme",
-  "bugs": "https://github.com/ozzy-labs/create-agentic-dev/issues",
+  "homepage": "https://github.com/ozzy-labs/create-agentic-app#readme",
+  "bugs": "https://github.com/ozzy-labs/create-agentic-app/issues",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ozzy-labs/create-agentic-dev.git"
+    "url": "https://github.com/ozzy-labs/create-agentic-app.git"
   },
   "keywords": [
     "create",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,5 +1,5 @@
 {
-  "intro": "create-agentic-dev",
+  "intro": "create-agentic-app",
   "cancel": "Operation cancelled.",
   "wizard": {
     "projectName": {
@@ -92,7 +92,7 @@
   },
   "outro": "Done! Happy coding.",
   "apply": {
-    "intro": "create-agentic-dev --apply",
+    "intro": "create-agentic-app --apply",
     "cloudsHint": "Used for MCP server distribution",
     "noFiles": "No files to generate. Please select at least one agent.",
     "start": "Generating agent configuration...",

--- a/src/i18n/ja.json
+++ b/src/i18n/ja.json
@@ -1,5 +1,5 @@
 {
-  "intro": "create-agentic-dev",
+  "intro": "create-agentic-app",
   "cancel": "操作がキャンセルされました。",
   "wizard": {
     "projectName": {
@@ -92,7 +92,7 @@
   },
   "outro": "完了！Happy coding.",
   "apply": {
-    "intro": "create-agentic-dev --apply",
+    "intro": "create-agentic-app --apply",
     "cloudsHint": "MCP サーバー配布に使用",
     "noFiles": "生成するファイルがありません。エージェントを1つ以上選択してください。",
     "start": "エージェント設定を生成中...",


### PR DESCRIPTION
## Summary

Package / bin / repo を `create-agentic-dev` → `create-agentic-app` にリネーム。業界慣例（`create-react-app` / `create-next-app` / `create-t3-app`）への準拠。

**BREAKING CHANGE**: npm パッケージ名と bin 名が変わるため、既存ユーザーは新パッケージへ移行が必要。

## Changes

- `package.json`: `name` / `bin` / `homepage` / `bugs` / `repository.url`
- `README.md` / `CLAUDE.md` / `AGENTS.md`: タイトル・Project Overview 表記
- `docs/design.md` / `docs/development.md` / `docs/releasing.md` / `docs/preset-authoring.md`: 参照更新
- `src/i18n/en.json` / `src/i18n/ja.json`: `intro` テキスト更新
- `.github/ISSUE_TEMPLATE/bug_report.yaml`: description と usage サンプル更新
- `CHANGELOG.md`: 過去エントリは実在 git tag への参照のため据え置き

## Publish flow

1. 本 PR merge
2. release-please が version bump PR を自動作成（`feat!` により pre-1.0 では 0.1.2 → 0.2.0）
3. release-please PR merge で GitHub Release + `@ozzylabs/create-agentic-app@0.2.0` 自動 publish
4. 旧 `@ozzylabs/create-agentic-dev` を `npm deprecate "Renamed to @ozzylabs/create-agentic-app"` で案内（別途手動）

## Related

- Closes #206
- Refs: ozzy-labs/handbook#20
- Refs: reviews/2026-04-19-restructuring.md § 4.2, § 6.3

## Test plan

- [x] `pnpm run build` 通過
- [x] `pnpm test` 全 822 tests passing
- [x] lefthook (biome / yamlfmt / markdownlint / gitleaks / commitlint) 通過
- [ ] CI 通過（PR 作成後）
- [ ] merge 後、release-please PR が生成される
- [ ] release PR merge 後、npm publish 成功
- [ ] `gh repo rename create-agentic-app` 実行成功