### PR TITLE
chore(skills-sync): switch renovate.json to umbrella skills-sync per ADR-0019

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "github>ozzy-labs/.github",
-    "github>ozzy-labs/skills//skills-sync/default",
-    "github>ozzy-labs/skills//skills-sync/claude-code",
-    "github>ozzy-labs/skills//skills-sync/codex-cli",
-    "github>ozzy-labs/skills//skills-sync/gemini-cli",
-    "github>ozzy-labs/skills//skills-sync/copilot"
-  ]
+  "extends": ["github>ozzy-labs/.github", "github>ozzy-labs/skills//skills-sync"]
 }


### PR DESCRIPTION
## Summary

[PR #226](https://github.com/ozzy-labs/create-agentic-app/pull/226) で `skills_adapters` field を追加した際、当初の task brief は renovate.json が既に umbrella 形式である前提だったが、実際は 5 per-adapter sub-preset（`skills-sync/default` + 4 adapter）を extends していた。本 PR で [ADR-0019](https://github.com/ozzy-labs/handbook/blob/main/adr/0019-adapter-aware-sync-conventions.md) Decision 2 の canonical umbrella 形式に統一する。

## Changes

- `renovate.json`: 5 per-adapter sub-preset → umbrella `github>ozzy-labs/skills//skills-sync` 1 件

## Test plan

- [x] biome check pass
- [x] commitlint pass
- [ ] CI check (Branch / PR Title)

Refs: ozzy-labs/handbook#70 ADR-0019