### PR TITLE
chore(lefthook): refactor lefthook.yaml to use extends

### DIFF
--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -1,7 +1,5 @@
-commit-msg:
-  commands:
-    commitlint:
-      run: npx commitlint --edit {1}
+extends:
+  - lefthook-base.yaml
 
 pre-commit:
   parallel: true
@@ -11,36 +9,9 @@ pre-commit:
       exclude: "{templates,.devcontainer,.copilot,.gemini,.codex,.agents,legacy-stub}/**"
       run: biome check --write {staged_files}
       stage_fixed: true
-    shellcheck:
-      glob: "*.sh"
-      run: shellcheck {staged_files}
-    shfmt:
-      glob: "*.sh"
-      run: shfmt -w {staged_files}
-      stage_fixed: true
-    taplo:
-      glob: "*.toml"
-      run: taplo format {staged_files}
-      stage_fixed: true
-    # mdformat: disabled until mdformat-gfm plugin is installed (breaks GFM tables)
-    #   glob: "*.md"
-    #   run: mdformat {staged_files}
-    #   stage_fixed: true
-    markdownlint:
-      glob: "*.md"
-      run: markdownlint-cli2 {staged_files}
-    yamlfmt:
-      glob: "*.{yaml,yml}"
-      run: yamlfmt {staged_files}
-      stage_fixed: true
-    yamllint:
-      glob: "*.{yaml,yml}"
-      run: yamllint -c .yamllint.yaml {staged_files}
     actionlint:
       glob: ".github/workflows/*.{yaml,yml}"
       run: actionlint
-    gitleaks:
-      run: gitleaks protect --staged --no-banner
 
 pre-push:
   commands:


### PR DESCRIPTION
Closes #256

## 概要

`lefthook.yaml` を `extends: [lefthook-base.yaml]` を使う構成にリファクタ。base から共通 hook を継承し、リポ固有 hook（biome / actionlint / typecheck）のみ local に残す。

## 削除

- `commit-msg.commands.commitlint` （base で `mise exec --` 経由化済み）
- `pre-commit.commands.{shellcheck, shfmt, taplo, markdownlint, yamlfmt, yamllint, gitleaks}` （base に集約）
- `mdformat` の disabled コメント（既に無効化、base にも未含のため整理）

## 残し

- `pre-commit.commands.{biome, actionlint}` — リポ固有
- `pre-push.commands.typecheck` — リポ固有

## 副作用（許容範囲と判断）

| 変更 | 影響 |
|---|---|
| `commitlint` 起動方法が `npx` → `mise exec` 経由 | バージョンは `^20.x` 系で同じ。`NODE_PATH` で sibling resolve |
| `markdownlint` に `--fix` が付く | 自動修正される（より望ましい挙動） |
| `shell` hook で `shellcheck`+`shfmt` 統合 | 機能等価 |
| `yaml` hook で `yamlfmt`+`yamllint` 統合 | 機能等価 |
| `trivy` hook 新規追加（base 由来） | セキュリティ強化。`.mise.toml` で trivy ピン済み |

## 検証

- `lefthook dump` で extends 効いていることを確認、base の hook（commitlint, shell, yaml, taplo, markdownlint, gitleaks, trivy）が継承される
- `pnpm run lint:all`: pass
- `pnpm run build`: pass
- `pnpm test`: 855 passed / 4 skipped
- 動作確認: pre-commit hook 実機実行で全 hook が走ることを確認

## 関連

- Refs: ozzy-labs/commons#117
- Refs: ozzy-labs/commons#118