### PR TITLE
feat(skills-sync): migrate to adapter-aware sync via @ozzylabs/skills

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,5 +1,7 @@
 {
   "context": {
-    "fileName": ["AGENTS.md"]
+    "fileName": [
+      "AGENTS.md"
+    ]
   }
 }

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,3 +26,18 @@ mise exec -- lefthook run pre-commit --all-files
 ```
 
 プロジェクト固有の検証は [AGENTS.md](../AGENTS.md) の「検証」セクションを参照。
+
+<!-- begin: @ozzylabs/skills -->
+## Available Skills
+
+- `commit` — 変更をステージし、Conventional Commits でコミットする。プッシュや PR 作成は行わない。
+- `commit-conventions` — Conventional Commits のメッセージ生成ルール（Type/Scope 判定表、フォーマット）。他スキルから参照される。
+- `drive` — Issue から実装・PR 作成・セルフレビュー・修正を自動で回し、merge-ready な PR を出す。Issue 番号またはテキスト指示を受け取る。
+- `implement` — Issue または指示をもとに、ブランチ作成・実装計画・コード変更を行う。Issue 番号またはテキスト指示を受け取る。
+- `lint` — 全リンターを自動修正付きで実行し、結果を報告する。コード品質チェック、フォーマット、型チェック、セキュリティスキャンを含む。
+- `lint-rules` — 拡張子別リンター・フォーマッターのコマンド対応表と型チェックルール。他スキルから参照される。
+- `pr` — コミット済みの変更をリモートにプッシュし、PR を作成・更新する。
+- `review` — コード変更や PR をレビューし、問題点・改善案を報告する。PR 番号または空（ワーキングツリー）を受け取る。
+- `ship` — lint・コミット・PR 作成を一括実行する。変更に対して lint → コミット → PR 作成を順に実行する統合パイプライン。
+- `test` — ビルド・テスト・型チェックを実行し、結果を報告する。
+<!-- end: @ozzylabs/skills -->

--- a/.github/workflows/sync-skills.yaml
+++ b/.github/workflows/sync-skills.yaml
@@ -1,15 +1,22 @@
 name: Sync skills
 
 # Renovate (skills-sync preset) が .dev-config/sync.yaml の skills_commit を更新する。
-# 本ワークフローは skills_commit に対応する skills repo の dist/.agents/skills/ を
-# .agents/skills/ にコピーし、差分があれば PR を作成する。
+# 本ワークフローは skills_commit に対応する skills repo の adapter 出力（dist/{adapter}/）
+# を 4 エージェント分の配置に同期し、差分があれば PR を作成する。
 #
 # 役割分担:
 #   - Renovate: 上流 SHA の追跡（skills_commit の bump）
-#   - 本ワークフロー: 物理ファイルの同期（dist → .agents/skills/）
+#   - 本ワークフロー: 物理ファイル + AGENTS.md / copilot-instructions.md の snippet 同期
 #
-# 移行期間中は commons の dist/.agents/skills/ も sync-commons 経由で配信される
-# 可能性がある（ADR-0016 で許容済みの一時的状態）。
+# Adapter 別 sync target:
+#   - dist/claude-code/.claude/skills/{name}/SKILL.md → .claude/skills/{name}/SKILL.md
+#   - dist/codex-cli/.agents/skills/{name}/SKILL.md   → .agents/skills/{name}/SKILL.md
+#   - dist/codex-cli/AGENTS.md.snippet                → AGENTS.md（マーカー間置換）
+#   - dist/copilot/.github/copilot-instructions.md.snippet
+#                                                     → .github/copilot-instructions.md（マーカー間置換）
+#   - dist/gemini-cli/.gemini/settings.json           → .gemini/settings.json（全置換）
+#
+# リポ固有 skill（例: setup）は dist 側に存在しないため、per-skill-dir コピーで保持される。
 on:
   schedule:
     # Every Monday 00:00 UTC（sync-commons と同じ枠で運用）
@@ -49,29 +56,88 @@ jobs:
           repository: ozzy-labs/skills
           ref: ${{ steps.read.outputs.sha }}
           path: .sync-skills
-          # skills repo は public だが、token を渡しても安全なのでそのまま残す。
-          token: ${{ secrets.RENOVATE_TOKEN }}
 
-      - name: Copy dist/.agents/skills/ → .agents/skills/
+      - name: Sync adapter outputs
         id: copy
         run: |
           set -euo pipefail
-          SRC=".sync-skills/dist/.agents/skills"
-          DST=".agents/skills"
-          if [[ ! -d "${SRC}" ]]; then
-            echo "Error: ${SRC} does not exist in skills repo at recorded commit" >&2
-            exit 1
-          fi
-          mkdir -p "${DST}"
-          # skills repo dist 由来の skill ディレクトリのみを上書きコピーする。
-          # リポ固有の README.md や setup skill など、dist に存在しないファイルは保持する。
-          for skill_dir in "${SRC}"/*/; do
-            name=$(basename "${skill_dir}")
-            rm -rf "${DST:?}/${name}"
-            cp -r "${skill_dir}" "${DST}/${name}"
-          done
+          SRC_ROOT=".sync-skills/dist"
+
+          # Helper: replace content between markers in a target file with snippet content.
+          # The snippet itself contains the begin/end markers, so we drop the original
+          # marker block (inclusive) and inject the snippet in its place.
+          replace_snippet() {
+            local target="$1"
+            local snippet="$2"
+            if [[ ! -f "${target}" ]]; then
+              echo "Error: ${target} does not exist (expected to contain @ozzylabs/skills markers)" >&2
+              return 1
+            fi
+            if [[ ! -f "${snippet}" ]]; then
+              echo "Error: ${snippet} not found in skills repo at recorded commit" >&2
+              return 1
+            fi
+            if ! grep -q '<!-- begin: @ozzylabs/skills -->' "${target}"; then
+              echo "Error: ${target} is missing the '<!-- begin: @ozzylabs/skills -->' marker" >&2
+              return 1
+            fi
+            awk -v snippet_file="${snippet}" '
+              BEGIN { in_block = 0 }
+              /<!-- begin: @ozzylabs\/skills -->/ && !in_block {
+                while ((getline line < snippet_file) > 0) print line
+                close(snippet_file)
+                in_block = 1
+                next
+              }
+              /<!-- end: @ozzylabs\/skills -->/ && in_block {
+                in_block = 0
+                next
+              }
+              !in_block { print }
+            ' "${target}" > "${target}.tmp"
+            mv "${target}.tmp" "${target}"
+          }
+
+          # Helper: copy adapter skill directories one-by-one so consumer-only files
+          # (e.g. .agents/skills/README.md, repo-specific skills like setup) survive sync.
+          sync_skill_dirs() {
+            local src="$1"
+            local dst="$2"
+            if [[ ! -d "${src}" ]]; then
+              echo "Error: ${src} does not exist in skills repo at recorded commit" >&2
+              return 1
+            fi
+            mkdir -p "${dst}"
+            for skill_dir in "${src}"/*/; do
+              local name
+              name=$(basename "${skill_dir}")
+              rm -rf "${dst:?}/${name}"
+              cp -r "${skill_dir}" "${dst}/${name}"
+            done
+          }
+
+          # 1. Claude Code: dist/claude-code/.claude/skills/ → .claude/skills/
+          sync_skill_dirs "${SRC_ROOT}/claude-code/.claude/skills" ".claude/skills"
+
+          # 2. Codex CLI: dist/codex-cli/.agents/skills/ → .agents/skills/
+          sync_skill_dirs "${SRC_ROOT}/codex-cli/.agents/skills" ".agents/skills"
+
+          # 3. AGENTS.md snippet (codex-cli と gemini-cli は同一 snippet)
+          replace_snippet "AGENTS.md" "${SRC_ROOT}/codex-cli/AGENTS.md.snippet"
+
+          # 4. GitHub Copilot snippet
+          replace_snippet \
+            ".github/copilot-instructions.md" \
+            "${SRC_ROOT}/copilot/.github/copilot-instructions.md.snippet"
+
+          # 5. Gemini CLI settings: dist/gemini-cli/.gemini/settings.json → .gemini/settings.json
+          mkdir -p .gemini
+          cp "${SRC_ROOT}/gemini-cli/.gemini/settings.json" ".gemini/settings.json"
+
           rm -rf .sync-skills
-          if git diff --quiet -- "${DST}"; then
+
+          paths=(.claude/skills .agents/skills .gemini/settings.json AGENTS.md .github/copilot-instructions.md)
+          if git diff --quiet -- "${paths[@]}"; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No changes to sync."
           else
@@ -94,7 +160,12 @@ jobs:
             [ozzy-labs/skills](https://github.com/ozzy-labs/skills) at
             `${{ steps.read.outputs.sha }}`.
 
-            Source: `dist/.agents/skills/` → `.agents/skills/`
+            Adapter sources:
+            - `dist/claude-code/.claude/skills/` → `.claude/skills/`
+            - `dist/codex-cli/.agents/skills/` → `.agents/skills/`
+            - `dist/codex-cli/AGENTS.md.snippet` → `AGENTS.md`（marker 間置換）
+            - `dist/copilot/.github/copilot-instructions.md.snippet` → `.github/copilot-instructions.md`（marker 間置換）
+            - `dist/gemini-cli/.gemini/settings.json` → `.gemini/settings.json`
 
             Triggered by the `Sync skills` workflow. Review the diff and merge when appropriate.
           labels: chore,skills-sync

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,21 @@ Conventional Commits required (enforced by commitlint):
 
 Types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`
 
