### PR TITLE
chore(deps): sync commons to 36408c3

### DIFF
--- a/.commons/sync.yaml
+++ b/.commons/sync.yaml
@@ -1,7 +1,11 @@
 # Auto-updated by commons sync.sh
 # 'pinned' is user-editable — add or remove paths freely
-commit: 5d2e324b9caa3d8501aa3599ac3ad332f749a28e
-synced_at: 2026-05-06T09:21:36Z
+commit: 36408c33296295380647cd68934002328402aaef
+synced_at: 2026-06-07T02:46:46Z
+
+# Skills sync (opt-in). Add adapter ids to skills_adapters and a SHA
+# to skills_commit. The skills repo's main HEAD SHA can be obtained via:
+#   gh api repos/ozzy-labs/skills/commits/main --jq .sha
 skills_commit: 27ae96210fee135e608b16e938cb338c9b2b45ae
 skills_adapters:
   - claude-code

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,1 +1,7 @@
-{ "context": { "fileName": ["AGENTS.md"] } }
+{
+  "context": {
+    "fileName": [
+      "AGENTS.md"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

ozzy-labs/commons HEAD `36408c3` を本リポに同期。

- `.commons/sync.yaml` の `commit` を `36408c33296295380647cd68934002328402aaef` に bump
- 対応する `dist/` を sync

## Synced via

`commons/scripts/sync-consumers.sh` (push 型同期、ozzy-labs/skills#80 epic)