### PR TITLE
fix(security): override vulnerable postcss

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
   },
   "pnpm": {
     "overrides": {
+      "postcss": "^8.5.10",
       "vite": "^8.0.8"
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  postcss: ^8.5.10
   vite: ^8.0.8
 
 importers:
@@ -941,8 +942,8 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  postcss@8.5.9:
-    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   quansync@1.0.0:
@@ -1964,7 +1965,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  postcss@8.5.9:
+  postcss@8.5.10:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -2138,7 +2139,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.9
+      postcss: 8.5.10
       rolldown: 1.0.0-rc.15
       tinyglobby: 0.2.16
     optionalDependencies:


### PR DESCRIPTION
## Summary
- Add a pnpm override for postcss ^8.5.10 to resolve CVE-2026-41305
- Refresh pnpm-lock.yaml so Vite resolves to the fixed PostCSS version

## Verification
- mise exec -- trivy fs --scanners vuln --exit-code 1 --no-progress .
- mise exec -- trivy fs --scanners vuln --exit-code 1 --include-dev-deps --no-progress .
- mise exec -- lefthook run pre-commit --all-files
- pnpm install --frozen-lockfile
- pnpm run build
- pnpm test
- pnpm run typecheck

Closes #228