### PR TITLE
chore(deps): sync commons to 5fcde56

### DIFF
--- a/.commons/sync.yaml
+++ b/.commons/sync.yaml
@@ -4,8 +4,8 @@
 # ozzy-labs/skills#80. 'pinned' is user-editable — add or remove paths
 # freely. 'commit' / 'skills_commit' / 'synced_at' should not be hand-
 # edited; they are rewritten by sync.sh / sync-skills.sh on each push.
-commit: feb31a670788174f06064cb86ce1b0d0f10200ef
-synced_at: 2026-06-07T03:29:54Z
+commit: 5fcde5666874736801b444dda33e02318f85dffb
+synced_at: 2026-06-07T03:40:13Z
 
 # Skills sync (opt-in). Add adapter ids to skills_adapters; skills_commit
 # is bumped by /sync-consumers --source=skills. The skills repo's main

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,1 +1,7 @@
-{ "context": { "fileName": ["AGENTS.md"] } }
+{
+  "context": {
+    "fileName": [
+      "AGENTS.md"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

ozzy-labs/commons HEAD `5fcde56` を本リポに同期。

- `.commons/sync.yaml` の `commit` を `5fcde5666874736801b444dda33e02318f85dffb` に bump
- 対応する `dist/` を sync

## Synced via

`commons/scripts/sync-consumers.sh` (push 型同期、ozzy-labs/skills#80 epic)