### PR TITLE
chore(skills-sync): add skills_adapters field per ADR-0019

### DIFF
--- a/.dev-config/sync.yaml
+++ b/.dev-config/sync.yaml
@@ -4,6 +4,7 @@ commit: 4f6de17bb3894eb2ad5d2f8f90e93dbc9d3b13ad
 synced_at: 2026-04-25T04:30:15Z
 # Auto-updated by Renovate (extends github>ozzy-labs/skills//skills-sync)
 skills_commit: c600d8621e46dd1435133d5498a63f96776fdeed
+skills_adapters: [claude-code, codex-cli, gemini-cli, copilot]
 pinned:
   - CLAUDE.md
   - AGENTS.md


### PR DESCRIPTION
## Summary

- `.dev-config/sync.yaml` に `skills_adapters: [claude-code, codex-cli, gemini-cli, copilot]` を追加
- ADR-0019 で確定した consumer 側 canonical pattern（opt-in 宣言レイヤー）に整合化
- 現状は advisory（workflow が field を読んで分岐するか無条件 4 adapter 配信するかは実装の選択）

## Refs

- ozzy-labs/handbook#70 — adapter-aware skills sync 整合化
- ozzy-labs/handbook ADR-0019 — adapter-aware sync conventions

## Test plan

- [x] `pnpm run lint:yaml` passes
- [x] lefthook pre-commit (yamlfmt / yamllint / gitleaks) passes
- [x] commitlint passes
- [x] pre-push typecheck passes