+<!-- begin: @ozzylabs/skills -->
+## Available Skills
+
+- `commit` — 変更をステージし、Conventional Commits でコミットする。プッシュや PR 作成は行わない。
+- `commit-conventions` — Conventional Commits のメッセージ生成ルール（Type/Scope 判定表、フォーマット）。他スキルから参照される。
+- `drive` — Issue から実装・PR 作成・セルフレビュー・修正を自動で回し、merge-ready な PR を出す。Issue 番号またはテキスト指示を受け取る。
+- `implement` — Issue または指示をもとに、ブランチ作成・実装計画・コード変更を行う。Issue 番号またはテキスト指示を受け取る。
+- `lint` — 全リンターを自動修正付きで実行し、結果を報告する。コード品質チェック、フォーマット、型チェック、セキュリティスキャンを含む。
+- `lint-rules` — 拡張子別リンター・フォーマッターのコマンド対応表と型チェックルール。他スキルから参照される。
+- `pr` — コミット済みの変更をリモートにプッシュし、PR を作成・更新する。
+- `review` — コード変更や PR をレビューし、問題点・改善案を報告する。PR 番号または空（ワーキングツリー）を受け取る。
+- `ship` — lint・コミット・PR 作成を一括実行する。変更に対して lint → コミット → PR 作成を順に実行する統合パイプライン。
+- `test` — ビルド・テスト・型チェックを実行し、結果を報告する。
+<!-- end: @ozzylabs/skills -->
+
 ## Branching
 
 GitHub Flow: `main` + feature branches. **squash merge only**.

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>ozzy-labs/.github", "github>ozzy-labs/skills//skills-sync"]
+  "extends": [
+    "github>ozzy-labs/.github",
+    "github>ozzy-labs/skills//skills-sync/default",
+    "github>ozzy-labs/skills//skills-sync/claude-code",
+    "github>ozzy-labs/skills//skills-sync/codex-cli",
+    "github>ozzy-labs/skills//skills-sync/gemini-cli",
+    "github>ozzy-labs/skills//skills-sync/copilot"
+  ]
 }


