### PR TITLE
fix(ci): disable trivy in release workflow mise-action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,10 @@ jobs:
         with:
           install: true
           cache: true
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MISE_DISABLE_TOOLS: trivy
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:


### PR DESCRIPTION
## Summary

- `.github/workflows/release.yaml` の mise-action ステップに `github_token` と `MISE_DISABLE_TOOLS: trivy` を追加
- `ci.yaml` と同じ構成に揃えて rate limit 起因の `publish` 失敗を解消

## Background

`.mise.toml` に `trivy = "0.69"` が含まれているが、`aquasecurity/trivy` の GitHub Releases API は publish job の mise install 時に 403（rate limit）になりがち。`ci.yaml` は `MISE_DISABLE_TOOLS: trivy` で既に回避しているが、`release.yaml` は未設定のため v0.2.0 の publish が連続失敗していた。

## Test plan

- [x] actionlint / yamllint 通過
- [ ] merge 後、pending の v0.2.0 release workflow が success で走ること