### PR TITLE
chore: restore @ozzylabs/skills markers + sync commons

### DIFF
--- a/.commons/sync.yaml
+++ b/.commons/sync.yaml
@@ -1,7 +1,7 @@
 # Auto-updated by commons sync.sh
 # 'pinned' is user-editable — add or remove paths freely
-commit: 7c831aa4e3c35428d6e4bcc31a216aa682c0fb25
-synced_at: 2026-05-05T10:20:12Z
+commit: bc4d40d64ccb69447881e3ad8c07ae482e3f406d
+synced_at: 2026-05-05T11:26:34Z
 pinned:
   - CLAUDE.md
   - AGENTS.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,4 @@
+<!-- begin: ozzy-labs/commons -->
 # GitHub Copilot Instructions
 
 共通方針は [AGENTS.md](../AGENTS.md) を参照してください。
@@ -26,3 +27,8 @@ mise exec -- lefthook run pre-commit --all-files
 ```
 
 プロジェクト固有の検証は [AGENTS.md](../AGENTS.md) の「検証」セクションを参照。
+<!-- end: ozzy-labs/commons -->
+
+<!-- begin: @ozzylabs/skills -->
+
+<!-- end: @ozzylabs/skills -->


### PR DESCRIPTION
Fixes Sync skills failure caused by missing markers (commons sync mechanism patched in ozzy-labs/commons#105). Re-syncs from commons new dist (with commons markers) and adds skills marker skeleton; Sync skills will populate the contents on push.