### PR TITLE
fix(skills-sync): update skills_commit to adapter-structured dist

### DIFF
--- a/.commons/sync.yaml
+++ b/.commons/sync.yaml
@@ -3,7 +3,7 @@
 commit: 4f6de17bb3894eb2ad5d2f8f90e93dbc9d3b13ad
 synced_at: 2026-04-25T04:30:15Z
 # Auto-updated by Renovate (extends github>ozzy-labs/skills//skills-sync)
-skills_commit: c600d8621e46dd1435133d5498a63f96776fdeed
+skills_commit: 4d35fa3683789c8b4a8633bf6aa5bf8e5e7bc230
 skills_adapters: [claude-code, codex-cli, gemini-cli, copilot]
 pinned:
   - CLAUDE.md


### PR DESCRIPTION
## Summary

- `.commons/sync.yaml` の `skills_commit` を `c600d86` → `4d35fa3` に更新
- 旧コミットは `dist/.agents/` のみのフラット構造であり、`sync-skills.yaml` が期待するアダプター別構造（`dist/claude-code/`, `dist/codex-cli/` 等）が存在しなかった
- 最新コミット (`4d35fa3`) には全アダプターのディレクトリが揃っており、ワークフローが正常動作する

## Root Cause

`feat/adapter-aware-skills-sync` (#225) で `sync-skills.yaml` をアダプター別構造に対応させたが、`skills_commit` がアダプター構造導入前の古いコミットを指したままだったため、`Sync skills` ワークフローが連続失敗していた。

## Test plan

- [x] `pnpm run build` 通過
- [x] `pnpm test` 通過（855 tests）
- [x] `pnpm run typecheck` 通過
- [x] `yamlfmt` / `yamllint` 通過