### PR TITLE
chore: sync commons defaults

### DIFF
--- a/.commons/sync.yaml
+++ b/.commons/sync.yaml
@@ -1,7 +1,7 @@
 # Auto-updated by commons sync.sh
 # 'pinned' is user-editable — add or remove paths freely
-commit: a32c498f106b8684e2419ab7861e95e1bbef5445
-synced_at: 2026-04-26T07:19:30Z
+commit: 7c831aa4e3c35428d6e4bcc31a216aa682c0fb25
+synced_at: 2026-05-05T10:20:12Z
 pinned:
   - CLAUDE.md
   - AGENTS.md

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,8 +1,8 @@
 [tools]
 # Runtime & package managers
 node = "24"
-pnpm = "10"
-uv = "0.11"
+"npm:pnpm" = "10" # aqua backend fails: registry expects v11 .tar.gz format (see ozzy-labs/commons#100)
+uv = "0.11.8"     # Pin: 0.11.9 fails attestation verification (see ozzy-labs/commons#98)
 
 # Linters & formatters
 biome = "2"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,4 @@
+<!-- begin: ozzy-labs/commons -->
 # Contributing
 
 This is a personal project maintained by [ozzy-labs](https://github.com/ozzy-labs). External contributions are not currently accepted.
@@ -9,3 +10,4 @@ If you find a bug or have an idea for improvement, please open an issue.
 ## License
 
 By interacting with this project, you agree that any contributions you make will be licensed under the [MIT License](LICENSE).
+<!-- end: ozzy-labs/commons -->


### PR DESCRIPTION
Manual sync from ozzy-labs/commons. Picks up uv 0.11.8 pin (ozzy-labs/commons#98), npm:pnpm backend (ozzy-labs/commons#100), and pr-check dependabot/release-please skip (ozzy-labs/commons#97). Part of the 10-consumer rollout after starlight-theme pilot.