### PR TITLE
fix(skills): add missing skills_commit and skills_adapters to sync.yaml

### DIFF
--- a/.commons/sync.yaml
+++ b/.commons/sync.yaml
@@ -2,6 +2,12 @@
 # 'pinned' is user-editable — add or remove paths freely
 commit: bc4d40d64ccb69447881e3ad8c07ae482e3f406d
 synced_at: 2026-05-05T11:26:34Z
+skills_commit: 4d35fa3683789c8b4a8633bf6aa5bf8e5e7bc230
+skills_adapters:
+  - claude-code
+  - codex-cli
+  - gemini-cli
+  - copilot
 pinned:
   - CLAUDE.md
   - AGENTS.md


### PR DESCRIPTION
Sync skills workflow was failing immediately because `.commons/sync.yaml` lacked `skills_commit` / `skills_adapters` fields. Other consumers had them; this repo was missing the opt-in.

`.claude/skills/` and `.agents/skills/` both exist, so the repo does use skills — this was a config drift, not an opt-out.

## Test plan
- [ ] Sync skills workflow succeeds after merge