### PR TITLE
test: add E2E smoke suite for @ozzylabs/preset-base/-web/-cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
-    "verify": "vitest run tests/smoke.test.ts"
+    "verify": "vitest run tests/smoke.test.ts tests/external-presets.smoke.test.ts"
   },
   "engines": {
     "node": ">=22"

--- a/tests/external-presets.smoke.test.ts
+++ b/tests/external-presets.smoke.test.ts
@@ -1,0 +1,98 @@
+/**
+ * E2E smoke tests for external preset loading via the published
+ * `@ozzylabs/preset-base` / `-web` / `-cli` packages.
+ *
+ * These tests opt in to the real npm packages that ship the canonical external
+ * presets (handbook ADR-0017). When the packages are not installed in this
+ * working tree (e.g. the `presets` repo has not yet been published, or local
+ * `pnpm install` has not pulled them), the suite skips itself with a console
+ * warning so CI does not fail before the upstream presets land.
+ *
+ * Run with: pnpm run verify
+ */
+import { createRequire } from "node:module";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { generate } from "../src/generator.js";
+import { loadExternalPresets } from "../src/loader.js";
+import { makeAnswers, readValidJson } from "./helpers.js";
+
+const TESTS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(TESTS_DIR, "..");
+
+const PRESET_BASE = "@ozzylabs/preset-base";
+const PRESET_WEB = "@ozzylabs/preset-web";
+const PRESET_CLI = "@ozzylabs/preset-cli";
+
+function canResolve(spec: string): boolean {
+  try {
+    const resolver = createRequire(path.join(REPO_ROOT, "package.json"));
+    resolver.resolve(spec);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const baseAvailable = canResolve(PRESET_BASE);
+const webAvailable = canResolve(PRESET_WEB);
+const cliAvailable = canResolve(PRESET_CLI);
+const allAvailable = baseAvailable && webAvailable && cliAvailable;
+
+if (!allAvailable) {
+  console.warn(
+    `[smoke] Skipping external preset E2E suite: ${PRESET_BASE}/${PRESET_WEB}/${PRESET_CLI} ` +
+      "are not installed. Install the @ozzylabs/preset-* packages (or link them via pnpm) " +
+      "to enable these tests.",
+  );
+}
+
+describe.skipIf(!allAvailable)("smoke: external @ozzylabs/preset-* E2E", () => {
+  it(`scaffolds successfully with ${PRESET_BASE} alone`, async () => {
+    const presets = await loadExternalPresets([PRESET_BASE], REPO_ROOT);
+    expect(presets).toHaveLength(1);
+
+    const result = generate(makeAnswers(), { extraPresets: presets });
+    const pkg = readValidJson(result, "package.json") as Record<string, unknown>;
+    expect(pkg.name).toBeTypeOf("string");
+
+    expect(result.hasFile("biome.json")).toBe(true);
+    readValidJson(result, "biome.json");
+  });
+
+  it(`scaffolds a web project with ${PRESET_BASE} + ${PRESET_WEB}`, async () => {
+    const presets = await loadExternalPresets([PRESET_BASE, PRESET_WEB], REPO_ROOT);
+    expect(presets).toHaveLength(2);
+
+    const result = generate(makeAnswers(), { extraPresets: presets });
+
+    // package.json and biome.json — the shared base contributions — are still valid
+    const pkg = readValidJson(result, "package.json") as Record<string, unknown>;
+    expect(pkg.scripts).toBeDefined();
+    expect(result.hasFile("biome.json")).toBe(true);
+    readValidJson(result, "biome.json");
+  });
+
+  it(`scaffolds a CLI project with ${PRESET_BASE} + ${PRESET_CLI}`, async () => {
+    const presets = await loadExternalPresets([PRESET_BASE, PRESET_CLI], REPO_ROOT);
+    expect(presets).toHaveLength(2);
+
+    const result = generate(makeAnswers(), { extraPresets: presets });
+
+    const pkg = readValidJson(result, "package.json") as Record<string, unknown>;
+    expect(pkg.scripts).toBeDefined();
+    expect(result.hasFile("biome.json")).toBe(true);
+    readValidJson(result, "biome.json");
+  });
+
+  it("resolves requires across external presets without error", async () => {
+    // Loading -web (or -cli) without -base should still succeed if -web declares
+    // `requires: ["base"]` and -base is loaded alongside, or fail clearly otherwise.
+    // Either way, supplying both must not throw at generation time.
+    const presets = await loadExternalPresets([PRESET_BASE, PRESET_WEB, PRESET_CLI], REPO_ROOT);
+    expect(presets.map((p) => p.name)).toEqual(expect.arrayContaining(presets.map((p) => p.name)));
+
+    expect(() => generate(makeAnswers(), { extraPresets: presets })).not.toThrow();
+  });
+});

--- a/tests/external-presets.smoke.test.ts
+++ b/tests/external-presets.smoke.test.ts
@@ -87,11 +87,13 @@ describe.skipIf(!allAvailable)("smoke: external @ozzylabs/preset-* E2E", () => {
   });
 
   it("resolves requires across external presets without error", async () => {
-    // Loading -web (or -cli) without -base should still succeed if -web declares
-    // `requires: ["base"]` and -base is loaded alongside, or fail clearly otherwise.
-    // Either way, supplying both must not throw at generation time.
+    // -web and -cli declare `requires: ["base"]` (per ADR-0017), so loading all
+    // three together must validate cleanly and generate without throwing.
     const presets = await loadExternalPresets([PRESET_BASE, PRESET_WEB, PRESET_CLI], REPO_ROOT);
-    expect(presets.map((p) => p.name)).toEqual(expect.arrayContaining(presets.map((p) => p.name)));
+    expect(presets).toHaveLength(3);
+
+    const names = presets.map((p) => p.name);
+    expect(new Set(names).size).toBe(3);
 
     expect(() => generate(makeAnswers(), { extraPresets: presets })).not.toThrow();
   });


### PR DESCRIPTION
## Summary

- Adds an opt-in E2E smoke suite that loads the canonical external preset packages (`@ozzylabs/preset-base`, `-web`, `-cli`) via the existing `loadExternalPresets` API and exercises scaffold composition through `generate()` (handbook ADR-0017).
- The suite resolves each package via Node's resolver and **dynamically skips itself with a console warning when the packages are not installed**, so this stays green until [presets#6](https://github.com/ozzy-labs/presets/issues/6) / [#7](https://github.com/ozzy-labs/presets/issues/7) / [#8](https://github.com/ozzy-labs/presets/issues/8) land and CI can install them.
- Wires the new file into `pnpm run verify` alongside the existing smoke test so generated-output regressions and external-preset breakage are covered by the same script.

## Test plan

- [x] `pnpm run typecheck`
- [x] `pnpm run build`
- [x] `pnpm test` — 837 passed / 4 skipped (the 4 skipped are this new suite, as the `@ozzylabs/preset-*` packages are not yet installed).
- [x] `pnpm run verify` — same: 200 passed + 4 skipped.

## Follow-ups

- Once `@ozzylabs/preset-base` / `-web` / `-cli` ship from the presets repo (presets#6/7/8) and are installed in CI, the suite will automatically activate. No code change required to flip skip → active.

Refs: #219

🤖 Generated with [Claude Code](https://claude.com/claude-code)