### PR DESCRIPTION
## Summary

[ADR-0018](https://github.com/ozzy-labs/handbook/blob/main/adr/0018-agent-adapter-architecture.md) で定義した agent adapter layer への移行。本リポを handbook PoC ([handbook#64](https://github.com/ozzy-labs/handbook/pull/64)) に続く 2 番目の consumer として、Phase 4 段階展開（Platform 層）に組み込む。

## Changes

- **`renovate.json`**: `skills-sync/default` に加え、`skills-sync/claude-code` / `skills-sync/codex-cli` / `skills-sync/gemini-cli` / `skills-sync/copilot` の各 adapter sub-preset を extends（4 エージェント全部 opt-in）
- **`.github/workflows/sync-skills.yaml`**: 単一 `dist/.agents/skills/` コピーから 4 adapter target sync に書き換え:
  - `dist/claude-code/.claude/skills/` → `.claude/skills/`（per-skill-dir コピー）
  - `dist/codex-cli/.agents/skills/` → `.agents/skills/`（同上、`README.md` を保持）
  - `dist/codex-cli/AGENTS.md.snippet` → `AGENTS.md`（マーカー間 awk 置換）
  - `dist/copilot/.github/copilot-instructions.md.snippet` → `.github/copilot-instructions.md`（同上）
  - `dist/gemini-cli/.gemini/settings.json` → `.gemini/settings.json`（全置換）
- **`AGENTS.md`** / **`.github/copilot-instructions.md`**: `<!-- begin: @ozzylabs/skills -->` マーカーを挿入し、初期コンテンツとして adapter snippet を投入
- **`.gemini/settings.json`**: adapter 出力のフォーマットに整形（内容同等、フォーマット差のみ吸収）

## Repo-specific notes

- リポ固有 skill `setup`（`.claude/skills/setup/`, `.agents/skills/setup/`）は dist 側に存在しないため per-skill-dir コピーで保持される
- `.agents/skills/README.md` も同様に保持
- **`templates/agent-skills/` 配下は本 PR のスコープ外**（CAA が scaffold 出力としてユーザープロジェクトへ配信する preset asset であり、CAA リポ自身の dev config ではない。adapter 化は別途検討）
- 本 PR では `.claude/skills/` / `.agents/skills/` の内容に差分は出ない（CAA の現状コンテンツが既に skills repo の adapter 出力と一致）

## Verification

ローカルで workflow ロジックを simulate 済み:

- 4 adapter sync target が期待通り反映され、`setup` skill / `README.md` が保持されることを確認
- 本 PR merge 後の最初の scheduled sync は差分ゼロで早期 exit する想定
- `pnpm run build` / `pnpm test`（855 passed）/ `pnpm run typecheck` 全て通過

## Refs

- ADR: [handbook ADR-0018](https://github.com/ozzy-labs/handbook/blob/main/adr/0018-agent-adapter-architecture.md)
- Parent: [handbook#68](https://github.com/ozzy-labs/handbook/issues/68)
- PoC: [handbook#64](https://github.com/ozzy-labs/handbook/pull/64)

Closes #224

## Test plan

- [x] `pnpm run lint` / `pnpm run lint:md` 通過
- [x] `pnpm run build` / `pnpm test` / `pnpm run typecheck` 通過
- [x] lefthook pre-commit / pre-push フック通過（actionlint / yamllint / markdownlint / gitleaks 含む）
- [x] sync ロジックをローカル simulate（差分ゼロ確認、`setup` skill 保持確認）
- [ ] マージ後、`Sync skills` workflow を `workflow_dispatch` で手動実行 → 差分なしで早期 exit すること
- [ ] 4 エージェント実機で skill 認識を確認