### PR TITLE
feat(skills-sync): opt-in @ozzylabs/skills as PoC consumer

### DIFF
--- a/.dev-config/sync.yaml
+++ b/.dev-config/sync.yaml
@@ -2,6 +2,8 @@
 # 'pinned' is user-editable — add or remove paths freely
 commit: 4f6de17bb3894eb2ad5d2f8f90e93dbc9d3b13ad
 synced_at: 2026-04-25T04:30:15Z
+# Auto-updated by Renovate (extends github>ozzy-labs/skills//skills-sync)
+skills_commit: c600d8621e46dd1435133d5498a63f96776fdeed
 pinned:
   - CLAUDE.md
   - AGENTS.md

--- a/.github/workflows/sync-skills.yaml
+++ b/.github/workflows/sync-skills.yaml
@@ -1,0 +1,101 @@
+name: Sync skills
+
+# Renovate (skills-sync preset) が .dev-config/sync.yaml の skills_commit を更新する。
+# 本ワークフローは skills_commit に対応する skills repo の dist/.agents/skills/ を
+# .agents/skills/ にコピーし、差分があれば PR を作成する。
+#
+# 役割分担:
+#   - Renovate: 上流 SHA の追跡（skills_commit の bump）
+#   - 本ワークフロー: 物理ファイルの同期（dist → .agents/skills/）
+#
+# 移行期間中は commons の dist/.agents/skills/ も sync-commons 経由で配信される
+# 可能性がある（ADR-0016 で許容済みの一時的状態）。
+on:
+  schedule:
+    # Every Monday 00:00 UTC（sync-commons と同じ枠で運用）
+    - cron: "0 0 * * 1"
+  push:
+    branches: [main]
+    paths:
+      - .dev-config/sync.yaml
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  sync:
+    name: Sync skills from ozzy-labs/skills
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout this repo
+        uses: actions/checkout@v4
+
+      - name: Read skills_commit from sync.yaml
+        id: read
+        run: |
+          set -euo pipefail
+          SHA=$(grep -E '^skills_commit:' .dev-config/sync.yaml | awk '{print $2}')
+          if [[ -z "${SHA}" ]]; then
+            echo "Error: skills_commit not found in .dev-config/sync.yaml" >&2
+            exit 1
+          fi
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+
+      - name: Clone skills at recorded commit
+        uses: actions/checkout@v4
+        with:
+          repository: ozzy-labs/skills
+          ref: ${{ steps.read.outputs.sha }}
+          path: .sync-skills
+          # skills repo は public だが、token を渡しても安全なのでそのまま残す。
+          token: ${{ secrets.RENOVATE_TOKEN }}
+
+      - name: Copy dist/.agents/skills/ → .agents/skills/
+        id: copy
+        run: |
+          set -euo pipefail
+          SRC=".sync-skills/dist/.agents/skills"
+          DST=".agents/skills"
+          if [[ ! -d "${SRC}" ]]; then
+            echo "Error: ${SRC} does not exist in skills repo at recorded commit" >&2
+            exit 1
+          fi
+          mkdir -p "${DST}"
+          # skills repo dist 由来の skill ディレクトリのみを上書きコピーする。
+          # リポ固有の README.md や setup skill など、dist に存在しないファイルは保持する。
+          for skill_dir in "${SRC}"/*/; do
+            name=$(basename "${skill_dir}")
+            rm -rf "${DST:?}/${name}"
+            cp -r "${skill_dir}" "${DST}/${name}"
+          done
+          rm -rf .sync-skills
+          if git diff --quiet -- "${DST}"; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changes to sync."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Pull Request
+        if: steps.copy.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: chore/sync-skills
+          base: main
+          commit-message: |
+            chore: sync skills from ozzy-labs/skills
+
+            Automated sync from ozzy-labs/skills at ${{ steps.read.outputs.sha }}.
+          title: "chore: sync skills from ozzy-labs/skills"
+          body: |
+            Automated sync from
+            [ozzy-labs/skills](https://github.com/ozzy-labs/skills) at
+            `${{ steps.read.outputs.sha }}`.
+
+            Source: `dist/.agents/skills/` → `.agents/skills/`
+
+            Triggered by the `Sync skills` workflow. Review the diff and merge when appropriate.
+          labels: chore,skills-sync
+          delete-branch: true

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>ozzy-labs/.github"]
+  "extends": ["github>ozzy-labs/.github", "github>ozzy-labs/skills//skills-sync"]
 }


### PR DESCRIPTION
Closes #216

## Summary

- `renovate.json` を `github>ozzy-labs/skills//skills-sync` に extend し、Renovate が `.dev-config/sync.yaml` の `skills_commit` を追跡するように設定
- `skills_commit` を skills repo main の現在 SHA `c600d8621e46dd1435133d5498a63f96776fdeed` で初期化
- `Sync skills` ワークフローを追加し、`skills_commit` で指定された commit の `dist/.agents/skills/` を `.agents/skills/` へ物理コピーして差分があれば PR を作成

## Design

- **Renovate**: 上流 SHA の追跡（`skills_commit` の bump）
- **`Sync skills` workflow**: 物理ファイルの同期（`dist/.agents/skills/` → `.agents/skills/`）

トリガーは weekly schedule + `.dev-config/sync.yaml` への push + `workflow_dispatch`。`.agents/skills/README.md` や `setup` skill のようなリポ固有ファイル/ディレクトリは保持される（skills repo の dist にあるディレクトリのみを上書きコピー）。

ADR-0016 の Implementation plan #4 の consumer 移行（handbook に続く 2 番目）。移行期間中は commons + skills 双方からの sync が並走するが、現時点で `.agents/skills/` の中身は両者で完全一致しているため上書きの差分は発生しない（ローカル検証済み）。

## Test plan

- [ ] CI（pr-check）が green
- [ ] マージ後、`Sync skills` workflow を `workflow_dispatch` で手動実行 → 差分なしで早期 exit すること
- [ ] skills repo に変更 → Renovate が `chore(deps): update skills` PR を起こすこと（次の Renovate サイクルで運用確認）

## Related

- Parent: ozzy-labs/handbook#52
- Reference impl: ozzy-labs/handbook#54

🤖 Generated with [Claude Code](https://claude.com/claude-code)