### PR TITLE
fix: align inline comments in .mise.toml to satisfy taplo format

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,8 +1,8 @@
 [tools]
 # Runtime & package managers
 node = "24"
-"npm:pnpm" = "10"  # aqua backend fails: registry expects v11 .tar.gz format (see ozzy-labs/commons#100)
-uv = "0.11.8"  # Pin: 0.11.9 fails attestation verification (see ozzy-labs/commons#98)
+"npm:pnpm" = "10" # aqua backend fails: registry expects v11 .tar.gz format (see ozzy-labs/commons#100)
+uv = "0.11.8"     # Pin: 0.11.9 fails attestation verification (see ozzy-labs/commons#98)
 
 # Linters & formatters
 biome = "2"


### PR DESCRIPTION
## Summary

- `taplo format --check ./*.toml` was failing on `main` after #246 (commons sync), breaking the CI lint-and-check job
- Apply `taplo format` to canonicalize inline comment spacing in `.mise.toml` (no semantic change)

## Test plan

- [x] `pnpm run lint:all` (includes `lint:toml`)
- [x] `pnpm run build`
- [x] `pnpm run typecheck`
- [x] `pnpm test`