### PR TITLE
fix: update pinned action versions to match project workflows

### DIFF
--- a/src/action-versions.ts
+++ b/src/action-versions.ts
@@ -5,9 +5,9 @@
  * When Renovate updates the workflow files, sync the hashes here too.
  */
 export const ACTIONS = {
-  checkout: "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5", // v4
-  mise: "jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac", // v2
-  cache: "actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830", // v4
+  checkout: "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd", // v6
+  mise: "jdx/mise-action@1648a7812b9aeae629881980618f079932869151", // v4
+  cache: "actions/cache@668228422ae6a00e4ad889ee87cd7109ec5666a7", // v5
   awsCredentials: "aws-actions/configure-aws-credentials@ececac1a45f3b08a01d2dd070d28d111c5fe6722", // v4
   azureLogin: "azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5", // v2
   gcpAuth: "google-github-actions/auth@ba79af03959ebeac9769e648f473a284504d9193", // v2


### PR DESCRIPTION
## Summary

- `src/action-versions.ts` のピン留め SHA を自プロジェクトのワークフローが使用している最新バージョンに同期
- 生成物の CI ワークフローに古いアクションバージョンが埋め込まれていた問題を修正

| Action | 変更前 | 変更後 |
|--------|--------|--------|
| `actions/checkout` | v4 (`34e1148`) | v6 (`de0fac2`) |
| `jdx/mise-action` | v2 (`c37c932`) | v4 (`1648a78`) |
| `actions/cache` | v4 (`0057852`) | v5 (`668228`) |

## Test plan

- [x] `pnpm run build` 通過
- [x] `pnpm test` 通過（855 tests）
- [x] `pnpm run typecheck` 通過
- [x] `biome check` 通過