### PR TITLE
chore: add legacy-stub source for deprecated @ozzylabs/create-agentic-dev

### DIFF
--- a/docs/legacy-package.md
+++ b/docs/legacy-package.md
@@ -1,0 +1,33 @@
+# Legacy Package: `@ozzylabs/create-agentic-dev`
+
+This repository was previously published under the name [`@ozzylabs/create-agentic-dev`](https://www.npmjs.com/package/@ozzylabs/create-agentic-dev). It has been renamed to [`@ozzylabs/create-agentic-app`](https://www.npmjs.com/package/@ozzylabs/create-agentic-app).
+
+## `legacy-stub/`
+
+The [`legacy-stub/`](../legacy-stub/) directory contains the source for the **end-of-life tombstone release** (`@ozzylabs/create-agentic-dev@1.0.0`) that was published to npm to redirect users to the new package.
+
+When invoked, the published `1.0.0` prints a migration notice and exits with a non-zero status:
+
+```text
+$ npx @ozzylabs/create-agentic-dev
+  ⚠️  @ozzylabs/create-agentic-dev has been renamed.
+      Please use the new package:
+        npx @ozzylabs/create-agentic-app
+```
+
+### Do not modify `legacy-stub/` casually
+
+This is a one-shot tombstone. The contents are kept in version control purely as an audit trail and a recovery path in case a follow-up patch (e.g. updated migration message, URL fix) is ever needed.
+
+If you do need to publish a follow-up:
+
+1. Bump `legacy-stub/package.json` version to `1.0.x` (patch).
+2. From the `legacy-stub/` directory, run `npm publish` while logged in as a user with publish access to `@ozzylabs/create-agentic-dev` (Trusted Publishers are intentionally disabled for this package; manual publish only).
+3. Apply or refresh the deprecation notice:
+
+   ```bash
+   npm deprecate @ozzylabs/create-agentic-dev@"*" \
+     "Renamed to @ozzylabs/create-agentic-app. Run: npx @ozzylabs/create-agentic-app"
+   ```
+
+The `legacy-stub/` directory is intentionally isolated from the main project's build, lint, type-check, and test pipelines. Do not add it to `tsconfig.json`, `biome.json`, `vitest.config.ts`, or `release-please-config.json`.

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -8,7 +8,7 @@ pre-commit:
   commands:
     biome:
       glob: "*.{ts,tsx,js,jsx,json,jsonc}"
-      exclude: "{templates,.devcontainer,.copilot,.gemini,.codex,.agents}/**"
+      exclude: "{templates,.devcontainer,.copilot,.gemini,.codex,.agents,legacy-stub}/**"
       run: biome check --write {staged_files}
       stage_fixed: true
     shellcheck:

--- a/legacy-stub/README.md
+++ b/legacy-stub/README.md
@@ -1,0 +1,17 @@
+# @ozzylabs/create-agentic-dev
+
+> **This package has been renamed and is no longer maintained.**
+
+Please use [`@ozzylabs/create-agentic-app`](https://www.npmjs.com/package/@ozzylabs/create-agentic-app) instead.
+
+## Migration
+
+```bash
+npx @ozzylabs/create-agentic-app
+```
+
+This `1.0.0` release is an end-of-life tombstone: running the old `create-agentic-dev` command now prints a migration notice and exits with a non-zero status. Please update any CI scripts, documentation, or muscle memory that still references the old name.
+
+## Source
+
+The codebase moved to [`ozzy-labs/create-agentic-app`](https://github.com/ozzy-labs/create-agentic-app). All future development happens there.

--- a/legacy-stub/bin/notice.js
+++ b/legacy-stub/bin/notice.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+console.error(
+  [
+    "",
+    "  ⚠️  @ozzylabs/create-agentic-dev has been renamed.",
+    "",
+    "      Please use the new package:",
+    "        npx @ozzylabs/create-agentic-app",
+    "",
+    "      Docs: https://github.com/ozzy-labs/create-agentic-app",
+    "",
+  ].join("\n"),
+);
+process.exit(1);

--- a/legacy-stub/package.json
+++ b/legacy-stub/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@ozzylabs/create-agentic-dev",
+  "version": "1.0.0",
+  "description": "Renamed to @ozzylabs/create-agentic-app. This package is deprecated.",
+  "bin": {
+    "create-agentic-dev": "bin/notice.js"
+  },
+  "files": [
+    "bin",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "license": "MIT",
+  "author": "ozzy-labs",
+  "homepage": "https://github.com/ozzy-labs/create-agentic-app#readme",
+  "bugs": "https://github.com/ozzy-labs/create-agentic-app/issues",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ozzy-labs/create-agentic-app.git"
+  },
+  "keywords": [
+    "deprecated"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `legacy-stub/` containing the source for `@ozzylabs/create-agentic-dev@1.0.0`, an end-of-life tombstone release that was published manually to redirect users from the renamed package to `@ozzylabs/create-agentic-app`.
- The published `1.0.0` prints a migration notice and exits with status 1 (verified via `npx -y @ozzylabs/create-agentic-dev@1.0.0`).
- `docs/legacy-package.md` documents the directory's purpose and the manual-only publish workflow for any future patch.
- `lefthook.yaml` excludes `legacy-stub/` from biome to mirror the existing `templates/` isolation; the stub is intentionally outside the project's tsconfig / biome / vitest / release-please scope.

## Background

The npm package `@ozzylabs/create-agentic-dev` (versions 0.1.0 - 0.1.2) was already deprecated, but the binary was still installable and runnable, with no in-tool guidance toward the new package. Publishing `1.0.0` as an EOL tombstone gives anyone running the old `npx @ozzylabs/create-agentic-dev` an immediate, hard-stop migration message. The old GitHub Trusted Publisher (pointing to the now-deleted `ozzy-labs/create-agentic-dev` repository) was deleted, and `1.0.0` was published manually by a maintainer with `read-write` access.

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm test` passes (855 tests)
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run lint:md` passes (covers new docs and stub README)
- [x] `npx -y @ozzylabs/create-agentic-dev@1.0.0` prints the migration notice and exits with status 1
- [x] `npm warn deprecated` is shown on install of the published `1.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)